### PR TITLE
Add an alias region for data segments

### DIFF
--- a/crates/cranelift/src/alias_region.rs
+++ b/crates/cranelift/src/alias_region.rs
@@ -47,7 +47,7 @@ enum VmType {
 /// that alias regions can be deduplicated during inlining.
 ///
 /// The key encodes into a single `u32` with the following layout:
-/// `[ kind: 5 bits | data: 27 bits ]`
+/// `[ kind: 6 bits | data: 26 bits ]`
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 enum AliasRegionKey {
     /// An access of a field within a VM data structure of type `ty`.
@@ -115,10 +115,13 @@ enum AliasRegionKey {
 
     /// An access of a `ValRaw` inside a passive element segment.
     ElementSegment,
+
+    /// An access of the bytes inside a data segment.
+    DataSegment,
 }
 
 impl AliasRegionKey {
-    const KIND_BITS: u32 = 5;
+    const KIND_BITS: u32 = 6;
     const KIND_OFFSET: u32 = 32 - Self::KIND_BITS;
     const KIND_MASK: u32 = ((1 << Self::KIND_BITS) - 1) << Self::KIND_OFFSET;
 
@@ -135,38 +138,39 @@ impl AliasRegionKey {
         kind << Self::KIND_OFFSET
     }
 
-    const VM_CONTEXT_KIND: u32 = Self::new_kind(0b00000);
-    const VM_STORE_CONTEXT_KIND: u32 = Self::new_kind(0b00001);
-    const IMPORTED_MEMORY_KIND: u32 = Self::new_kind(0b00010);
-    const DEFINED_MEMORY_KIND: u32 = Self::new_kind(0b00011);
-    const IMPORTED_TABLE_KIND: u32 = Self::new_kind(0b00100);
-    const DEFINED_TABLE_KIND: u32 = Self::new_kind(0b00101);
-    const IMPORTED_GLOBAL_KIND: u32 = Self::new_kind(0b00110);
-    const DEFINED_GLOBAL_KIND: u32 = Self::new_kind(0b00111);
-    const GC_HEAP_KIND: u32 = Self::new_kind(0b01000);
-    const VM_MEMORY_DEFINITION_KIND: u32 = Self::new_kind(0b01001);
-    const VM_TABLE_DEFINITION_KIND: u32 = Self::new_kind(0b01010);
-    const VM_COMPONENT_CONTEXT_KIND: u32 = Self::new_kind(0b01011);
-    const VM_DRC_HEAP_DATA_KIND: u32 = Self::new_kind(0b01100);
-    const VM_COPYING_HEAP_DATA_KIND: u32 = Self::new_kind(0b01101);
-    const VM_NULL_HEAP_DATA_KIND: u32 = Self::new_kind(0b01110);
-    const VM_DEFERRED_THREAD_KIND: u32 = Self::new_kind(0b01111);
-    const VM_CONTREF_KIND: u32 = Self::new_kind(0b10000);
-    const CONTINUATION_STACK_MEMORY_KIND: u32 = Self::new_kind(0b10001);
-    const VM_FUNCTION_IMPORT_KIND: u32 = Self::new_kind(0b10010);
-    const VM_MEMORY_IMPORT_KIND: u32 = Self::new_kind(0b10011);
-    const VM_TABLE_IMPORT_KIND: u32 = Self::new_kind(0b10100);
-    const VM_TAG_IMPORT_KIND: u32 = Self::new_kind(0b10101);
-    const VM_GLOBAL_IMPORT_KIND: u32 = Self::new_kind(0b10110);
-    const STACK_KIND: u32 = Self::new_kind(0b10111);
-    const VM_FUNC_REF_KIND: u32 = Self::new_kind(0b11000);
-    const TYPE_IDS_ARRAY_KIND: u32 = Self::new_kind(0b11001);
-    const EPOCH_COUNTER_KIND: u32 = Self::new_kind(0b11010);
-    const BUILTIN_FUNCTIONS_KIND: u32 = Self::new_kind(0b11011);
-    const COMPONENT_BUILTIN_FUNCTIONS_KIND: u32 = Self::new_kind(0b11100);
-    const UNSAFE_INTRINSIC_MEMORY_KIND: u32 = Self::new_kind(0b11101);
-    const HOST_VAL_RAW_KIND: u32 = Self::new_kind(0b11110);
-    const ELEMENT_SEGMENT_KIND: u32 = Self::new_kind(0b11111);
+    const VM_CONTEXT_KIND: u32 = Self::new_kind(0b000000);
+    const VM_STORE_CONTEXT_KIND: u32 = Self::new_kind(0b000001);
+    const IMPORTED_MEMORY_KIND: u32 = Self::new_kind(0b000010);
+    const DEFINED_MEMORY_KIND: u32 = Self::new_kind(0b000011);
+    const IMPORTED_TABLE_KIND: u32 = Self::new_kind(0b000100);
+    const DEFINED_TABLE_KIND: u32 = Self::new_kind(0b000101);
+    const IMPORTED_GLOBAL_KIND: u32 = Self::new_kind(0b000110);
+    const DEFINED_GLOBAL_KIND: u32 = Self::new_kind(0b000111);
+    const GC_HEAP_KIND: u32 = Self::new_kind(0b001000);
+    const VM_MEMORY_DEFINITION_KIND: u32 = Self::new_kind(0b001001);
+    const VM_TABLE_DEFINITION_KIND: u32 = Self::new_kind(0b001010);
+    const VM_COMPONENT_CONTEXT_KIND: u32 = Self::new_kind(0b001011);
+    const VM_DRC_HEAP_DATA_KIND: u32 = Self::new_kind(0b001100);
+    const VM_COPYING_HEAP_DATA_KIND: u32 = Self::new_kind(0b001101);
+    const VM_NULL_HEAP_DATA_KIND: u32 = Self::new_kind(0b001110);
+    const VM_DEFERRED_THREAD_KIND: u32 = Self::new_kind(0b001111);
+    const VM_CONTREF_KIND: u32 = Self::new_kind(0b010000);
+    const CONTINUATION_STACK_MEMORY_KIND: u32 = Self::new_kind(0b010001);
+    const VM_FUNCTION_IMPORT_KIND: u32 = Self::new_kind(0b010010);
+    const VM_MEMORY_IMPORT_KIND: u32 = Self::new_kind(0b010011);
+    const VM_TABLE_IMPORT_KIND: u32 = Self::new_kind(0b010100);
+    const VM_TAG_IMPORT_KIND: u32 = Self::new_kind(0b010101);
+    const VM_GLOBAL_IMPORT_KIND: u32 = Self::new_kind(0b010110);
+    const STACK_KIND: u32 = Self::new_kind(0b010111);
+    const VM_FUNC_REF_KIND: u32 = Self::new_kind(0b011000);
+    const TYPE_IDS_ARRAY_KIND: u32 = Self::new_kind(0b011001);
+    const EPOCH_COUNTER_KIND: u32 = Self::new_kind(0b011010);
+    const BUILTIN_FUNCTIONS_KIND: u32 = Self::new_kind(0b011011);
+    const COMPONENT_BUILTIN_FUNCTIONS_KIND: u32 = Self::new_kind(0b011100);
+    const UNSAFE_INTRINSIC_MEMORY_KIND: u32 = Self::new_kind(0b011101);
+    const HOST_VAL_RAW_KIND: u32 = Self::new_kind(0b011110);
+    const ELEMENT_SEGMENT_KIND: u32 = Self::new_kind(0b011111);
+    const DATA_SEGMENT_KIND: u32 = Self::new_kind(0b100000);
 
     /// Encode this key into a raw `u32` suitable for use as an
     /// `AliasRegionData::user_id`.
@@ -240,6 +244,7 @@ impl AliasRegionKey {
             }
             AliasRegionKey::UnsafeIntrinsicMemory => Self::UNSAFE_INTRINSIC_MEMORY_KIND,
             AliasRegionKey::ElementSegment => Self::ELEMENT_SEGMENT_KIND,
+            AliasRegionKey::DataSegment => Self::DATA_SEGMENT_KIND,
         }
     }
 }
@@ -264,6 +269,7 @@ impl fmt::Debug for AliasRegionKey {
             AliasRegionKey::Stack { slot } => write!(f, "Stack({slot:?})"),
             AliasRegionKey::UnsafeIntrinsicMemory => write!(f, "UnsafeIntrinsicMemory"),
             AliasRegionKey::ElementSegment => write!(f, "ElementSegment"),
+            AliasRegionKey::DataSegment => write!(f, "DataSegment"),
         }
     }
 }
@@ -2092,7 +2098,7 @@ where
     }
 }
 
-/// Passive element-related methods.
+/// Passive data and element segment-related methods.
 impl<Offsets> AliasRegions<Offsets>
 where
     Offsets: GetPtrSize,
@@ -2102,6 +2108,12 @@ where
     /// `table.init` and `array.{new,init}_elem`).
     pub fn element_segment_region(&mut self, func: &mut ir::Function) -> ir::AliasRegion {
         self.region(func, AliasRegionKey::ElementSegment)
+    }
+
+    /// Get the alias region for the bytes of data segments (read by
+    /// `memory.init` and `array.{new,init}_data`).
+    pub fn data_segment_region(&mut self, func: &mut ir::Function) -> ir::AliasRegion {
+        self.region(func, AliasRegionKey::DataSegment)
     }
 }
 

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -414,13 +414,15 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
         &mut self,
         func: &mut Function,
         entity: CheckedEntity,
-    ) -> Option<ir::AliasRegion> {
+    ) -> ir::AliasRegion {
         match entity {
-            CheckedEntity::Memory(index) => Some(self.memory_alias_region(func, index)),
-            CheckedEntity::Table { table, .. } => Some(self.table_alias_region(func, table)),
-            CheckedEntity::Array { .. } => Some(self.alias_regions.gc_heap_region(func)),
-            CheckedEntity::Elem(_) => Some(self.alias_regions.element_segment_region(func)),
-            CheckedEntity::Data { .. } | CheckedEntity::RuntimeData(_) => None,
+            CheckedEntity::Memory(index) => self.memory_alias_region(func, index),
+            CheckedEntity::Table { table, .. } => self.table_alias_region(func, table),
+            CheckedEntity::Array { .. } => self.alias_regions.gc_heap_region(func),
+            CheckedEntity::Elem(_) => self.alias_regions.element_segment_region(func),
+            CheckedEntity::Data { .. } | CheckedEntity::RuntimeData(_) => {
+                self.alias_regions.data_segment_region(func)
+            }
         }
     }
 
@@ -4723,8 +4725,8 @@ impl FuncEnvironment<'_> {
         dst_addr: ir::Value,
         src_addr: ir::Value,
         bytes: u64,
-        src_region: Option<ir::AliasRegion>,
-        dst_region: Option<ir::AliasRegion>,
+        src_region: ir::AliasRegion,
+        dst_region: ir::AliasRegion,
     ) {
         // `trusted()` (notrap + aligned) is sound: the range is already
         // bounds-checked, and each load feeds only its paired store, so the
@@ -4740,10 +4742,10 @@ impl FuncEnvironment<'_> {
         // region-tagged store to the same address.
         let load_flags = ir::MemFlagsData::trusted()
             .with_endianness(Endianness::Little)
-            .with_alias_region(src_region);
+            .with_alias_region(Some(src_region));
         let store_flags = ir::MemFlagsData::trusted()
             .with_endianness(Endianness::Little)
-            .with_alias_region(dst_region);
+            .with_alias_region(Some(dst_region));
         const WIDTHS: &[(u64, ir::Type)] = &[
             (16, ir::types::I8X16),
             (8, ir::types::I64),

--- a/tests/disas/alias-region-globals.wat
+++ b/tests/disas/alias-region-globals.wat
@@ -16,10 +16,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 2952790016 "VMGlobalImport+0x0"
-;;     region3 = 805306368 "PublicGlobal"
-;;     region4 = 939524096 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 1476395008 "VMGlobalImport+0x0"
+;;     region3 = 402653184 "PublicGlobal"
+;;     region4 = 469762048 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/alias-region-memories.wat
+++ b/tests/disas/alias-region-memories.wat
@@ -16,12 +16,12 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 2550136832 "VMMemoryImport+0x0"
-;;     region3 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region4 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region5 = 268435456 "PublicMemory"
-;;     region6 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 1275068416 "VMMemoryImport+0x0"
+;;     region3 = 603979776 "VMMemoryDefinition+0x0"
+;;     region4 = 603979784 "VMMemoryDefinition+0x8"
+;;     region5 = 134217728 "PublicMemory"
+;;     region6 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/alias-region-tables.wat
+++ b/tests/disas/alias-region-tables.wat
@@ -17,17 +17,17 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 2684354560 "VMTableImport+0x0"
-;;     region3 = 1342177280 "VMTableDefinition+0x0"
-;;     region4 = 1342177288 "VMTableDefinition+0x8"
-;;     region5 = 536870912 "PublicTable"
-;;     region6 = 671088640 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 1342177280 "VMTableImport+0x0"
+;;     region3 = 671088640 "VMTableDefinition+0x0"
+;;     region4 = 671088648 "VMTableDefinition+0x8"
+;;     region5 = 268435456 "PublicTable"
+;;     region6 = 335544320 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     region7 = 40 "VMContext+0x28"
-;;     region8 = 3355443200 "TypeIdsArray+0x0"
-;;     region9 = 3221225488 "VMFuncRef+0x10"
-;;     region10 = 3221225480 "VMFuncRef+0x8"
-;;     region11 = 3221225496 "VMFuncRef+0x18"
+;;     region8 = 1677721600 "TypeIdsArray+0x0"
+;;     region9 = 1610612752 "VMFuncRef+0x10"
+;;     region10 = 1610612744 "VMFuncRef+0x8"
+;;     region11 = 1610612760 "VMFuncRef+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/arith.wat
+++ b/tests/disas/arith.wat
@@ -16,7 +16,7 @@
 
 ;; function u0:0(i64 vmctx, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/array-call-trampoline.wat
+++ b/tests/disas/array-call-trampoline.wat
@@ -9,12 +9,12 @@
   )
 )
 ;; function u268435456:0(i64 vmctx, i64, i64, i64) -> i8 system_v {
-;;     region0 = 4026531840 "HostValRaw+0x0"
+;;     region0 = 2013265920 "HostValRaw+0x0"
 ;;     region1 = 8 "VMContext+0x8"
-;;     region2 = 134217800 "VMStoreContext+0x48"
-;;     region3 = 134217792 "VMStoreContext+0x40"
-;;     region4 = 134217808 "VMStoreContext+0x50"
-;;     region5 = 134217864 "VMStoreContext+0x88"
+;;     region2 = 67108936 "VMStoreContext+0x48"
+;;     region3 = 67108928 "VMStoreContext+0x40"
+;;     region4 = 67108944 "VMStoreContext+0x50"
+;;     region5 = 67109000 "VMStoreContext+0x88"
 ;;     sig0 = (i64 vmctx, i64, i32, i64) -> i32, i64 tail
 ;;     fn0 = colocated u0:0 sig0
 ;;

--- a/tests/disas/array-copy-anyref.wat
+++ b/tests/disas/array-copy-anyref.wat
@@ -11,10 +11,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/array-copy-i64.wat
+++ b/tests/disas/array-copy-i64.wat
@@ -11,10 +11,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/array-copy-i8.wat
+++ b/tests/disas/array-copy-i8.wat
@@ -11,10 +11,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/array-copy-inline.wat
+++ b/tests/disas/array-copy-inline.wat
@@ -17,10 +17,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/array-fill-anyref.wat
+++ b/tests/disas/array-fill-anyref.wat
@@ -19,10 +19,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -76,10 +76,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -135,10 +135,10 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/array-fill-externref.wat
+++ b/tests/disas/array-fill-externref.wat
@@ -15,10 +15,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -72,10 +72,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/array-fill-f32.wat
+++ b/tests/disas/array-fill-f32.wat
@@ -19,10 +19,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, f32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -76,10 +76,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -123,10 +123,10 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/array-fill-f64.wat
+++ b/tests/disas/array-fill-f64.wat
@@ -19,10 +19,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, f64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -76,10 +76,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -123,10 +123,10 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/array-fill-funcref.wat
+++ b/tests/disas/array-fill-funcref.wat
@@ -22,10 +22,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -83,10 +83,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -145,11 +145,11 @@
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
-;;     region5 = 3087007744 "Stack(ss0)"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
+;;     region5 = 1543503872 "Stack(ss0)"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -214,7 +214,7 @@
 ;;
 ;; function u0:3(i64 vmctx, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/array-fill-i16.wat
+++ b/tests/disas/array-fill-i16.wat
@@ -23,10 +23,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -80,10 +80,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -127,10 +127,10 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -174,10 +174,10 @@
 ;;
 ;; function u0:3(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/array-fill-i31ref.wat
+++ b/tests/disas/array-fill-i31ref.wat
@@ -19,10 +19,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -76,10 +76,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -135,10 +135,10 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/array-fill-i32.wat
+++ b/tests/disas/array-fill-i32.wat
@@ -23,10 +23,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -80,10 +80,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -127,10 +127,10 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -174,10 +174,10 @@
 ;;
 ;; function u0:3(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/array-fill-i64.wat
+++ b/tests/disas/array-fill-i64.wat
@@ -23,10 +23,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -80,10 +80,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -127,10 +127,10 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -174,10 +174,10 @@
 ;;
 ;; function u0:3(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/basic-wat-test.wat
+++ b/tests/disas/basic-wat-test.wat
@@ -11,10 +11,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/block-params-br_if-single-pred.wat
+++ b/tests/disas/block-params-br_if-single-pred.wat
@@ -22,9 +22,9 @@
 )
 ;; function u0:0(i64 vmctx, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 2415919128 "VMFunctionImport+0x18"
-;;     region3 = 2415919112 "VMFunctionImport+0x8"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 1207959576 "VMFunctionImport+0x18"
+;;     region3 = 1207959560 "VMFunctionImport+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/block-params-if-else-same-values.wat
+++ b/tests/disas/block-params-if-else-same-values.wat
@@ -22,9 +22,9 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32) -> i32, i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 2415919128 "VMFunctionImport+0x18"
-;;     region3 = 2415919112 "VMFunctionImport+0x8"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 1207959576 "VMFunctionImport+0x18"
+;;     region3 = 1207959560 "VMFunctionImport+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/block-params-loop-single-iteration.wat
+++ b/tests/disas/block-params-loop-single-iteration.wat
@@ -15,7 +15,7 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/bounds-check.wat
+++ b/tests/disas/bounds-check.wat
@@ -26,10 +26,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/br_table.wat
+++ b/tests/disas/br_table.wat
@@ -33,7 +33,7 @@
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -71,7 +71,7 @@
 ;;
 ;; function u0:1(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -109,7 +109,7 @@
 ;;
 ;; function u0:2(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -135,7 +135,7 @@
 ;;
 ;; function u0:3(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/branch-hinting-disabled.wat
+++ b/tests/disas/branch-hinting-disabled.wat
@@ -29,7 +29,7 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -55,7 +55,7 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/branch-hinting.wat
+++ b/tests/disas/branch-hinting.wat
@@ -74,7 +74,7 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -97,7 +97,7 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -120,7 +120,7 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -146,7 +146,7 @@
 ;;
 ;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -172,8 +172,8 @@
 ;;
 ;; function u0:4(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 939524096 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 469762048 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/byteswap.wat
+++ b/tests/disas/byteswap.wat
@@ -73,7 +73,7 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -89,7 +89,7 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/call-indirect-with-gc.wat
+++ b/tests/disas/call-indirect-with-gc.wat
@@ -11,15 +11,15 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1342177280 "VMTableDefinition+0x0"
-;;     region3 = 1342177288 "VMTableDefinition+0x8"
-;;     region4 = 536870912 "PublicTable"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 671088640 "VMTableDefinition+0x0"
+;;     region3 = 671088648 "VMTableDefinition+0x8"
+;;     region4 = 268435456 "PublicTable"
 ;;     region5 = 40 "VMContext+0x28"
-;;     region6 = 3355443204 "TypeIdsArray+0x4"
-;;     region7 = 3221225488 "VMFuncRef+0x10"
-;;     region8 = 3221225480 "VMFuncRef+0x8"
-;;     region9 = 3221225496 "VMFuncRef+0x18"
+;;     region6 = 1677721604 "TypeIdsArray+0x4"
+;;     region7 = 1610612752 "VMFuncRef+0x10"
+;;     region8 = 1610612744 "VMFuncRef+0x8"
+;;     region9 = 1610612760 "VMFuncRef+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/call-indirect-without-gc.wat
+++ b/tests/disas/call-indirect-without-gc.wat
@@ -11,15 +11,15 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1342177280 "VMTableDefinition+0x0"
-;;     region3 = 1342177288 "VMTableDefinition+0x8"
-;;     region4 = 536870912 "PublicTable"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 671088640 "VMTableDefinition+0x0"
+;;     region3 = 671088648 "VMTableDefinition+0x8"
+;;     region4 = 268435456 "PublicTable"
 ;;     region5 = 40 "VMContext+0x28"
-;;     region6 = 3355443204 "TypeIdsArray+0x4"
-;;     region7 = 3221225488 "VMFuncRef+0x10"
-;;     region8 = 3221225480 "VMFuncRef+0x8"
-;;     region9 = 3221225496 "VMFuncRef+0x18"
+;;     region6 = 1677721604 "TypeIdsArray+0x4"
+;;     region7 = 1610612752 "VMFuncRef+0x10"
+;;     region8 = 1610612744 "VMFuncRef+0x8"
+;;     region9 = 1610612760 "VMFuncRef+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/call-indirect.wat
+++ b/tests/disas/call-indirect.wat
@@ -9,15 +9,15 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1342177280 "VMTableDefinition+0x0"
-;;     region3 = 1342177288 "VMTableDefinition+0x8"
-;;     region4 = 536870912 "PublicTable"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 671088640 "VMTableDefinition+0x0"
+;;     region3 = 671088648 "VMTableDefinition+0x8"
+;;     region4 = 268435456 "PublicTable"
 ;;     region5 = 40 "VMContext+0x28"
-;;     region6 = 3355443204 "TypeIdsArray+0x4"
-;;     region7 = 3221225488 "VMFuncRef+0x10"
-;;     region8 = 3221225480 "VMFuncRef+0x8"
-;;     region9 = 3221225496 "VMFuncRef+0x18"
+;;     region6 = 1677721604 "TypeIdsArray+0x4"
+;;     region7 = 1610612752 "VMFuncRef+0x10"
+;;     region8 = 1610612744 "VMFuncRef+0x8"
+;;     region9 = 1610612760 "VMFuncRef+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/call-simd.wat
+++ b/tests/disas/call-simd.wat
@@ -17,7 +17,7 @@
 
 ;; function u0:0(i64 vmctx, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -38,7 +38,7 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i8x16, i8x16) -> i8x16 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/call.wat
+++ b/tests/disas/call.wat
@@ -13,7 +13,7 @@
 
 ;; function u0:0(i64 vmctx, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -33,7 +33,7 @@
 ;;
 ;; function u0:1(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/component-model/checked-intrinsics-inlined-no-spectre.wat
+++ b/tests/disas/component-model/checked-intrinsics-inlined-no-spectre.wat
@@ -49,10 +49,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i64, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 2415919128 "VMFunctionImport+0x18"
-;;     region3 = 134217832 "VMStoreContext+0x68"
-;;     region4 = 3892314112 "UnsafeIntrinsicMemory"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 1207959576 "VMFunctionImport+0x18"
+;;     region3 = 67108968 "VMStoreContext+0x68"
+;;     region4 = 1946157056 "UnsafeIntrinsicMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/component-model/checked-intrinsics-inlined.wat
+++ b/tests/disas/component-model/checked-intrinsics-inlined.wat
@@ -50,10 +50,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i64, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 2415919128 "VMFunctionImport+0x18"
-;;     region3 = 134217832 "VMStoreContext+0x68"
-;;     region4 = 3892314112 "UnsafeIntrinsicMemory"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 1207959576 "VMFunctionImport+0x18"
+;;     region3 = 67108968 "VMStoreContext+0x68"
+;;     region4 = 1946157056 "UnsafeIntrinsicMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/component-model/checked-intrinsics-trampoline.wat
+++ b/tests/disas/component-model/checked-intrinsics-trampoline.wat
@@ -32,7 +32,7 @@
     )
 )
 ;; function u0:0(i64 vmctx, i64, i64, i64, i64) -> i32 tail {
-;;     region0 = 3892314112 "UnsafeIntrinsicMemory"
+;;     region0 = 1946157056 "UnsafeIntrinsicMemory"
 ;;
 ;; block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64):
 ;;     v5 = iconst.i64 4
@@ -48,7 +48,7 @@
 ;; }
 ;;
 ;; function u0:0(i64 vmctx, i64, i64, i64, i64, i32) tail {
-;;     region0 = 3892314112 "UnsafeIntrinsicMemory"
+;;     region0 = 1946157056 "UnsafeIntrinsicMemory"
 ;;
 ;; block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i32):
 ;;     v6 = iconst.i64 4

--- a/tests/disas/component-model/direct-adapter-calls-inlining.wat
+++ b/tests/disas/component-model/direct-adapter-calls-inlining.wat
@@ -56,11 +56,11 @@
 
 ;; function u1:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 2415919128 "VMFunctionImport+0x18"
-;;     region3 = 2952790016 "VMGlobalImport+0x0"
-;;     region4 = 805306368 "PublicGlobal"
-;;     region5 = 2415919112 "VMFunctionImport+0x8"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 1207959576 "VMFunctionImport+0x18"
+;;     region3 = 1476395008 "VMGlobalImport+0x0"
+;;     region4 = 402653184 "PublicGlobal"
+;;     region5 = 1207959560 "VMFunctionImport+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/component-model/direct-adapter-calls.wat
+++ b/tests/disas/component-model/direct-adapter-calls.wat
@@ -59,7 +59,7 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -76,8 +76,8 @@
 ;;
 ;; function u1:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 2415919128 "VMFunctionImport+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 1207959576 "VMFunctionImport+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -97,11 +97,11 @@
 ;;
 ;; function u2:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 2952790016 "VMGlobalImport+0x0"
-;;     region3 = 805306368 "PublicGlobal"
-;;     region4 = 2415919128 "VMFunctionImport+0x18"
-;;     region5 = 2415919112 "VMFunctionImport+0x8"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 1476395008 "VMGlobalImport+0x0"
+;;     region3 = 402653184 "PublicGlobal"
+;;     region4 = 1207959576 "VMFunctionImport+0x18"
+;;     region5 = 1207959560 "VMFunctionImport+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/component-model/exported-module-makes-adapters-indirect.wat
+++ b/tests/disas/component-model/exported-module-makes-adapters-indirect.wat
@@ -60,9 +60,9 @@
 
 ;; function u1:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 2415919128 "VMFunctionImport+0x18"
-;;     region3 = 2415919112 "VMFunctionImport+0x8"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 1207959576 "VMFunctionImport+0x18"
+;;     region3 = 1207959560 "VMFunctionImport+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/component-model/inlining-and-unsafe-intrinsics.wat
+++ b/tests/disas/component-model/inlining-and-unsafe-intrinsics.wat
@@ -44,10 +44,10 @@
 
 ;; function u0:0(i64 vmctx, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 2415919128 "VMFunctionImport+0x18"
-;;     region3 = 134217832 "VMStoreContext+0x68"
-;;     region4 = 3892314112 "UnsafeIntrinsicMemory"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 1207959576 "VMFunctionImport+0x18"
+;;     region3 = 67108968 "VMStoreContext+0x68"
+;;     region4 = 1946157056 "UnsafeIntrinsicMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/component-model/inlining-bug.wat
+++ b/tests/disas/component-model/inlining-bug.wat
@@ -36,8 +36,8 @@
 
 ;; function u2:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 2415919128 "VMFunctionImport+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 1207959576 "VMFunctionImport+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/component-model/inlining-fuzz-bug.wat
+++ b/tests/disas/component-model/inlining-fuzz-bug.wat
@@ -39,8 +39,8 @@
 
 ;; function u2:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 2415919128 "VMFunctionImport+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 1207959576 "VMFunctionImport+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/component-model/issue-11458.wat
+++ b/tests/disas/component-model/issue-11458.wat
@@ -21,8 +21,8 @@
 
 ;; function u1:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 2415919128 "VMFunctionImport+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 1207959576 "VMFunctionImport+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/component-model/multiple-instantiations-makes-adapters-indirect.wat
+++ b/tests/disas/component-model/multiple-instantiations-makes-adapters-indirect.wat
@@ -66,9 +66,9 @@
 
 ;; function u1:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 2415919128 "VMFunctionImport+0x18"
-;;     region3 = 2415919112 "VMFunctionImport+0x8"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 1207959576 "VMFunctionImport+0x18"
+;;     region3 = 1207959560 "VMFunctionImport+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/component-model/sync-adapter-calls.wat
+++ b/tests/disas/component-model/sync-adapter-calls.wat
@@ -52,7 +52,7 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -70,20 +70,20 @@
 ;; function u1:0(i64 vmctx, i64) -> i32 tail {
 ;;     ss0 = explicit_slot 32, align = 8
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 2415919128 "VMFunctionImport+0x18"
-;;     region3 = 2952790016 "VMGlobalImport+0x0"
-;;     region4 = 805306368 "PublicGlobal"
-;;     region5 = 134217864 "VMStoreContext+0x88"
-;;     region6 = 2013265920 "VMDeferredThread+0x0"
-;;     region7 = 2013265928 "VMDeferredThread+0x8"
-;;     region8 = 2013265932 "VMDeferredThread+0xc"
-;;     region9 = 2013265936 "VMDeferredThread+0x10"
-;;     region10 = 134217856 "VMStoreContext+0x80"
-;;     region11 = 2013265940 "VMDeferredThread+0x14"
-;;     region12 = 134217860 "VMStoreContext+0x84"
-;;     region13 = 2013265944 "VMDeferredThread+0x18"
-;;     region14 = 2415919112 "VMFunctionImport+0x8"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 1207959576 "VMFunctionImport+0x18"
+;;     region3 = 1476395008 "VMGlobalImport+0x0"
+;;     region4 = 402653184 "PublicGlobal"
+;;     region5 = 67109000 "VMStoreContext+0x88"
+;;     region6 = 1006632960 "VMDeferredThread+0x0"
+;;     region7 = 1006632968 "VMDeferredThread+0x8"
+;;     region8 = 1006632972 "VMDeferredThread+0xc"
+;;     region9 = 1006632976 "VMDeferredThread+0x10"
+;;     region10 = 67108992 "VMStoreContext+0x80"
+;;     region11 = 1006632980 "VMDeferredThread+0x14"
+;;     region12 = 67108996 "VMStoreContext+0x84"
+;;     region13 = 1006632984 "VMDeferredThread+0x18"
+;;     region14 = 1207959560 "VMFunctionImport+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -202,20 +202,20 @@
 ;; function u2:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 32, align = 8
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 2952790016 "VMGlobalImport+0x0"
-;;     region3 = 805306368 "PublicGlobal"
-;;     region4 = 2415919128 "VMFunctionImport+0x18"
-;;     region5 = 2415919112 "VMFunctionImport+0x8"
-;;     region6 = 134217864 "VMStoreContext+0x88"
-;;     region7 = 2013265920 "VMDeferredThread+0x0"
-;;     region8 = 2013265928 "VMDeferredThread+0x8"
-;;     region9 = 2013265932 "VMDeferredThread+0xc"
-;;     region10 = 2013265936 "VMDeferredThread+0x10"
-;;     region11 = 134217856 "VMStoreContext+0x80"
-;;     region12 = 2013265940 "VMDeferredThread+0x14"
-;;     region13 = 134217860 "VMStoreContext+0x84"
-;;     region14 = 2013265944 "VMDeferredThread+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 1476395008 "VMGlobalImport+0x0"
+;;     region3 = 402653184 "PublicGlobal"
+;;     region4 = 1207959576 "VMFunctionImport+0x18"
+;;     region5 = 1207959560 "VMFunctionImport+0x8"
+;;     region6 = 67109000 "VMStoreContext+0x88"
+;;     region7 = 1006632960 "VMDeferredThread+0x0"
+;;     region8 = 1006632968 "VMDeferredThread+0x8"
+;;     region9 = 1006632972 "VMDeferredThread+0xc"
+;;     region10 = 1006632976 "VMDeferredThread+0x10"
+;;     region11 = 67108992 "VMStoreContext+0x80"
+;;     region12 = 1006632980 "VMDeferredThread+0x14"
+;;     region13 = 67108996 "VMStoreContext+0x84"
+;;     region14 = 1006632984 "VMDeferredThread+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/component-model/unsafe-intrinsics-used.wat
+++ b/tests/disas/component-model/unsafe-intrinsics-used.wat
@@ -36,7 +36,7 @@
 
 ;; function u0:0(i64 vmctx, i64) -> i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217832 "VMStoreContext+0x68"
+;;     region1 = 67108968 "VMStoreContext+0x68"
 ;;
 ;; block0(v0: i64, v1: i64):
 ;;     v2 = load.i64 notrap aligned readonly can_move region0 v1+8
@@ -45,7 +45,7 @@
 ;; }
 ;;
 ;; function u0:0(i64 vmctx, i64, i64) -> i32 tail {
-;;     region0 = 3892314112 "UnsafeIntrinsicMemory"
+;;     region0 = 1946157056 "UnsafeIntrinsicMemory"
 ;;
 ;; block0(v0: i64, v1: i64, v2: i64):
 ;;     v3 = load.i8 notrap aligned region0 v2

--- a/tests/disas/conditional-traps.wat
+++ b/tests/disas/conditional-traps.wat
@@ -23,7 +23,7 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -42,7 +42,7 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/dead-code.wat
+++ b/tests/disas/dead-code.wat
@@ -23,7 +23,7 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -50,7 +50,7 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -65,7 +65,7 @@
 ;;
 ;; function u0:2(i64 vmctx, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -80,7 +80,7 @@
 ;;
 ;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/duplicate-function-types.wat
+++ b/tests/disas/duplicate-function-types.wat
@@ -18,16 +18,16 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32, i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 2684354560 "VMTableImport+0x0"
-;;     region3 = 1342177280 "VMTableDefinition+0x0"
-;;     region4 = 1342177288 "VMTableDefinition+0x8"
-;;     region5 = 536870912 "PublicTable"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 1342177280 "VMTableImport+0x0"
+;;     region3 = 671088640 "VMTableDefinition+0x0"
+;;     region4 = 671088648 "VMTableDefinition+0x8"
+;;     region5 = 268435456 "PublicTable"
 ;;     region6 = 40 "VMContext+0x28"
-;;     region7 = 3355443200 "TypeIdsArray+0x0"
-;;     region8 = 3221225488 "VMFuncRef+0x10"
-;;     region9 = 3221225480 "VMFuncRef+0x8"
-;;     region10 = 3221225496 "VMFuncRef+0x18"
+;;     region7 = 1677721600 "TypeIdsArray+0x0"
+;;     region8 = 1610612752 "VMFuncRef+0x10"
+;;     region9 = 1610612744 "VMFuncRef+0x8"
+;;     region10 = 1610612760 "VMFuncRef+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/duplicate-loads-dynamic-memory.wat
+++ b/tests/disas/duplicate-loads-dynamic-memory.wat
@@ -24,10 +24,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32, i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 268435456 "PublicMemory"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 134217728 "PublicMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -50,10 +50,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32, i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 268435456 "PublicMemory"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 134217728 "PublicMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/duplicate-loads-static-memory.wat
+++ b/tests/disas/duplicate-loads-static-memory.wat
@@ -19,10 +19,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32, i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 268435456 "PublicMemory"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 134217728 "PublicMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -41,10 +41,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32, i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 268435456 "PublicMemory"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 134217728 "PublicMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/dynamic-memory-no-spectre-access-same-index-different-offsets.wat
+++ b/tests/disas/dynamic-memory-no-spectre-access-same-index-different-offsets.wat
@@ -37,10 +37,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32, i32, i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 268435456 "PublicMemory"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 134217728 "PublicMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -72,10 +72,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 268435456 "PublicMemory"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 134217728 "PublicMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/dynamic-memory-yes-spectre-access-same-index-different-offsets.wat
+++ b/tests/disas/dynamic-memory-yes-spectre-access-same-index-different-offsets.wat
@@ -33,10 +33,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32, i32, i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 268435456 "PublicMemory"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 134217728 "PublicMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -70,10 +70,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 268435456 "PublicMemory"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 134217728 "PublicMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/elem-segment.wat
+++ b/tests/disas/elem-segment.wat
@@ -12,10 +12,10 @@
 )
 ;; function u2415919104:1(i64 vmctx, i64, i64, i64) -> i8 system_v {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217800 "VMStoreContext+0x48"
-;;     region2 = 134217792 "VMStoreContext+0x40"
-;;     region3 = 134217808 "VMStoreContext+0x50"
-;;     region4 = 134217864 "VMStoreContext+0x88"
+;;     region1 = 67108936 "VMStoreContext+0x48"
+;;     region2 = 67108928 "VMStoreContext+0x40"
+;;     region3 = 67108944 "VMStoreContext+0x50"
+;;     region4 = 67109000 "VMStoreContext+0x88"
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     fn0 = colocated u2415919104:0 sig0
 ;;
@@ -44,7 +44,7 @@
 ;; }
 ;;
 ;; function u2415919104:0(i64 vmctx, i64) tail {
-;;     region0 = 4160749568 "ElementSegment"
+;;     region0 = 2080374784 "ElementSegment"
 ;;     sig0 = (i64 vmctx, i32) -> i64 tail
 ;;     sig1 = (i64 vmctx, i32) -> i64 tail
 ;;     fn0 = colocated u805306368:4 sig0

--- a/tests/disas/epoch-interruption.wat
+++ b/tests/disas/epoch-interruption.wat
@@ -6,10 +6,10 @@
 
 ;; function u0:0(i64 vmctx, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 24 "VMContext+0x18"
-;;     region3 = 3489660928 "EpochCounter+0x0"
-;;     region4 = 134217736 "VMStoreContext+0x8"
+;;     region3 = 1744830464 "EpochCounter+0x0"
+;;     region4 = 67108872 "VMStoreContext+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/f32-load.wat
+++ b/tests/disas/f32-load.wat
@@ -8,10 +8,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> f32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/f32-store.wat
+++ b/tests/disas/f32-store.wat
@@ -11,10 +11,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, f32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/f64-load.wat
+++ b/tests/disas/f64-load.wat
@@ -10,10 +10,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> f64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/f64-store.wat
+++ b/tests/disas/f64-store.wat
@@ -11,10 +11,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, f64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/fac-multi-value.wat
+++ b/tests/disas/fac-multi-value.wat
@@ -22,7 +22,7 @@
 
 ;; function u0:0(i64 vmctx, i64, i64) -> i64, i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -37,7 +37,7 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64, i64) -> i64, i64, i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -52,7 +52,7 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i64) -> i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/fibonacci.wat
+++ b/tests/disas/fibonacci.wat
@@ -25,10 +25,10 @@
 
 ;; function u0:0(i64 vmctx, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/fixed-size-memory.wat
+++ b/tests/disas/fixed-size-memory.wat
@@ -22,10 +22,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -47,10 +47,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/foo.wat
+++ b/tests/disas/foo.wat
@@ -16,19 +16,19 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32, i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
-;;     region5 = 2684354560 "VMTableImport+0x0"
-;;     region6 = 1342177280 "VMTableDefinition+0x0"
-;;     region7 = 1342177288 "VMTableDefinition+0x8"
-;;     region8 = 536870912 "PublicTable"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region5 = 1342177280 "VMTableImport+0x0"
+;;     region6 = 671088640 "VMTableDefinition+0x0"
+;;     region7 = 671088648 "VMTableDefinition+0x8"
+;;     region8 = 268435456 "PublicTable"
 ;;     region9 = 40 "VMContext+0x28"
-;;     region10 = 3355443204 "TypeIdsArray+0x4"
-;;     region11 = 3221225488 "VMFuncRef+0x10"
-;;     region12 = 3221225480 "VMFuncRef+0x8"
-;;     region13 = 3221225496 "VMFuncRef+0x18"
+;;     region10 = 1677721604 "TypeIdsArray+0x4"
+;;     region11 = 1610612752 "VMFuncRef+0x10"
+;;     region12 = 1610612744 "VMFuncRef+0x8"
+;;     region13 = 1610612760 "VMFuncRef+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/array-copy-with-fuel.wat
+++ b/tests/disas/gc/array-copy-with-fuel.wat
@@ -13,13 +13,13 @@
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     ss1 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217728 "VMStoreContext+0x0"
-;;     region3 = 134217760 "VMStoreContext+0x20"
-;;     region4 = 134217768 "VMStoreContext+0x28"
-;;     region5 = 1073741824 "GcHeap"
-;;     region6 = 3087007744 "Stack(ss0)"
-;;     region7 = 3087007745 "Stack(ss1)"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108864 "VMStoreContext+0x0"
+;;     region3 = 67108896 "VMStoreContext+0x20"
+;;     region4 = 67108904 "VMStoreContext+0x28"
+;;     region5 = 536870912 "GcHeap"
+;;     region6 = 1543503872 "Stack(ss0)"
+;;     region7 = 1543503873 "Stack(ss1)"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/array-fill-i8.wat
+++ b/tests/disas/gc/array-fill-i8.wat
@@ -11,10 +11,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/array-init-data.wat
+++ b/tests/disas/gc/array-init-data.wat
@@ -15,10 +15,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     region5 = 56 "VMContext+0x38"
 ;;     region6 = 48 "VMContext+0x30"
 ;;     gv0 = vmctx

--- a/tests/disas/gc/array-new-data.wat
+++ b/tests/disas/gc/array-new-data.wat
@@ -78,18 +78,18 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 56 "VMContext+0x38"
 ;;     region3 = 48 "VMContext+0x30"
 ;;     region4 = 32 "VMContext+0x20"
-;;     region5 = 1744830464 "VMCopyingHeapData+0x0"
-;;     region6 = 1744830468 "VMCopyingHeapData+0x4"
+;;     region5 = 872415232 "VMCopyingHeapData+0x0"
+;;     region6 = 872415236 "VMCopyingHeapData+0x4"
 ;;     region7 = 40 "VMContext+0x28"
-;;     region8 = 3355443200 "TypeIdsArray+0x0"
-;;     region9 = 134217760 "VMStoreContext+0x20"
-;;     region10 = 1073741824 "GcHeap"
-;;     region11 = 134217768 "VMStoreContext+0x28"
-;;     region12 = 3087007744 "Stack(ss0)"
+;;     region8 = 1677721600 "TypeIdsArray+0x0"
+;;     region9 = 67108896 "VMStoreContext+0x20"
+;;     region10 = 536870912 "GcHeap"
+;;     region11 = 67108904 "VMStoreContext+0x28"
+;;     region12 = 1543503872 "Stack(ss0)"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/array-new-default-anyref.wat
+++ b/tests/disas/gc/array-new-default-anyref.wat
@@ -11,15 +11,15 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 1744830464 "VMCopyingHeapData+0x0"
-;;     region4 = 1744830468 "VMCopyingHeapData+0x4"
+;;     region3 = 872415232 "VMCopyingHeapData+0x0"
+;;     region4 = 872415236 "VMCopyingHeapData+0x4"
 ;;     region5 = 40 "VMContext+0x28"
-;;     region6 = 3355443200 "TypeIdsArray+0x0"
-;;     region7 = 134217760 "VMStoreContext+0x20"
-;;     region8 = 1073741824 "GcHeap"
-;;     region9 = 134217768 "VMStoreContext+0x28"
+;;     region6 = 1677721600 "TypeIdsArray+0x0"
+;;     region7 = 67108896 "VMStoreContext+0x20"
+;;     region8 = 536870912 "GcHeap"
+;;     region9 = 67108904 "VMStoreContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/array-new-default-exnref.wat
+++ b/tests/disas/gc/array-new-default-exnref.wat
@@ -11,15 +11,15 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 1744830464 "VMCopyingHeapData+0x0"
-;;     region4 = 1744830468 "VMCopyingHeapData+0x4"
+;;     region3 = 872415232 "VMCopyingHeapData+0x0"
+;;     region4 = 872415236 "VMCopyingHeapData+0x4"
 ;;     region5 = 40 "VMContext+0x28"
-;;     region6 = 3355443200 "TypeIdsArray+0x0"
-;;     region7 = 134217760 "VMStoreContext+0x20"
-;;     region8 = 1073741824 "GcHeap"
-;;     region9 = 134217768 "VMStoreContext+0x28"
+;;     region6 = 1677721600 "TypeIdsArray+0x0"
+;;     region7 = 67108896 "VMStoreContext+0x20"
+;;     region8 = 536870912 "GcHeap"
+;;     region9 = 67108904 "VMStoreContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/array-new-default-externref.wat
+++ b/tests/disas/gc/array-new-default-externref.wat
@@ -11,15 +11,15 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 1744830464 "VMCopyingHeapData+0x0"
-;;     region4 = 1744830468 "VMCopyingHeapData+0x4"
+;;     region3 = 872415232 "VMCopyingHeapData+0x0"
+;;     region4 = 872415236 "VMCopyingHeapData+0x4"
 ;;     region5 = 40 "VMContext+0x28"
-;;     region6 = 3355443200 "TypeIdsArray+0x0"
-;;     region7 = 134217760 "VMStoreContext+0x20"
-;;     region8 = 1073741824 "GcHeap"
-;;     region9 = 134217768 "VMStoreContext+0x28"
+;;     region6 = 1677721600 "TypeIdsArray+0x0"
+;;     region7 = 67108896 "VMStoreContext+0x20"
+;;     region8 = 536870912 "GcHeap"
+;;     region9 = 67108904 "VMStoreContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/array-new-default-f32.wat
+++ b/tests/disas/gc/array-new-default-f32.wat
@@ -12,16 +12,16 @@
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 1744830464 "VMCopyingHeapData+0x0"
-;;     region4 = 1744830468 "VMCopyingHeapData+0x4"
+;;     region3 = 872415232 "VMCopyingHeapData+0x0"
+;;     region4 = 872415236 "VMCopyingHeapData+0x4"
 ;;     region5 = 40 "VMContext+0x28"
-;;     region6 = 3355443200 "TypeIdsArray+0x0"
-;;     region7 = 134217760 "VMStoreContext+0x20"
-;;     region8 = 1073741824 "GcHeap"
-;;     region9 = 134217768 "VMStoreContext+0x28"
-;;     region10 = 3087007744 "Stack(ss0)"
+;;     region6 = 1677721600 "TypeIdsArray+0x0"
+;;     region7 = 67108896 "VMStoreContext+0x20"
+;;     region8 = 536870912 "GcHeap"
+;;     region9 = 67108904 "VMStoreContext+0x28"
+;;     region10 = 1543503872 "Stack(ss0)"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/array-new-default-f64.wat
+++ b/tests/disas/gc/array-new-default-f64.wat
@@ -12,16 +12,16 @@
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 1744830464 "VMCopyingHeapData+0x0"
-;;     region4 = 1744830468 "VMCopyingHeapData+0x4"
+;;     region3 = 872415232 "VMCopyingHeapData+0x0"
+;;     region4 = 872415236 "VMCopyingHeapData+0x4"
 ;;     region5 = 40 "VMContext+0x28"
-;;     region6 = 3355443200 "TypeIdsArray+0x0"
-;;     region7 = 134217760 "VMStoreContext+0x20"
-;;     region8 = 1073741824 "GcHeap"
-;;     region9 = 134217768 "VMStoreContext+0x28"
-;;     region10 = 3087007744 "Stack(ss0)"
+;;     region6 = 1677721600 "TypeIdsArray+0x0"
+;;     region7 = 67108896 "VMStoreContext+0x20"
+;;     region8 = 536870912 "GcHeap"
+;;     region9 = 67108904 "VMStoreContext+0x28"
+;;     region10 = 1543503872 "Stack(ss0)"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/array-new-default-funcref.wat
+++ b/tests/disas/gc/array-new-default-funcref.wat
@@ -12,16 +12,16 @@
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 1744830464 "VMCopyingHeapData+0x0"
-;;     region4 = 1744830468 "VMCopyingHeapData+0x4"
+;;     region3 = 872415232 "VMCopyingHeapData+0x0"
+;;     region4 = 872415236 "VMCopyingHeapData+0x4"
 ;;     region5 = 40 "VMContext+0x28"
-;;     region6 = 3355443200 "TypeIdsArray+0x0"
-;;     region7 = 134217760 "VMStoreContext+0x20"
-;;     region8 = 1073741824 "GcHeap"
-;;     region9 = 134217768 "VMStoreContext+0x28"
-;;     region10 = 3087007744 "Stack(ss0)"
+;;     region6 = 1677721600 "TypeIdsArray+0x0"
+;;     region7 = 67108896 "VMStoreContext+0x20"
+;;     region8 = 536870912 "GcHeap"
+;;     region9 = 67108904 "VMStoreContext+0x28"
+;;     region10 = 1543503872 "Stack(ss0)"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/array-new-default-i16.wat
+++ b/tests/disas/gc/array-new-default-i16.wat
@@ -12,16 +12,16 @@
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 1744830464 "VMCopyingHeapData+0x0"
-;;     region4 = 1744830468 "VMCopyingHeapData+0x4"
+;;     region3 = 872415232 "VMCopyingHeapData+0x0"
+;;     region4 = 872415236 "VMCopyingHeapData+0x4"
 ;;     region5 = 40 "VMContext+0x28"
-;;     region6 = 3355443200 "TypeIdsArray+0x0"
-;;     region7 = 134217760 "VMStoreContext+0x20"
-;;     region8 = 1073741824 "GcHeap"
-;;     region9 = 134217768 "VMStoreContext+0x28"
-;;     region10 = 3087007744 "Stack(ss0)"
+;;     region6 = 1677721600 "TypeIdsArray+0x0"
+;;     region7 = 67108896 "VMStoreContext+0x20"
+;;     region8 = 536870912 "GcHeap"
+;;     region9 = 67108904 "VMStoreContext+0x28"
+;;     region10 = 1543503872 "Stack(ss0)"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/array-new-default-i32.wat
+++ b/tests/disas/gc/array-new-default-i32.wat
@@ -12,16 +12,16 @@
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 1744830464 "VMCopyingHeapData+0x0"
-;;     region4 = 1744830468 "VMCopyingHeapData+0x4"
+;;     region3 = 872415232 "VMCopyingHeapData+0x0"
+;;     region4 = 872415236 "VMCopyingHeapData+0x4"
 ;;     region5 = 40 "VMContext+0x28"
-;;     region6 = 3355443200 "TypeIdsArray+0x0"
-;;     region7 = 134217760 "VMStoreContext+0x20"
-;;     region8 = 1073741824 "GcHeap"
-;;     region9 = 134217768 "VMStoreContext+0x28"
-;;     region10 = 3087007744 "Stack(ss0)"
+;;     region6 = 1677721600 "TypeIdsArray+0x0"
+;;     region7 = 67108896 "VMStoreContext+0x20"
+;;     region8 = 536870912 "GcHeap"
+;;     region9 = 67108904 "VMStoreContext+0x28"
+;;     region10 = 1543503872 "Stack(ss0)"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/array-new-default-i64.wat
+++ b/tests/disas/gc/array-new-default-i64.wat
@@ -12,16 +12,16 @@
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 1744830464 "VMCopyingHeapData+0x0"
-;;     region4 = 1744830468 "VMCopyingHeapData+0x4"
+;;     region3 = 872415232 "VMCopyingHeapData+0x0"
+;;     region4 = 872415236 "VMCopyingHeapData+0x4"
 ;;     region5 = 40 "VMContext+0x28"
-;;     region6 = 3355443200 "TypeIdsArray+0x0"
-;;     region7 = 134217760 "VMStoreContext+0x20"
-;;     region8 = 1073741824 "GcHeap"
-;;     region9 = 134217768 "VMStoreContext+0x28"
-;;     region10 = 3087007744 "Stack(ss0)"
+;;     region6 = 1677721600 "TypeIdsArray+0x0"
+;;     region7 = 67108896 "VMStoreContext+0x20"
+;;     region8 = 536870912 "GcHeap"
+;;     region9 = 67108904 "VMStoreContext+0x28"
+;;     region10 = 1543503872 "Stack(ss0)"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/array-new-default-i8.wat
+++ b/tests/disas/gc/array-new-default-i8.wat
@@ -12,16 +12,16 @@
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 1744830464 "VMCopyingHeapData+0x0"
-;;     region4 = 1744830468 "VMCopyingHeapData+0x4"
+;;     region3 = 872415232 "VMCopyingHeapData+0x0"
+;;     region4 = 872415236 "VMCopyingHeapData+0x4"
 ;;     region5 = 40 "VMContext+0x28"
-;;     region6 = 3355443200 "TypeIdsArray+0x0"
-;;     region7 = 134217760 "VMStoreContext+0x20"
-;;     region8 = 1073741824 "GcHeap"
-;;     region9 = 134217768 "VMStoreContext+0x28"
-;;     region10 = 3087007744 "Stack(ss0)"
+;;     region6 = 1677721600 "TypeIdsArray+0x0"
+;;     region7 = 67108896 "VMStoreContext+0x20"
+;;     region8 = 536870912 "GcHeap"
+;;     region9 = 67108904 "VMStoreContext+0x28"
+;;     region10 = 1543503872 "Stack(ss0)"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/call-indirect-final-type.wat
+++ b/tests/disas/gc/call-indirect-final-type.wat
@@ -17,15 +17,15 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1342177280 "VMTableDefinition+0x0"
-;;     region3 = 1342177288 "VMTableDefinition+0x8"
-;;     region4 = 671088640 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 671088640 "VMTableDefinition+0x0"
+;;     region3 = 671088648 "VMTableDefinition+0x8"
+;;     region4 = 335544320 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     region5 = 40 "VMContext+0x28"
-;;     region6 = 3355443200 "TypeIdsArray+0x0"
-;;     region7 = 3221225488 "VMFuncRef+0x10"
-;;     region8 = 3221225480 "VMFuncRef+0x8"
-;;     region9 = 3221225496 "VMFuncRef+0x18"
+;;     region6 = 1677721600 "TypeIdsArray+0x0"
+;;     region7 = 1610612752 "VMFuncRef+0x10"
+;;     region8 = 1610612744 "VMFuncRef+0x8"
+;;     region9 = 1610612760 "VMFuncRef+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -72,15 +72,15 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1342177280 "VMTableDefinition+0x0"
-;;     region3 = 1342177288 "VMTableDefinition+0x8"
-;;     region4 = 671088640 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 671088640 "VMTableDefinition+0x0"
+;;     region3 = 671088648 "VMTableDefinition+0x8"
+;;     region4 = 335544320 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     region5 = 40 "VMContext+0x28"
-;;     region6 = 3355443200 "TypeIdsArray+0x0"
-;;     region7 = 3221225488 "VMFuncRef+0x10"
-;;     region8 = 3221225480 "VMFuncRef+0x8"
-;;     region9 = 3221225496 "VMFuncRef+0x18"
+;;     region6 = 1677721600 "TypeIdsArray+0x0"
+;;     region7 = 1610612752 "VMFuncRef+0x10"
+;;     region8 = 1610612744 "VMFuncRef+0x8"
+;;     region9 = 1610612760 "VMFuncRef+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/copying/array-fill.wat
+++ b/tests/disas/gc/copying/array-fill.wat
@@ -10,10 +10,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/copying/array-get-s.wat
+++ b/tests/disas/gc/copying/array-get-s.wat
@@ -10,10 +10,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/copying/array-get-u.wat
+++ b/tests/disas/gc/copying/array-get-u.wat
@@ -10,10 +10,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/copying/array-get.wat
+++ b/tests/disas/gc/copying/array-get.wat
@@ -10,10 +10,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/copying/array-len.wat
+++ b/tests/disas/gc/copying/array-len.wat
@@ -10,10 +10,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/copying/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/copying/array-new-fixed-of-gc-refs.wat
@@ -13,18 +13,18 @@
 ;;     ss1 = explicit_slot 4, align = 4
 ;;     ss2 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 1744830464 "VMCopyingHeapData+0x0"
-;;     region4 = 1744830468 "VMCopyingHeapData+0x4"
+;;     region3 = 872415232 "VMCopyingHeapData+0x0"
+;;     region4 = 872415236 "VMCopyingHeapData+0x4"
 ;;     region5 = 40 "VMContext+0x28"
-;;     region6 = 3355443200 "TypeIdsArray+0x0"
-;;     region7 = 134217760 "VMStoreContext+0x20"
-;;     region8 = 1073741824 "GcHeap"
-;;     region9 = 134217768 "VMStoreContext+0x28"
-;;     region10 = 3087007744 "Stack(ss0)"
-;;     region11 = 3087007745 "Stack(ss1)"
-;;     region12 = 3087007746 "Stack(ss2)"
+;;     region6 = 1677721600 "TypeIdsArray+0x0"
+;;     region7 = 67108896 "VMStoreContext+0x20"
+;;     region8 = 536870912 "GcHeap"
+;;     region9 = 67108904 "VMStoreContext+0x28"
+;;     region10 = 1543503872 "Stack(ss0)"
+;;     region11 = 1543503873 "Stack(ss1)"
+;;     region12 = 1543503874 "Stack(ss2)"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/copying/array-new-fixed.wat
+++ b/tests/disas/gc/copying/array-new-fixed.wat
@@ -10,15 +10,15 @@
 )
 ;; function u0:0(i64 vmctx, i64, i64, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 1744830464 "VMCopyingHeapData+0x0"
-;;     region4 = 1744830468 "VMCopyingHeapData+0x4"
+;;     region3 = 872415232 "VMCopyingHeapData+0x0"
+;;     region4 = 872415236 "VMCopyingHeapData+0x4"
 ;;     region5 = 40 "VMContext+0x28"
-;;     region6 = 3355443200 "TypeIdsArray+0x0"
-;;     region7 = 134217760 "VMStoreContext+0x20"
-;;     region8 = 1073741824 "GcHeap"
-;;     region9 = 134217768 "VMStoreContext+0x28"
+;;     region6 = 1677721600 "TypeIdsArray+0x0"
+;;     region7 = 67108896 "VMStoreContext+0x20"
+;;     region8 = 536870912 "GcHeap"
+;;     region9 = 67108904 "VMStoreContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/copying/array-new.wat
+++ b/tests/disas/gc/copying/array-new.wat
@@ -10,15 +10,15 @@
 )
 ;; function u0:0(i64 vmctx, i64, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 1744830464 "VMCopyingHeapData+0x0"
-;;     region4 = 1744830468 "VMCopyingHeapData+0x4"
+;;     region3 = 872415232 "VMCopyingHeapData+0x0"
+;;     region4 = 872415236 "VMCopyingHeapData+0x4"
 ;;     region5 = 40 "VMContext+0x28"
-;;     region6 = 3355443200 "TypeIdsArray+0x0"
-;;     region7 = 134217760 "VMStoreContext+0x20"
-;;     region8 = 1073741824 "GcHeap"
-;;     region9 = 134217768 "VMStoreContext+0x28"
+;;     region6 = 1677721600 "TypeIdsArray+0x0"
+;;     region7 = 67108896 "VMStoreContext+0x20"
+;;     region8 = 536870912 "GcHeap"
+;;     region9 = 67108904 "VMStoreContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/copying/array-set.wat
+++ b/tests/disas/gc/copying/array-set.wat
@@ -10,10 +10,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/copying/br-on-cast-fail.wat
+++ b/tests/disas/gc/copying/br-on-cast-fail.wat
@@ -17,14 +17,14 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 40 "VMContext+0x28"
-;;     region3 = 3355443200 "TypeIdsArray+0x0"
-;;     region4 = 134217760 "VMStoreContext+0x20"
-;;     region5 = 134217768 "VMStoreContext+0x28"
-;;     region6 = 1073741824 "GcHeap"
-;;     region7 = 2415919128 "VMFunctionImport+0x18"
-;;     region8 = 2415919112 "VMFunctionImport+0x8"
+;;     region3 = 1677721600 "TypeIdsArray+0x0"
+;;     region4 = 67108896 "VMStoreContext+0x20"
+;;     region5 = 67108904 "VMStoreContext+0x28"
+;;     region6 = 536870912 "GcHeap"
+;;     region7 = 1207959576 "VMFunctionImport+0x18"
+;;     region8 = 1207959560 "VMFunctionImport+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/copying/br-on-cast.wat
+++ b/tests/disas/gc/copying/br-on-cast.wat
@@ -17,14 +17,14 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 40 "VMContext+0x28"
-;;     region3 = 3355443200 "TypeIdsArray+0x0"
-;;     region4 = 134217760 "VMStoreContext+0x20"
-;;     region5 = 134217768 "VMStoreContext+0x28"
-;;     region6 = 1073741824 "GcHeap"
-;;     region7 = 2415919128 "VMFunctionImport+0x18"
-;;     region8 = 2415919112 "VMFunctionImport+0x8"
+;;     region3 = 1677721600 "TypeIdsArray+0x0"
+;;     region4 = 67108896 "VMStoreContext+0x20"
+;;     region5 = 67108904 "VMStoreContext+0x28"
+;;     region6 = 536870912 "GcHeap"
+;;     region7 = 1207959576 "VMFunctionImport+0x18"
+;;     region8 = 1207959560 "VMFunctionImport+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/copying/call-indirect-and-subtyping.wat
+++ b/tests/disas/gc/copying/call-indirect-and-subtyping.wat
@@ -17,14 +17,14 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1342177280 "VMTableDefinition+0x0"
-;;     region3 = 671088640 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 671088640 "VMTableDefinition+0x0"
+;;     region3 = 335544320 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     region4 = 40 "VMContext+0x28"
-;;     region5 = 3355443200 "TypeIdsArray+0x0"
-;;     region6 = 3221225488 "VMFuncRef+0x10"
-;;     region7 = 3221225480 "VMFuncRef+0x8"
-;;     region8 = 3221225496 "VMFuncRef+0x18"
+;;     region5 = 1677721600 "TypeIdsArray+0x0"
+;;     region6 = 1610612752 "VMFuncRef+0x10"
+;;     region7 = 1610612744 "VMFuncRef+0x8"
+;;     region8 = 1610612760 "VMFuncRef+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/copying/externref-globals.wat
+++ b/tests/disas/gc/copying/externref-globals.wat
@@ -12,8 +12,8 @@
 )
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 939524096 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 469762048 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -31,8 +31,8 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 939524096 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 469762048 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/copying/funcref-in-gc-heap-get.wat
+++ b/tests/disas/gc/copying/funcref-in-gc-heap-get.wat
@@ -10,10 +10,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/copying/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/copying/funcref-in-gc-heap-new.wat
@@ -11,15 +11,15 @@
 ;; function u0:0(i64 vmctx, i64, i64) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 1744830464 "VMCopyingHeapData+0x0"
-;;     region4 = 1744830468 "VMCopyingHeapData+0x4"
+;;     region3 = 872415232 "VMCopyingHeapData+0x0"
+;;     region4 = 872415236 "VMCopyingHeapData+0x4"
 ;;     region5 = 40 "VMContext+0x28"
-;;     region6 = 3355443200 "TypeIdsArray+0x0"
-;;     region7 = 134217760 "VMStoreContext+0x20"
-;;     region8 = 1073741824 "GcHeap"
-;;     region9 = 3087007744 "Stack(ss0)"
+;;     region6 = 1677721600 "TypeIdsArray+0x0"
+;;     region7 = 67108896 "VMStoreContext+0x20"
+;;     region8 = 536870912 "GcHeap"
+;;     region9 = 1543503872 "Stack(ss0)"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/copying/funcref-in-gc-heap-set.wat
+++ b/tests/disas/gc/copying/funcref-in-gc-heap-set.wat
@@ -10,10 +10,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/copying/i31ref-globals.wat
+++ b/tests/disas/gc/copying/i31ref-globals.wat
@@ -12,8 +12,8 @@
 )
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 939524096 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 469762048 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -31,8 +31,8 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 939524096 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 469762048 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/copying/multiple-array-get.wat
+++ b/tests/disas/gc/copying/multiple-array-get.wat
@@ -11,10 +11,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32) -> i64, i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/copying/multiple-struct-get.wat
+++ b/tests/disas/gc/copying/multiple-struct-get.wat
@@ -12,10 +12,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> f32, i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/copying/ref-cast.wat
+++ b/tests/disas/gc/copying/ref-cast.wat
@@ -9,12 +9,12 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 40 "VMContext+0x28"
-;;     region3 = 3355443200 "TypeIdsArray+0x0"
-;;     region4 = 134217760 "VMStoreContext+0x20"
-;;     region5 = 134217768 "VMStoreContext+0x28"
-;;     region6 = 1073741824 "GcHeap"
+;;     region3 = 1677721600 "TypeIdsArray+0x0"
+;;     region4 = 67108896 "VMStoreContext+0x20"
+;;     region5 = 67108904 "VMStoreContext+0x28"
+;;     region6 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/copying/ref-is-null.wat
+++ b/tests/disas/gc/copying/ref-is-null.wat
@@ -11,7 +11,7 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -29,7 +29,7 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/copying/ref-test-any.wat
+++ b/tests/disas/gc/copying/ref-test-any.wat
@@ -11,7 +11,7 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -29,7 +29,7 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/copying/ref-test-array.wat
+++ b/tests/disas/gc/copying/ref-test-array.wat
@@ -8,10 +8,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/copying/ref-test-concrete-func-type.wat
+++ b/tests/disas/gc/copying/ref-test-concrete-func-type.wat
@@ -9,10 +9,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 40 "VMContext+0x28"
-;;     region3 = 3355443200 "TypeIdsArray+0x0"
-;;     region4 = 3221225488 "VMFuncRef+0x10"
+;;     region3 = 1677721600 "TypeIdsArray+0x0"
+;;     region4 = 1610612752 "VMFuncRef+0x10"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/copying/ref-test-concrete-type.wat
+++ b/tests/disas/gc/copying/ref-test-concrete-type.wat
@@ -9,12 +9,12 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 40 "VMContext+0x28"
-;;     region3 = 3355443200 "TypeIdsArray+0x0"
-;;     region4 = 134217760 "VMStoreContext+0x20"
-;;     region5 = 134217768 "VMStoreContext+0x28"
-;;     region6 = 1073741824 "GcHeap"
+;;     region3 = 1677721600 "TypeIdsArray+0x0"
+;;     region4 = 67108896 "VMStoreContext+0x20"
+;;     region5 = 67108904 "VMStoreContext+0x28"
+;;     region6 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/copying/ref-test-eq.wat
+++ b/tests/disas/gc/copying/ref-test-eq.wat
@@ -8,10 +8,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/copying/ref-test-i31.wat
+++ b/tests/disas/gc/copying/ref-test-i31.wat
@@ -8,7 +8,7 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/copying/ref-test-none.wat
+++ b/tests/disas/gc/copying/ref-test-none.wat
@@ -11,7 +11,7 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -27,7 +27,7 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/copying/ref-test-struct.wat
+++ b/tests/disas/gc/copying/ref-test-struct.wat
@@ -8,10 +8,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/copying/struct-get.wat
+++ b/tests/disas/gc/copying/struct-get.wat
@@ -24,10 +24,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> f32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -50,10 +50,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -77,10 +77,10 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -104,10 +104,10 @@
 ;;
 ;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/copying/struct-new-default.wat
+++ b/tests/disas/gc/copying/struct-new-default.wat
@@ -12,14 +12,14 @@
 )
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 1744830464 "VMCopyingHeapData+0x0"
-;;     region4 = 1744830468 "VMCopyingHeapData+0x4"
+;;     region3 = 872415232 "VMCopyingHeapData+0x0"
+;;     region4 = 872415236 "VMCopyingHeapData+0x4"
 ;;     region5 = 40 "VMContext+0x28"
-;;     region6 = 3355443200 "TypeIdsArray+0x0"
-;;     region7 = 134217760 "VMStoreContext+0x20"
-;;     region8 = 1073741824 "GcHeap"
+;;     region6 = 1677721600 "TypeIdsArray+0x0"
+;;     region7 = 67108896 "VMStoreContext+0x20"
+;;     region8 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/copying/struct-new.wat
+++ b/tests/disas/gc/copying/struct-new.wat
@@ -13,15 +13,15 @@
 ;; function u0:0(i64 vmctx, i64, f32, i32, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 1744830464 "VMCopyingHeapData+0x0"
-;;     region4 = 1744830468 "VMCopyingHeapData+0x4"
+;;     region3 = 872415232 "VMCopyingHeapData+0x0"
+;;     region4 = 872415236 "VMCopyingHeapData+0x4"
 ;;     region5 = 40 "VMContext+0x28"
-;;     region6 = 3355443200 "TypeIdsArray+0x0"
-;;     region7 = 134217760 "VMStoreContext+0x20"
-;;     region8 = 1073741824 "GcHeap"
-;;     region9 = 3087007744 "Stack(ss0)"
+;;     region6 = 1677721600 "TypeIdsArray+0x0"
+;;     region7 = 67108896 "VMStoreContext+0x20"
+;;     region8 = 536870912 "GcHeap"
+;;     region9 = 1543503872 "Stack(ss0)"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/copying/struct-set.wat
+++ b/tests/disas/gc/copying/struct-set.wat
@@ -20,10 +20,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, f32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -46,10 +46,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -72,10 +72,10 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/copying/v128-fields.wat
+++ b/tests/disas/gc/copying/v128-fields.wat
@@ -12,10 +12,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i8x16 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/drc/array-fill.wat
+++ b/tests/disas/gc/drc/array-fill.wat
@@ -11,10 +11,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/drc/array-get-s.wat
+++ b/tests/disas/gc/drc/array-get-s.wat
@@ -11,10 +11,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/drc/array-get-u.wat
+++ b/tests/disas/gc/drc/array-get-u.wat
@@ -11,10 +11,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/drc/array-get.wat
+++ b/tests/disas/gc/drc/array-get.wat
@@ -11,10 +11,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/drc/array-len.wat
+++ b/tests/disas/gc/drc/array-len.wat
@@ -11,10 +11,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
@@ -14,15 +14,15 @@
 ;;     ss1 = explicit_slot 4, align = 4
 ;;     ss2 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 40 "VMContext+0x28"
-;;     region3 = 3355443200 "TypeIdsArray+0x0"
-;;     region4 = 134217760 "VMStoreContext+0x20"
-;;     region5 = 1073741824 "GcHeap"
-;;     region6 = 134217768 "VMStoreContext+0x28"
-;;     region7 = 3087007744 "Stack(ss0)"
-;;     region8 = 3087007745 "Stack(ss1)"
-;;     region9 = 3087007746 "Stack(ss2)"
+;;     region3 = 1677721600 "TypeIdsArray+0x0"
+;;     region4 = 67108896 "VMStoreContext+0x20"
+;;     region5 = 536870912 "GcHeap"
+;;     region6 = 67108904 "VMStoreContext+0x28"
+;;     region7 = 1543503872 "Stack(ss0)"
+;;     region8 = 1543503873 "Stack(ss1)"
+;;     region9 = 1543503874 "Stack(ss2)"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/drc/array-new-fixed.wat
+++ b/tests/disas/gc/drc/array-new-fixed.wat
@@ -11,12 +11,12 @@
 )
 ;; function u0:0(i64 vmctx, i64, i64, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 40 "VMContext+0x28"
-;;     region3 = 3355443200 "TypeIdsArray+0x0"
-;;     region4 = 134217760 "VMStoreContext+0x20"
-;;     region5 = 1073741824 "GcHeap"
-;;     region6 = 134217768 "VMStoreContext+0x28"
+;;     region3 = 1677721600 "TypeIdsArray+0x0"
+;;     region4 = 67108896 "VMStoreContext+0x20"
+;;     region5 = 536870912 "GcHeap"
+;;     region6 = 67108904 "VMStoreContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/drc/array-new.wat
+++ b/tests/disas/gc/drc/array-new.wat
@@ -11,12 +11,12 @@
 )
 ;; function u0:0(i64 vmctx, i64, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 40 "VMContext+0x28"
-;;     region3 = 3355443200 "TypeIdsArray+0x0"
-;;     region4 = 134217760 "VMStoreContext+0x20"
-;;     region5 = 1073741824 "GcHeap"
-;;     region6 = 134217768 "VMStoreContext+0x28"
+;;     region3 = 1677721600 "TypeIdsArray+0x0"
+;;     region4 = 67108896 "VMStoreContext+0x20"
+;;     region5 = 536870912 "GcHeap"
+;;     region6 = 67108904 "VMStoreContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/drc/array-set.wat
+++ b/tests/disas/gc/drc/array-set.wat
@@ -11,10 +11,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/drc/br-on-cast-fail.wat
+++ b/tests/disas/gc/drc/br-on-cast-fail.wat
@@ -18,14 +18,14 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 40 "VMContext+0x28"
-;;     region3 = 3355443200 "TypeIdsArray+0x0"
-;;     region4 = 134217760 "VMStoreContext+0x20"
-;;     region5 = 134217768 "VMStoreContext+0x28"
-;;     region6 = 1073741824 "GcHeap"
-;;     region7 = 2415919128 "VMFunctionImport+0x18"
-;;     region8 = 2415919112 "VMFunctionImport+0x8"
+;;     region3 = 1677721600 "TypeIdsArray+0x0"
+;;     region4 = 67108896 "VMStoreContext+0x20"
+;;     region5 = 67108904 "VMStoreContext+0x28"
+;;     region6 = 536870912 "GcHeap"
+;;     region7 = 1207959576 "VMFunctionImport+0x18"
+;;     region8 = 1207959560 "VMFunctionImport+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/drc/br-on-cast.wat
+++ b/tests/disas/gc/drc/br-on-cast.wat
@@ -18,14 +18,14 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 40 "VMContext+0x28"
-;;     region3 = 3355443200 "TypeIdsArray+0x0"
-;;     region4 = 134217760 "VMStoreContext+0x20"
-;;     region5 = 134217768 "VMStoreContext+0x28"
-;;     region6 = 1073741824 "GcHeap"
-;;     region7 = 2415919128 "VMFunctionImport+0x18"
-;;     region8 = 2415919112 "VMFunctionImport+0x8"
+;;     region3 = 1677721600 "TypeIdsArray+0x0"
+;;     region4 = 67108896 "VMStoreContext+0x20"
+;;     region5 = 67108904 "VMStoreContext+0x28"
+;;     region6 = 536870912 "GcHeap"
+;;     region7 = 1207959576 "VMFunctionImport+0x18"
+;;     region8 = 1207959560 "VMFunctionImport+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/drc/call-indirect-and-subtyping.wat
+++ b/tests/disas/gc/drc/call-indirect-and-subtyping.wat
@@ -18,14 +18,14 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1342177280 "VMTableDefinition+0x0"
-;;     region3 = 671088640 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 671088640 "VMTableDefinition+0x0"
+;;     region3 = 335544320 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     region4 = 40 "VMContext+0x28"
-;;     region5 = 3355443200 "TypeIdsArray+0x0"
-;;     region6 = 3221225488 "VMFuncRef+0x10"
-;;     region7 = 3221225480 "VMFuncRef+0x8"
-;;     region8 = 3221225496 "VMFuncRef+0x18"
+;;     region5 = 1677721600 "TypeIdsArray+0x0"
+;;     region6 = 1610612752 "VMFuncRef+0x10"
+;;     region7 = 1610612744 "VMFuncRef+0x8"
+;;     region8 = 1610612760 "VMFuncRef+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/drc/externref-globals.wat
+++ b/tests/disas/gc/drc/externref-globals.wat
@@ -15,16 +15,16 @@
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 939524096 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
-;;     region3 = 134217760 "VMStoreContext+0x20"
-;;     region4 = 134217768 "VMStoreContext+0x28"
-;;     region5 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 469762048 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
+;;     region3 = 67108896 "VMStoreContext+0x20"
+;;     region4 = 67108904 "VMStoreContext+0x28"
+;;     region5 = 536870912 "GcHeap"
 ;;     region6 = 32 "VMContext+0x20"
-;;     region7 = 1610612736 "VMDrcHeapData+0x0"
-;;     region8 = 1610612740 "VMDrcHeapData+0x4"
-;;     region9 = 1610612744 "VMDrcHeapData+0x8"
-;;     region10 = 3087007744 "Stack(ss0)"
+;;     region7 = 805306368 "VMDrcHeapData+0x0"
+;;     region8 = 805306372 "VMDrcHeapData+0x4"
+;;     region9 = 805306376 "VMDrcHeapData+0x8"
+;;     region10 = 1543503872 "Stack(ss0)"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -100,11 +100,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 939524096 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
-;;     region3 = 134217760 "VMStoreContext+0x20"
-;;     region4 = 134217768 "VMStoreContext+0x28"
-;;     region5 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 469762048 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
+;;     region3 = 67108896 "VMStoreContext+0x20"
+;;     region4 = 67108904 "VMStoreContext+0x28"
+;;     region5 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/drc/funcref-in-gc-heap-get.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-get.wat
@@ -11,10 +11,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/drc/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-new.wat
@@ -12,12 +12,12 @@
 ;; function u0:0(i64 vmctx, i64, i64) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 40 "VMContext+0x28"
-;;     region3 = 3355443200 "TypeIdsArray+0x0"
-;;     region4 = 134217760 "VMStoreContext+0x20"
-;;     region5 = 1073741824 "GcHeap"
-;;     region6 = 3087007744 "Stack(ss0)"
+;;     region3 = 1677721600 "TypeIdsArray+0x0"
+;;     region4 = 67108896 "VMStoreContext+0x20"
+;;     region5 = 536870912 "GcHeap"
+;;     region6 = 1543503872 "Stack(ss0)"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/drc/funcref-in-gc-heap-set.wat
+++ b/tests/disas/gc/drc/funcref-in-gc-heap-set.wat
@@ -11,10 +11,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/drc/i31ref-globals.wat
+++ b/tests/disas/gc/drc/i31ref-globals.wat
@@ -14,8 +14,8 @@
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 939524096 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 469762048 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -33,8 +33,8 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 939524096 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 469762048 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/drc/multiple-array-get.wat
+++ b/tests/disas/gc/drc/multiple-array-get.wat
@@ -12,10 +12,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32) -> i64, i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/drc/multiple-struct-get.wat
+++ b/tests/disas/gc/drc/multiple-struct-get.wat
@@ -13,10 +13,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> f32, i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/drc/ref-cast.wat
+++ b/tests/disas/gc/drc/ref-cast.wat
@@ -10,12 +10,12 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 40 "VMContext+0x28"
-;;     region3 = 3355443200 "TypeIdsArray+0x0"
-;;     region4 = 134217760 "VMStoreContext+0x20"
-;;     region5 = 134217768 "VMStoreContext+0x28"
-;;     region6 = 1073741824 "GcHeap"
+;;     region3 = 1677721600 "TypeIdsArray+0x0"
+;;     region4 = 67108896 "VMStoreContext+0x20"
+;;     region5 = 67108904 "VMStoreContext+0x28"
+;;     region6 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/drc/ref-is-null.wat
+++ b/tests/disas/gc/drc/ref-is-null.wat
@@ -12,7 +12,7 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -30,7 +30,7 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/drc/ref-test-any.wat
+++ b/tests/disas/gc/drc/ref-test-any.wat
@@ -12,7 +12,7 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -30,7 +30,7 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/drc/ref-test-array.wat
+++ b/tests/disas/gc/drc/ref-test-array.wat
@@ -9,10 +9,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/drc/ref-test-concrete-func-type.wat
+++ b/tests/disas/gc/drc/ref-test-concrete-func-type.wat
@@ -10,10 +10,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 40 "VMContext+0x28"
-;;     region3 = 3355443200 "TypeIdsArray+0x0"
-;;     region4 = 3221225488 "VMFuncRef+0x10"
+;;     region3 = 1677721600 "TypeIdsArray+0x0"
+;;     region4 = 1610612752 "VMFuncRef+0x10"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/drc/ref-test-concrete-type.wat
+++ b/tests/disas/gc/drc/ref-test-concrete-type.wat
@@ -10,12 +10,12 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 40 "VMContext+0x28"
-;;     region3 = 3355443200 "TypeIdsArray+0x0"
-;;     region4 = 134217760 "VMStoreContext+0x20"
-;;     region5 = 134217768 "VMStoreContext+0x28"
-;;     region6 = 1073741824 "GcHeap"
+;;     region3 = 1677721600 "TypeIdsArray+0x0"
+;;     region4 = 67108896 "VMStoreContext+0x20"
+;;     region5 = 67108904 "VMStoreContext+0x28"
+;;     region6 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/drc/ref-test-eq.wat
+++ b/tests/disas/gc/drc/ref-test-eq.wat
@@ -9,10 +9,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/drc/ref-test-i31.wat
+++ b/tests/disas/gc/drc/ref-test-i31.wat
@@ -9,7 +9,7 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/drc/ref-test-none.wat
+++ b/tests/disas/gc/drc/ref-test-none.wat
@@ -12,7 +12,7 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -28,7 +28,7 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/drc/ref-test-struct.wat
+++ b/tests/disas/gc/drc/ref-test-struct.wat
@@ -9,10 +9,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/drc/struct-get.wat
+++ b/tests/disas/gc/drc/struct-get.wat
@@ -25,10 +25,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> f32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -51,10 +51,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -78,10 +78,10 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -106,15 +106,15 @@
 ;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     region5 = 32 "VMContext+0x20"
-;;     region6 = 1610612736 "VMDrcHeapData+0x0"
-;;     region7 = 1610612740 "VMDrcHeapData+0x4"
-;;     region8 = 1610612744 "VMDrcHeapData+0x8"
-;;     region9 = 3087007744 "Stack(ss0)"
+;;     region6 = 805306368 "VMDrcHeapData+0x0"
+;;     region7 = 805306372 "VMDrcHeapData+0x4"
+;;     region8 = 805306376 "VMDrcHeapData+0x8"
+;;     region9 = 1543503872 "Stack(ss0)"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/drc/struct-new-default.wat
+++ b/tests/disas/gc/drc/struct-new-default.wat
@@ -13,12 +13,12 @@
 )
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 40 "VMContext+0x28"
-;;     region3 = 3355443200 "TypeIdsArray+0x0"
-;;     region4 = 134217760 "VMStoreContext+0x20"
-;;     region5 = 1073741824 "GcHeap"
-;;     region6 = 134217768 "VMStoreContext+0x28"
+;;     region3 = 1677721600 "TypeIdsArray+0x0"
+;;     region4 = 67108896 "VMStoreContext+0x20"
+;;     region5 = 536870912 "GcHeap"
+;;     region6 = 67108904 "VMStoreContext+0x28"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/drc/struct-new.wat
+++ b/tests/disas/gc/drc/struct-new.wat
@@ -14,13 +14,13 @@
 ;; function u0:0(i64 vmctx, i64, f32, i32, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 40 "VMContext+0x28"
-;;     region3 = 3355443200 "TypeIdsArray+0x0"
-;;     region4 = 134217760 "VMStoreContext+0x20"
-;;     region5 = 1073741824 "GcHeap"
-;;     region6 = 134217768 "VMStoreContext+0x28"
-;;     region7 = 3087007744 "Stack(ss0)"
+;;     region3 = 1677721600 "TypeIdsArray+0x0"
+;;     region4 = 67108896 "VMStoreContext+0x20"
+;;     region5 = 536870912 "GcHeap"
+;;     region6 = 67108904 "VMStoreContext+0x28"
+;;     region7 = 1543503872 "Stack(ss0)"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/drc/struct-set.wat
+++ b/tests/disas/gc/drc/struct-set.wat
@@ -21,10 +21,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, f32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -47,10 +47,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -73,10 +73,10 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/null/array-fill.wat
+++ b/tests/disas/gc/null/array-fill.wat
@@ -11,10 +11,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/null/array-get-s.wat
+++ b/tests/disas/gc/null/array-get-s.wat
@@ -11,10 +11,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/null/array-get-u.wat
+++ b/tests/disas/gc/null/array-get-u.wat
@@ -11,10 +11,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/null/array-get.wat
+++ b/tests/disas/gc/null/array-get.wat
@@ -11,10 +11,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/null/array-len.wat
+++ b/tests/disas/gc/null/array-len.wat
@@ -11,10 +11,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/null/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/null/array-new-fixed-of-gc-refs.wat
@@ -14,17 +14,17 @@
 ;;     ss1 = explicit_slot 4, align = 4
 ;;     ss2 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 1879048192 "VMNullHeapData+0x0"
-;;     region4 = 134217768 "VMStoreContext+0x28"
-;;     region5 = 134217760 "VMStoreContext+0x20"
+;;     region3 = 939524096 "VMNullHeapData+0x0"
+;;     region4 = 67108904 "VMStoreContext+0x28"
+;;     region5 = 67108896 "VMStoreContext+0x20"
 ;;     region6 = 40 "VMContext+0x28"
-;;     region7 = 3355443200 "TypeIdsArray+0x0"
-;;     region8 = 1073741824 "GcHeap"
-;;     region9 = 3087007744 "Stack(ss0)"
-;;     region10 = 3087007745 "Stack(ss1)"
-;;     region11 = 3087007746 "Stack(ss2)"
+;;     region7 = 1677721600 "TypeIdsArray+0x0"
+;;     region8 = 536870912 "GcHeap"
+;;     region9 = 1543503872 "Stack(ss0)"
+;;     region10 = 1543503873 "Stack(ss1)"
+;;     region11 = 1543503874 "Stack(ss2)"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/null/array-new-fixed.wat
+++ b/tests/disas/gc/null/array-new-fixed.wat
@@ -11,14 +11,14 @@
 )
 ;; function u0:0(i64 vmctx, i64, i64, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 1879048192 "VMNullHeapData+0x0"
-;;     region4 = 134217768 "VMStoreContext+0x28"
-;;     region5 = 134217760 "VMStoreContext+0x20"
+;;     region3 = 939524096 "VMNullHeapData+0x0"
+;;     region4 = 67108904 "VMStoreContext+0x28"
+;;     region5 = 67108896 "VMStoreContext+0x20"
 ;;     region6 = 40 "VMContext+0x28"
-;;     region7 = 3355443200 "TypeIdsArray+0x0"
-;;     region8 = 1073741824 "GcHeap"
+;;     region7 = 1677721600 "TypeIdsArray+0x0"
+;;     region8 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/null/array-new.wat
+++ b/tests/disas/gc/null/array-new.wat
@@ -11,14 +11,14 @@
 )
 ;; function u0:0(i64 vmctx, i64, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 1879048192 "VMNullHeapData+0x0"
-;;     region4 = 134217768 "VMStoreContext+0x28"
-;;     region5 = 134217760 "VMStoreContext+0x20"
+;;     region3 = 939524096 "VMNullHeapData+0x0"
+;;     region4 = 67108904 "VMStoreContext+0x28"
+;;     region5 = 67108896 "VMStoreContext+0x20"
 ;;     region6 = 40 "VMContext+0x28"
-;;     region7 = 3355443200 "TypeIdsArray+0x0"
-;;     region8 = 1073741824 "GcHeap"
+;;     region7 = 1677721600 "TypeIdsArray+0x0"
+;;     region8 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/null/array-set.wat
+++ b/tests/disas/gc/null/array-set.wat
@@ -11,10 +11,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/null/br-on-cast-fail.wat
+++ b/tests/disas/gc/null/br-on-cast-fail.wat
@@ -18,14 +18,14 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 40 "VMContext+0x28"
-;;     region3 = 3355443200 "TypeIdsArray+0x0"
-;;     region4 = 134217760 "VMStoreContext+0x20"
-;;     region5 = 134217768 "VMStoreContext+0x28"
-;;     region6 = 1073741824 "GcHeap"
-;;     region7 = 2415919128 "VMFunctionImport+0x18"
-;;     region8 = 2415919112 "VMFunctionImport+0x8"
+;;     region3 = 1677721600 "TypeIdsArray+0x0"
+;;     region4 = 67108896 "VMStoreContext+0x20"
+;;     region5 = 67108904 "VMStoreContext+0x28"
+;;     region6 = 536870912 "GcHeap"
+;;     region7 = 1207959576 "VMFunctionImport+0x18"
+;;     region8 = 1207959560 "VMFunctionImport+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/null/br-on-cast.wat
+++ b/tests/disas/gc/null/br-on-cast.wat
@@ -18,14 +18,14 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 40 "VMContext+0x28"
-;;     region3 = 3355443200 "TypeIdsArray+0x0"
-;;     region4 = 134217760 "VMStoreContext+0x20"
-;;     region5 = 134217768 "VMStoreContext+0x28"
-;;     region6 = 1073741824 "GcHeap"
-;;     region7 = 2415919128 "VMFunctionImport+0x18"
-;;     region8 = 2415919112 "VMFunctionImport+0x8"
+;;     region3 = 1677721600 "TypeIdsArray+0x0"
+;;     region4 = 67108896 "VMStoreContext+0x20"
+;;     region5 = 67108904 "VMStoreContext+0x28"
+;;     region6 = 536870912 "GcHeap"
+;;     region7 = 1207959576 "VMFunctionImport+0x18"
+;;     region8 = 1207959560 "VMFunctionImport+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/null/call-indirect-and-subtyping.wat
+++ b/tests/disas/gc/null/call-indirect-and-subtyping.wat
@@ -18,14 +18,14 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1342177280 "VMTableDefinition+0x0"
-;;     region3 = 671088640 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 671088640 "VMTableDefinition+0x0"
+;;     region3 = 335544320 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     region4 = 40 "VMContext+0x28"
-;;     region5 = 3355443200 "TypeIdsArray+0x0"
-;;     region6 = 3221225488 "VMFuncRef+0x10"
-;;     region7 = 3221225480 "VMFuncRef+0x8"
-;;     region8 = 3221225496 "VMFuncRef+0x18"
+;;     region5 = 1677721600 "TypeIdsArray+0x0"
+;;     region6 = 1610612752 "VMFuncRef+0x10"
+;;     region7 = 1610612744 "VMFuncRef+0x8"
+;;     region8 = 1610612760 "VMFuncRef+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/null/externref-globals.wat
+++ b/tests/disas/gc/null/externref-globals.wat
@@ -14,8 +14,8 @@
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 939524096 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 469762048 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -33,8 +33,8 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 939524096 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 469762048 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/null/funcref-in-gc-heap-get.wat
+++ b/tests/disas/gc/null/funcref-in-gc-heap-get.wat
@@ -11,10 +11,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/null/funcref-in-gc-heap-new.wat
+++ b/tests/disas/gc/null/funcref-in-gc-heap-new.wat
@@ -11,14 +11,14 @@
 )
 ;; function u0:0(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 1879048192 "VMNullHeapData+0x0"
-;;     region4 = 134217768 "VMStoreContext+0x28"
-;;     region5 = 134217760 "VMStoreContext+0x20"
+;;     region3 = 939524096 "VMNullHeapData+0x0"
+;;     region4 = 67108904 "VMStoreContext+0x28"
+;;     region5 = 67108896 "VMStoreContext+0x20"
 ;;     region6 = 40 "VMContext+0x28"
-;;     region7 = 3355443200 "TypeIdsArray+0x0"
-;;     region8 = 1073741824 "GcHeap"
+;;     region7 = 1677721600 "TypeIdsArray+0x0"
+;;     region8 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/null/funcref-in-gc-heap-set.wat
+++ b/tests/disas/gc/null/funcref-in-gc-heap-set.wat
@@ -11,10 +11,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/null/i31ref-globals.wat
+++ b/tests/disas/gc/null/i31ref-globals.wat
@@ -14,8 +14,8 @@
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 939524096 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 469762048 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -33,8 +33,8 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 939524096 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 469762048 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/null/multiple-array-get.wat
+++ b/tests/disas/gc/null/multiple-array-get.wat
@@ -12,10 +12,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32) -> i64, i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/null/multiple-struct-get.wat
+++ b/tests/disas/gc/null/multiple-struct-get.wat
@@ -13,10 +13,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> f32, i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/null/ref-cast.wat
+++ b/tests/disas/gc/null/ref-cast.wat
@@ -10,12 +10,12 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 40 "VMContext+0x28"
-;;     region3 = 3355443200 "TypeIdsArray+0x0"
-;;     region4 = 134217760 "VMStoreContext+0x20"
-;;     region5 = 134217768 "VMStoreContext+0x28"
-;;     region6 = 1073741824 "GcHeap"
+;;     region3 = 1677721600 "TypeIdsArray+0x0"
+;;     region4 = 67108896 "VMStoreContext+0x20"
+;;     region5 = 67108904 "VMStoreContext+0x28"
+;;     region6 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/null/ref-is-null.wat
+++ b/tests/disas/gc/null/ref-is-null.wat
@@ -12,7 +12,7 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -30,7 +30,7 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/null/ref-test-any.wat
+++ b/tests/disas/gc/null/ref-test-any.wat
@@ -12,7 +12,7 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -30,7 +30,7 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/null/ref-test-array.wat
+++ b/tests/disas/gc/null/ref-test-array.wat
@@ -9,10 +9,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/null/ref-test-concrete-func-type.wat
+++ b/tests/disas/gc/null/ref-test-concrete-func-type.wat
@@ -10,10 +10,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 40 "VMContext+0x28"
-;;     region3 = 3355443200 "TypeIdsArray+0x0"
-;;     region4 = 3221225488 "VMFuncRef+0x10"
+;;     region3 = 1677721600 "TypeIdsArray+0x0"
+;;     region4 = 1610612752 "VMFuncRef+0x10"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/null/ref-test-concrete-type.wat
+++ b/tests/disas/gc/null/ref-test-concrete-type.wat
@@ -10,12 +10,12 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 40 "VMContext+0x28"
-;;     region3 = 3355443200 "TypeIdsArray+0x0"
-;;     region4 = 134217760 "VMStoreContext+0x20"
-;;     region5 = 134217768 "VMStoreContext+0x28"
-;;     region6 = 1073741824 "GcHeap"
+;;     region3 = 1677721600 "TypeIdsArray+0x0"
+;;     region4 = 67108896 "VMStoreContext+0x20"
+;;     region5 = 67108904 "VMStoreContext+0x28"
+;;     region6 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/null/ref-test-eq.wat
+++ b/tests/disas/gc/null/ref-test-eq.wat
@@ -9,10 +9,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/null/ref-test-i31.wat
+++ b/tests/disas/gc/null/ref-test-i31.wat
@@ -9,7 +9,7 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/null/ref-test-none.wat
+++ b/tests/disas/gc/null/ref-test-none.wat
@@ -12,7 +12,7 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -28,7 +28,7 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/null/ref-test-struct.wat
+++ b/tests/disas/gc/null/ref-test-struct.wat
@@ -9,10 +9,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/null/struct-get-guard-pages.wat
+++ b/tests/disas/gc/null/struct-get-guard-pages.wat
@@ -25,10 +25,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> f32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -51,10 +51,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -78,10 +78,10 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -105,10 +105,10 @@
 ;;
 ;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/null/struct-get-no-guard-pages.wat
+++ b/tests/disas/gc/null/struct-get-no-guard-pages.wat
@@ -25,10 +25,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> f32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -57,10 +57,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -90,10 +90,10 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -123,10 +123,10 @@
 ;;
 ;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/null/struct-get.wat
+++ b/tests/disas/gc/null/struct-get.wat
@@ -25,10 +25,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> f32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -51,10 +51,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -78,10 +78,10 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -105,10 +105,10 @@
 ;;
 ;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/null/struct-new-default.wat
+++ b/tests/disas/gc/null/struct-new-default.wat
@@ -13,14 +13,14 @@
 )
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 1879048192 "VMNullHeapData+0x0"
-;;     region4 = 134217768 "VMStoreContext+0x28"
-;;     region5 = 134217760 "VMStoreContext+0x20"
+;;     region3 = 939524096 "VMNullHeapData+0x0"
+;;     region4 = 67108904 "VMStoreContext+0x28"
+;;     region5 = 67108896 "VMStoreContext+0x20"
 ;;     region6 = 40 "VMContext+0x28"
-;;     region7 = 3355443200 "TypeIdsArray+0x0"
-;;     region8 = 1073741824 "GcHeap"
+;;     region7 = 1677721600 "TypeIdsArray+0x0"
+;;     region8 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/null/struct-new.wat
+++ b/tests/disas/gc/null/struct-new.wat
@@ -14,15 +14,15 @@
 ;; function u0:0(i64 vmctx, i64, f32, i32, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 1879048192 "VMNullHeapData+0x0"
-;;     region4 = 134217768 "VMStoreContext+0x28"
-;;     region5 = 134217760 "VMStoreContext+0x20"
+;;     region3 = 939524096 "VMNullHeapData+0x0"
+;;     region4 = 67108904 "VMStoreContext+0x28"
+;;     region5 = 67108896 "VMStoreContext+0x20"
 ;;     region6 = 40 "VMContext+0x28"
-;;     region7 = 3355443200 "TypeIdsArray+0x0"
-;;     region8 = 1073741824 "GcHeap"
-;;     region9 = 3087007744 "Stack(ss0)"
+;;     region7 = 1677721600 "TypeIdsArray+0x0"
+;;     region8 = 536870912 "GcHeap"
+;;     region9 = 1543503872 "Stack(ss0)"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/null/struct-set.wat
+++ b/tests/disas/gc/null/struct-set.wat
@@ -21,10 +21,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, f32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -47,10 +47,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -73,10 +73,10 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/null/v128-fields.wat
+++ b/tests/disas/gc/null/v128-fields.wat
@@ -13,10 +13,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i8x16 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217760 "VMStoreContext+0x20"
-;;     region3 = 134217768 "VMStoreContext+0x28"
-;;     region4 = 1073741824 "GcHeap"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108896 "VMStoreContext+0x20"
+;;     region3 = 67108904 "VMStoreContext+0x28"
+;;     region4 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/ref-test-cast-final-type.wat
+++ b/tests/disas/gc/ref-test-cast-final-type.wat
@@ -16,12 +16,12 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 40 "VMContext+0x28"
-;;     region3 = 3355443200 "TypeIdsArray+0x0"
-;;     region4 = 134217760 "VMStoreContext+0x20"
-;;     region5 = 134217768 "VMStoreContext+0x28"
-;;     region6 = 1073741824 "GcHeap"
+;;     region3 = 1677721600 "TypeIdsArray+0x0"
+;;     region4 = 67108896 "VMStoreContext+0x20"
+;;     region5 = 67108904 "VMStoreContext+0x28"
+;;     region6 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -61,12 +61,12 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 40 "VMContext+0x28"
-;;     region3 = 3355443200 "TypeIdsArray+0x0"
-;;     region4 = 134217760 "VMStoreContext+0x20"
-;;     region5 = 134217768 "VMStoreContext+0x28"
-;;     region6 = 1073741824 "GcHeap"
+;;     region3 = 1677721600 "TypeIdsArray+0x0"
+;;     region4 = 67108896 "VMStoreContext+0x20"
+;;     region5 = 67108904 "VMStoreContext+0x28"
+;;     region6 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/struct-new-default.wat
+++ b/tests/disas/gc/struct-new-default.wat
@@ -14,14 +14,14 @@
 )
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 1744830464 "VMCopyingHeapData+0x0"
-;;     region4 = 1744830468 "VMCopyingHeapData+0x4"
+;;     region3 = 872415232 "VMCopyingHeapData+0x0"
+;;     region4 = 872415236 "VMCopyingHeapData+0x4"
 ;;     region5 = 40 "VMContext+0x28"
-;;     region6 = 3355443200 "TypeIdsArray+0x0"
-;;     region7 = 134217760 "VMStoreContext+0x20"
-;;     region8 = 1073741824 "GcHeap"
+;;     region6 = 1677721600 "TypeIdsArray+0x0"
+;;     region7 = 67108896 "VMStoreContext+0x20"
+;;     region8 = 536870912 "GcHeap"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/struct-new.wat
+++ b/tests/disas/gc/struct-new.wat
@@ -14,15 +14,15 @@
 ;; function u0:0(i64 vmctx, i64, f32, i32, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 32 "VMContext+0x20"
-;;     region3 = 1744830464 "VMCopyingHeapData+0x0"
-;;     region4 = 1744830468 "VMCopyingHeapData+0x4"
+;;     region3 = 872415232 "VMCopyingHeapData+0x0"
+;;     region4 = 872415236 "VMCopyingHeapData+0x4"
 ;;     region5 = 40 "VMContext+0x28"
-;;     region6 = 3355443200 "TypeIdsArray+0x0"
-;;     region7 = 134217760 "VMStoreContext+0x20"
-;;     region8 = 1073741824 "GcHeap"
-;;     region9 = 3087007744 "Stack(ss0)"
+;;     region6 = 1677721600 "TypeIdsArray+0x0"
+;;     region7 = 67108896 "VMStoreContext+0x20"
+;;     region8 = 536870912 "GcHeap"
+;;     region9 = 1543503872 "Stack(ss0)"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/gc/typed-select-and-stack-maps.wat
+++ b/tests/disas/gc/typed-select-and-stack-maps.wat
@@ -42,10 +42,10 @@
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     ss0 = explicit_slot 4, align = 4
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 2415919128 "VMFunctionImport+0x18"
-;;     region3 = 2415919112 "VMFunctionImport+0x8"
-;;     region4 = 3087007744 "Stack(ss0)"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 1207959576 "VMFunctionImport+0x18"
+;;     region3 = 1207959560 "VMFunctionImport+0x8"
+;;     region4 = 1543503872 "Stack(ss0)"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -72,9 +72,9 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 2415919128 "VMFunctionImport+0x18"
-;;     region3 = 2415919112 "VMFunctionImport+0x8"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 1207959576 "VMFunctionImport+0x18"
+;;     region3 = 1207959560 "VMFunctionImport+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/global-get.wat
+++ b/tests/disas/global-get.wat
@@ -32,9 +32,9 @@
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 2952790016 "VMGlobalImport+0x0"
-;;     region3 = 805306368 "PublicGlobal"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 1476395008 "VMGlobalImport+0x0"
+;;     region3 = 402653184 "PublicGlobal"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -51,9 +51,9 @@
 ;;
 ;; function u0:1(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 2952790016 "VMGlobalImport+0x0"
-;;     region3 = 805306368 "PublicGlobal"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 1476395008 "VMGlobalImport+0x0"
+;;     region3 = 402653184 "PublicGlobal"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -70,7 +70,7 @@
 ;;
 ;; function u0:2(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -86,8 +86,8 @@
 ;;
 ;; function u0:3(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 939524097 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(1))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 469762049 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(1))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/globals.wat
+++ b/tests/disas/globals.wat
@@ -11,11 +11,11 @@
 
 ;; function u0:0(i64 vmctx, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 939524096 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
-;;     region3 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region4 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region5 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 469762048 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
+;;     region3 = 603979776 "VMMemoryDefinition+0x0"
+;;     region4 = 603979784 "VMMemoryDefinition+0x8"
+;;     region5 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/guest-debugging.wat
+++ b/tests/disas/guest-debugging.wat
@@ -21,8 +21,8 @@
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     ss0 = explicit_slot 28, key = 0
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 3087007744 "Stack(ss0)"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 1543503872 "Stack(ss0)"
 ;;     sig0 = (i64 vmctx, i8) tail
 ;;     sig1 = (i64 vmctx) tail
 ;;     sig2 = (i64) preserve_all

--- a/tests/disas/i128-cmp.wat
+++ b/tests/disas/i128-cmp.wat
@@ -101,7 +101,7 @@
 )
 ;; function u0:0(i64 vmctx, i64, i64, i64, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -120,7 +120,7 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64, i64, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -139,7 +139,7 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i64, i64, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -158,7 +158,7 @@
 ;;
 ;; function u0:3(i64 vmctx, i64, i64, i64, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -177,7 +177,7 @@
 ;;
 ;; function u0:4(i64 vmctx, i64, i64, i64, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -196,7 +196,7 @@
 ;;
 ;; function u0:5(i64 vmctx, i64, i64, i64, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -215,7 +215,7 @@
 ;;
 ;; function u0:6(i64 vmctx, i64, i64, i64, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -234,7 +234,7 @@
 ;;
 ;; function u0:7(i64 vmctx, i64, i64, i64, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/i32-load.wat
+++ b/tests/disas/i32-load.wat
@@ -10,10 +10,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/i32-load16-s.wat
+++ b/tests/disas/i32-load16-s.wat
@@ -10,10 +10,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/i32-load16-u.wat
+++ b/tests/disas/i32-load16-u.wat
@@ -10,10 +10,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/i32-load8-s.wat
+++ b/tests/disas/i32-load8-s.wat
@@ -10,10 +10,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/i32-load8-u.wat
+++ b/tests/disas/i32-load8-u.wat
@@ -10,10 +10,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/i32-store.wat
+++ b/tests/disas/i32-store.wat
@@ -11,10 +11,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/i32-store16.wat
+++ b/tests/disas/i32-store16.wat
@@ -11,10 +11,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/i32-store8.wat
+++ b/tests/disas/i32-store8.wat
@@ -11,10 +11,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/i64-load.wat
+++ b/tests/disas/i64-load.wat
@@ -10,10 +10,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/i64-load16-s.wat
+++ b/tests/disas/i64-load16-s.wat
@@ -10,10 +10,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/i64-load16-u.wat
+++ b/tests/disas/i64-load16-u.wat
@@ -10,10 +10,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/i64-load8-s.wat
+++ b/tests/disas/i64-load8-s.wat
@@ -10,10 +10,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/i64-load8-u.wat
+++ b/tests/disas/i64-load8-u.wat
@@ -10,10 +10,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/i64-store.wat
+++ b/tests/disas/i64-store.wat
@@ -11,10 +11,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/i64-store16.wat
+++ b/tests/disas/i64-store16.wat
@@ -11,10 +11,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/i64-store32.wat
+++ b/tests/disas/i64-store32.wat
@@ -11,10 +11,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/i64-store8.wat
+++ b/tests/disas/i64-store8.wat
@@ -11,10 +11,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/icall-loop.wat
+++ b/tests/disas/icall-loop.wat
@@ -24,14 +24,14 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1342177280 "VMTableDefinition+0x0"
-;;     region3 = 671088640 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 671088640 "VMTableDefinition+0x0"
+;;     region3 = 335544320 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     region4 = 40 "VMContext+0x28"
-;;     region5 = 3355443200 "TypeIdsArray+0x0"
-;;     region6 = 3221225488 "VMFuncRef+0x10"
-;;     region7 = 3221225480 "VMFuncRef+0x8"
-;;     region8 = 3221225496 "VMFuncRef+0x18"
+;;     region5 = 1677721600 "TypeIdsArray+0x0"
+;;     region6 = 1610612752 "VMFuncRef+0x10"
+;;     region7 = 1610612744 "VMFuncRef+0x8"
+;;     region8 = 1610612760 "VMFuncRef+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -79,14 +79,14 @@
 ;;
 ;; function u0:1(i64 vmctx, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1342177280 "VMTableDefinition+0x0"
-;;     region3 = 671088640 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 671088640 "VMTableDefinition+0x0"
+;;     region3 = 335544320 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     region4 = 40 "VMContext+0x28"
-;;     region5 = 3355443200 "TypeIdsArray+0x0"
-;;     region6 = 3221225488 "VMFuncRef+0x10"
-;;     region7 = 3221225480 "VMFuncRef+0x8"
-;;     region8 = 3221225496 "VMFuncRef+0x18"
+;;     region5 = 1677721600 "TypeIdsArray+0x0"
+;;     region6 = 1610612752 "VMFuncRef+0x10"
+;;     region7 = 1610612744 "VMFuncRef+0x8"
+;;     region8 = 1610612760 "VMFuncRef+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/icall-simd.wat
+++ b/tests/disas/icall-simd.wat
@@ -10,14 +10,14 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i8x16) -> i8x16 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1342177280 "VMTableDefinition+0x0"
-;;     region3 = 671088640 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 671088640 "VMTableDefinition+0x0"
+;;     region3 = 335544320 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     region4 = 40 "VMContext+0x28"
-;;     region5 = 3355443200 "TypeIdsArray+0x0"
-;;     region6 = 3221225488 "VMFuncRef+0x10"
-;;     region7 = 3221225480 "VMFuncRef+0x8"
-;;     region8 = 3221225496 "VMFuncRef+0x18"
+;;     region5 = 1677721600 "TypeIdsArray+0x0"
+;;     region6 = 1610612752 "VMFuncRef+0x10"
+;;     region7 = 1610612744 "VMFuncRef+0x8"
+;;     region8 = 1610612760 "VMFuncRef+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/icall.wat
+++ b/tests/disas/icall.wat
@@ -10,14 +10,14 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, f32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1342177280 "VMTableDefinition+0x0"
-;;     region3 = 671088640 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 671088640 "VMTableDefinition+0x0"
+;;     region3 = 335544320 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     region4 = 40 "VMContext+0x28"
-;;     region5 = 3355443200 "TypeIdsArray+0x0"
-;;     region6 = 3221225488 "VMFuncRef+0x10"
-;;     region7 = 3221225480 "VMFuncRef+0x8"
-;;     region8 = 3221225496 "VMFuncRef+0x18"
+;;     region5 = 1677721600 "TypeIdsArray+0x0"
+;;     region6 = 1610612752 "VMFuncRef+0x10"
+;;     region7 = 1610612744 "VMFuncRef+0x8"
+;;     region8 = 1610612760 "VMFuncRef+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/idempotent-store.wat
+++ b/tests/disas/idempotent-store.wat
@@ -16,10 +16,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/if-reachability-translation-0.wat
+++ b/tests/disas/if-reachability-translation-0.wat
@@ -15,7 +15,7 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/if-reachability-translation-1.wat
+++ b/tests/disas/if-reachability-translation-1.wat
@@ -15,7 +15,7 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/if-reachability-translation-2.wat
+++ b/tests/disas/if-reachability-translation-2.wat
@@ -15,7 +15,7 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/if-reachability-translation-3.wat
+++ b/tests/disas/if-reachability-translation-3.wat
@@ -15,7 +15,7 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/if-reachability-translation-4.wat
+++ b/tests/disas/if-reachability-translation-4.wat
@@ -15,7 +15,7 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/if-reachability-translation-5.wat
+++ b/tests/disas/if-reachability-translation-5.wat
@@ -17,7 +17,7 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/if-reachability-translation-6.wat
+++ b/tests/disas/if-reachability-translation-6.wat
@@ -17,7 +17,7 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/if-unreachable-else-params-2.wat
+++ b/tests/disas/if-unreachable-else-params-2.wat
@@ -21,10 +21,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> f64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 268435456 "PublicMemory"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 134217728 "PublicMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/if-unreachable-else-params.wat
+++ b/tests/disas/if-unreachable-else-params.wat
@@ -44,10 +44,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 268435456 "PublicMemory"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 134217728 "PublicMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/indirect-call-no-caching.wat
+++ b/tests/disas/indirect-call-no-caching.wat
@@ -22,7 +22,7 @@
  (elem (i32.const 1) func $f1 $f2 $f3))
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -38,7 +38,7 @@
 ;;
 ;; function u0:1(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -54,7 +54,7 @@
 ;;
 ;; function u0:2(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -70,14 +70,14 @@
 ;;
 ;; function u0:3(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1342177280 "VMTableDefinition+0x0"
-;;     region3 = 671088640 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 671088640 "VMTableDefinition+0x0"
+;;     region3 = 335544320 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     region4 = 40 "VMContext+0x28"
-;;     region5 = 3355443200 "TypeIdsArray+0x0"
-;;     region6 = 3221225488 "VMFuncRef+0x10"
-;;     region7 = 3221225480 "VMFuncRef+0x8"
-;;     region8 = 3221225496 "VMFuncRef+0x18"
+;;     region5 = 1677721600 "TypeIdsArray+0x0"
+;;     region6 = 1610612752 "VMFuncRef+0x10"
+;;     region7 = 1610612744 "VMFuncRef+0x8"
+;;     region8 = 1610612760 "VMFuncRef+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/intra-module-inlining.wat
+++ b/tests/disas/intra-module-inlining.wat
@@ -11,7 +11,7 @@
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -27,7 +27,7 @@
 ;;
 ;; function u0:1(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/issue-10929-v128-icmp-egraphs.wat
+++ b/tests/disas/issue-10929-v128-icmp-egraphs.wat
@@ -12,7 +12,7 @@
 )
 ;; function u0:0(i64 vmctx, i64, i8x16) -> i8x16 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/issue-5696.wat
+++ b/tests/disas/issue-5696.wat
@@ -11,7 +11,7 @@
 )
 ;; function u0:0(i64 vmctx, i64, i64) -> i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -47,10 +47,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -49,10 +49,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -49,10 +49,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -45,10 +45,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -49,10 +49,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -49,10 +49,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -48,10 +48,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -50,10 +50,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -50,10 +50,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -46,10 +46,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -50,10 +50,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -50,10 +50,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -45,10 +45,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -47,10 +47,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -47,10 +47,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -45,10 +45,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -47,10 +47,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -47,10 +47,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -46,10 +46,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -48,10 +48,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -48,10 +48,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -46,10 +46,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -48,10 +48,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -48,10 +48,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -46,10 +46,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -48,10 +48,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -48,10 +48,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -44,10 +44,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -48,10 +48,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -48,10 +48,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -47,10 +47,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -49,10 +49,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -49,10 +49,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -45,10 +45,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -49,10 +49,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -49,10 +49,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -44,10 +44,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -46,10 +46,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -46,10 +46,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -44,10 +44,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -46,10 +46,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -46,10 +46,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -45,10 +45,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -47,10 +47,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -47,10 +47,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -45,10 +45,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -47,10 +47,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -47,10 +47,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -45,10 +45,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -47,10 +47,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -47,10 +47,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -42,10 +42,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -47,10 +47,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -47,10 +47,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -46,10 +46,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -48,10 +48,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -48,10 +48,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -42,10 +42,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -48,10 +48,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -48,10 +48,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -42,10 +42,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -44,10 +44,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -44,10 +44,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -42,10 +42,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -44,10 +44,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -44,10 +44,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -42,10 +42,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -44,10 +44,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -44,10 +44,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -42,10 +42,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -44,10 +44,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -44,10 +44,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -44,10 +44,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -46,10 +46,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -46,10 +46,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -44,10 +44,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -46,10 +46,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -46,10 +46,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -45,10 +45,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -47,10 +47,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -47,10 +47,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -45,10 +45,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -47,10 +47,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -47,10 +47,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -44,10 +44,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -46,10 +46,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -46,10 +46,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -44,10 +44,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -46,10 +46,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -46,10 +46,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -45,10 +45,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -47,10 +47,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -47,10 +47,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -45,10 +45,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -47,10 +47,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -20,10 +20,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -47,10 +47,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/memory-copy-epochs.wat
+++ b/tests/disas/memory-copy-epochs.wat
@@ -10,12 +10,12 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 24 "VMContext+0x18"
-;;     region3 = 3489660928 "EpochCounter+0x0"
-;;     region4 = 134217736 "VMStoreContext+0x8"
-;;     region5 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region6 = 1207959560 "VMMemoryDefinition+0x8"
+;;     region3 = 1744830464 "EpochCounter+0x0"
+;;     region4 = 67108872 "VMStoreContext+0x8"
+;;     region5 = 603979776 "VMMemoryDefinition+0x0"
+;;     region6 = 603979784 "VMMemoryDefinition+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/memory-copy-fuel.wat
+++ b/tests/disas/memory-copy-fuel.wat
@@ -10,10 +10,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217728 "VMStoreContext+0x0"
-;;     region3 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region4 = 1207959560 "VMMemoryDefinition+0x8"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108864 "VMStoreContext+0x0"
+;;     region3 = 603979776 "VMMemoryDefinition+0x0"
+;;     region4 = 603979784 "VMMemoryDefinition+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/memory-copy-inline.wat
+++ b/tests/disas/memory-copy-inline.wat
@@ -13,10 +13,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/memory-min-max-same.wat
+++ b/tests/disas/memory-min-max-same.wat
@@ -35,12 +35,12 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 2415919128 "VMFunctionImport+0x18"
-;;     region3 = 2415919112 "VMFunctionImport+0x8"
-;;     region4 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region5 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region6 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 1207959576 "VMFunctionImport+0x18"
+;;     region3 = 1207959560 "VMFunctionImport+0x8"
+;;     region4 = 603979776 "VMMemoryDefinition+0x0"
+;;     region5 = 603979784 "VMMemoryDefinition+0x8"
+;;     region6 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/memory.wat
+++ b/tests/disas/memory.wat
@@ -14,10 +14,10 @@
 
 ;; function u0:0(i64 vmctx, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/memory_copy_host32.wat
+++ b/tests/disas/memory_copy_host32.wat
@@ -50,8 +50,8 @@
   )
 )
 ;; function u0:0(i32 vmctx, i32, i32, i32, i32) tail {
-;;     region0 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region1 = 1207959556 "VMMemoryDefinition+0x4"
+;;     region0 = 603979776 "VMMemoryDefinition+0x0"
+;;     region1 = 603979780 "VMMemoryDefinition+0x4"
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;
@@ -78,8 +78,8 @@
 ;; }
 ;;
 ;; function u0:1(i32 vmctx, i32, i32, i32, i32) tail {
-;;     region0 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region1 = 1207959556 "VMMemoryDefinition+0x4"
+;;     region0 = 603979776 "VMMemoryDefinition+0x0"
+;;     region1 = 603979780 "VMMemoryDefinition+0x4"
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;
@@ -109,8 +109,8 @@
 ;; }
 ;;
 ;; function u0:2(i32 vmctx, i32, i64, i32, i32) tail {
-;;     region0 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region1 = 1207959556 "VMMemoryDefinition+0x4"
+;;     region0 = 603979776 "VMMemoryDefinition+0x0"
+;;     region1 = 603979780 "VMMemoryDefinition+0x4"
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;
@@ -140,8 +140,8 @@
 ;; }
 ;;
 ;; function u0:3(i32 vmctx, i32, i64, i64, i64) tail {
-;;     region0 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region1 = 1207959556 "VMMemoryDefinition+0x4"
+;;     region0 = 603979776 "VMMemoryDefinition+0x0"
+;;     region1 = 603979780 "VMMemoryDefinition+0x4"
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;
@@ -168,8 +168,8 @@
 ;; }
 ;;
 ;; function u0:4(i32 vmctx, i32, i64, i64, i64) tail {
-;;     region0 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region1 = 1207959556 "VMMemoryDefinition+0x4"
+;;     region0 = 603979776 "VMMemoryDefinition+0x0"
+;;     region1 = 603979780 "VMMemoryDefinition+0x4"
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;
@@ -199,8 +199,8 @@
 ;; }
 ;;
 ;; function u0:5(i32 vmctx, i32, i32, i64, i32) tail {
-;;     region0 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region1 = 1207959556 "VMMemoryDefinition+0x4"
+;;     region0 = 603979776 "VMMemoryDefinition+0x0"
+;;     region1 = 603979780 "VMMemoryDefinition+0x4"
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;

--- a/tests/disas/memory_copy_host64.wat
+++ b/tests/disas/memory_copy_host64.wat
@@ -51,9 +51,9 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -84,9 +84,9 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -119,9 +119,9 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -153,9 +153,9 @@
 ;;
 ;; function u0:3(i64 vmctx, i64, i64, i64, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -183,9 +183,9 @@
 ;;
 ;; function u0:4(i64 vmctx, i64, i64, i64, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -215,9 +215,9 @@
 ;;
 ;; function u0:5(i64 vmctx, i64, i32, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/memory_fill_host32.wat
+++ b/tests/disas/memory_fill_host32.wat
@@ -47,8 +47,8 @@
   )
 )
 ;; function u0:0(i32 vmctx, i32, i32, i32) tail {
-;;     region0 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region1 = 1207959556 "VMMemoryDefinition+0x4"
+;;     region0 = 603979776 "VMMemoryDefinition+0x0"
+;;     region1 = 603979780 "VMMemoryDefinition+0x4"
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;
@@ -71,8 +71,8 @@
 ;; }
 ;;
 ;; function u0:1(i32 vmctx, i32, i64, i64) tail {
-;;     region0 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region1 = 1207959556 "VMMemoryDefinition+0x4"
+;;     region0 = 603979776 "VMMemoryDefinition+0x0"
+;;     region1 = 603979780 "VMMemoryDefinition+0x4"
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;
@@ -95,8 +95,8 @@
 ;; }
 ;;
 ;; function u0:2(i32 vmctx, i32, i32, i32) tail {
-;;     region0 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region1 = 1207959556 "VMMemoryDefinition+0x4"
+;;     region0 = 603979776 "VMMemoryDefinition+0x0"
+;;     region1 = 603979780 "VMMemoryDefinition+0x4"
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;
@@ -119,8 +119,8 @@
 ;; }
 ;;
 ;; function u0:3(i32 vmctx, i32, i64, i64) tail {
-;;     region0 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region1 = 1207959556 "VMMemoryDefinition+0x4"
+;;     region0 = 603979776 "VMMemoryDefinition+0x0"
+;;     region1 = 603979780 "VMMemoryDefinition+0x4"
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;
@@ -143,8 +143,8 @@
 ;; }
 ;;
 ;; function u0:4(i32 vmctx, i32, i32, i32) tail {
-;;     region0 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region1 = 1207959556 "VMMemoryDefinition+0x4"
+;;     region0 = 603979776 "VMMemoryDefinition+0x0"
+;;     region1 = 603979780 "VMMemoryDefinition+0x4"
 ;;     sig0 = (i32 vmctx, i32, i32, i32) tail
 ;;     fn0 = colocated u805306368:2 sig0
 ;;

--- a/tests/disas/memory_fill_host64.wat
+++ b/tests/disas/memory_fill_host64.wat
@@ -45,9 +45,9 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -74,9 +74,9 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i64, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -101,9 +101,9 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -130,9 +130,9 @@
 ;;
 ;; function u0:3(i64 vmctx, i64, i64, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -157,9 +157,9 @@
 ;;
 ;; function u0:4(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/multi-0.wat
+++ b/tests/disas/multi-0.wat
@@ -6,7 +6,7 @@
 
 ;; function u0:0(i64 vmctx, i64, i64) -> i64, i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/multi-1.wat
+++ b/tests/disas/multi-1.wat
@@ -9,7 +9,7 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) -> i32, i64, f64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/multi-10.wat
+++ b/tests/disas/multi-10.wat
@@ -13,7 +13,7 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) -> i64, i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/multi-11.wat
+++ b/tests/disas/multi-11.wat
@@ -10,7 +10,7 @@
 
 ;; function u0:0(i64 vmctx, i64, i64) -> i64, i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/multi-12.wat
+++ b/tests/disas/multi-12.wat
@@ -12,7 +12,7 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i64, i64) -> i64, i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/multi-13.wat
+++ b/tests/disas/multi-13.wat
@@ -13,7 +13,7 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/multi-14.wat
+++ b/tests/disas/multi-14.wat
@@ -13,7 +13,7 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/multi-15.wat
+++ b/tests/disas/multi-15.wat
@@ -25,7 +25,7 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i64, f32, f32, i32, f64, f32, i32, i32, i32, f32, f64, f64, f64, i32, i32, f32) -> f64, f32, i32, i32, i32, i64, f32, i32, i32, f32, f64, f64, i32, f32, i32, f64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/multi-16.wat
+++ b/tests/disas/multi-16.wat
@@ -12,7 +12,7 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/multi-17.wat
+++ b/tests/disas/multi-17.wat
@@ -29,7 +29,7 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/multi-2.wat
+++ b/tests/disas/multi-2.wat
@@ -9,7 +9,7 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i64) -> i64, i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/multi-3.wat
+++ b/tests/disas/multi-3.wat
@@ -16,7 +16,7 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i64, i64) -> i64, i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/multi-4.wat
+++ b/tests/disas/multi-4.wat
@@ -16,7 +16,7 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i64, i64) -> i64, i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/multi-5.wat
+++ b/tests/disas/multi-5.wat
@@ -14,7 +14,7 @@
 
 ;; function u0:0(i64 vmctx, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/multi-6.wat
+++ b/tests/disas/multi-6.wat
@@ -14,7 +14,7 @@
 
 ;; function u0:0(i64 vmctx, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/multi-7.wat
+++ b/tests/disas/multi-7.wat
@@ -12,7 +12,7 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) -> i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/multi-8.wat
+++ b/tests/disas/multi-8.wat
@@ -15,7 +15,7 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) -> i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/multi-9.wat
+++ b/tests/disas/multi-9.wat
@@ -18,7 +18,7 @@
 
 ;; function u0:0(i64 vmctx, i64, i64, i32) -> i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/non-fixed-size-memory.wat
+++ b/tests/disas/non-fixed-size-memory.wat
@@ -22,10 +22,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -47,10 +47,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/nullref.wat
+++ b/tests/disas/nullref.wat
@@ -14,7 +14,7 @@
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -30,7 +30,7 @@
 ;;
 ;; function u0:1(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/passive-data.wat
+++ b/tests/disas/passive-data.wat
@@ -15,9 +15,9 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
 ;;     region4 = 152 "VMContext+0x98"
 ;;     region5 = 144 "VMContext+0x90"
 ;;     gv0 = vmctx
@@ -63,7 +63,7 @@
 ;;
 ;; function u0:1(i64 vmctx, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 152 "VMContext+0x98"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8

--- a/tests/disas/pic.wat
+++ b/tests/disas/pic.wat
@@ -49,10 +49,10 @@
 )
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -71,13 +71,13 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 939524096 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
-;;     region3 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region4 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region5 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
-;;     region6 = 2415919128 "VMFunctionImport+0x18"
-;;     region7 = 2415919112 "VMFunctionImport+0x8"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 469762048 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
+;;     region3 = 603979776 "VMMemoryDefinition+0x0"
+;;     region4 = 603979784 "VMMemoryDefinition+0x8"
+;;     region5 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region6 = 1207959576 "VMFunctionImport+0x18"
+;;     region7 = 1207959560 "VMFunctionImport+0x8"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/pr2303.wat
+++ b/tests/disas/pr2303.wat
@@ -18,10 +18,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 268435456 "PublicMemory"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 134217728 "PublicMemory"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/pr2559.wat
+++ b/tests/disas/pr2559.wat
@@ -54,7 +54,7 @@
 
 ;; function u0:0(i64 vmctx, i64) -> i8x16, i8x16, i8x16 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -96,7 +96,7 @@
 ;;
 ;; function u0:1(i64 vmctx, i64) -> i8x16, i8x16, i8x16 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/readonly-funcrefs.wat
+++ b/tests/disas/readonly-funcrefs.wat
@@ -20,7 +20,7 @@
 
 ;; function u0:0(i64 vmctx, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -35,14 +35,14 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1342177280 "VMTableDefinition+0x0"
-;;     region3 = 671088640 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 671088640 "VMTableDefinition+0x0"
+;;     region3 = 335544320 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;     region4 = 40 "VMContext+0x28"
-;;     region5 = 3355443200 "TypeIdsArray+0x0"
-;;     region6 = 3221225488 "VMFuncRef+0x10"
-;;     region7 = 3221225480 "VMFuncRef+0x8"
-;;     region8 = 3221225496 "VMFuncRef+0x18"
+;;     region5 = 1677721600 "TypeIdsArray+0x0"
+;;     region6 = 1610612752 "VMFuncRef+0x10"
+;;     region7 = 1610612744 "VMFuncRef+0x8"
+;;     region8 = 1610612760 "VMFuncRef+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/readonly-heap-base-pointer1.wat
+++ b/tests/disas/readonly-heap-base-pointer1.wat
@@ -9,10 +9,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/readonly-heap-base-pointer2.wat
+++ b/tests/disas/readonly-heap-base-pointer2.wat
@@ -9,11 +9,11 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 48 "VMContext+0x30"
-;;     region3 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region4 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region5 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region3 = 603979776 "VMMemoryDefinition+0x0"
+;;     region4 = 603979784 "VMMemoryDefinition+0x8"
+;;     region5 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/readonly-heap-base-pointer3.wat
+++ b/tests/disas/readonly-heap-base-pointer3.wat
@@ -9,10 +9,10 @@
 )
 ;; function u0:0(i64 vmctx, i64, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/ref-func-0.wat
+++ b/tests/disas/ref-func-0.wat
@@ -15,8 +15,8 @@
 
 ;; function u0:0(i64 vmctx, i64) -> i32, i32, i64, i64 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 805306368 "PublicGlobal"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 402653184 "PublicGlobal"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/riscv64-component-builtins.wat
+++ b/tests/disas/riscv64-component-builtins.wat
@@ -12,13 +12,13 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217776 "VMStoreContext+0x30"
-;;     region2 = 134217784 "VMStoreContext+0x38"
-;;     region3 = 1476395040 "VMComponentContext+0x20"
-;;     region4 = 1476395016 "VMComponentContext+0x8"
-;;     region5 = 3758096400 "ComponentBuiltinFunctionsArray+0x10"
+;;     region1 = 67108912 "VMStoreContext+0x30"
+;;     region2 = 67108920 "VMStoreContext+0x38"
+;;     region3 = 738197536 "VMComponentContext+0x20"
+;;     region4 = 738197512 "VMComponentContext+0x8"
+;;     region5 = 1879048208 "ComponentBuiltinFunctionsArray+0x10"
 ;;     region6 = 16 "VMContext+0x10"
-;;     region7 = 3623878984 "BuiltinFunctionsArray+0x148"
+;;     region7 = 1811939656 "BuiltinFunctionsArray+0x148"
 ;;     sig0 = (i64 sext, i32 sext, i32 sext, i32 sext) -> i64 sext system_v
 ;;     sig1 = (i64 sext vmctx) system_v
 ;;

--- a/tests/disas/select.wat
+++ b/tests/disas/select.wat
@@ -22,7 +22,7 @@
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -41,7 +41,7 @@
 ;;
 ;; function u0:1(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -60,7 +60,7 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/simd-store.wat
+++ b/tests/disas/simd-store.wat
@@ -86,10 +86,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -110,10 +110,10 @@
 ;;
 ;; function u0:10(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -136,10 +136,10 @@
 ;;
 ;; function u0:11(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -162,10 +162,10 @@
 ;;
 ;; function u0:12(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -186,10 +186,10 @@
 ;;
 ;; function u0:13(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -212,10 +212,10 @@
 ;;
 ;; function u0:14(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -238,10 +238,10 @@
 ;;
 ;; function u0:15(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -262,10 +262,10 @@
 ;;
 ;; function u0:16(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -288,10 +288,10 @@
 ;;
 ;; function u0:17(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -314,10 +314,10 @@
 ;;
 ;; function u0:18(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -340,10 +340,10 @@
 ;;
 ;; function u0:19(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -364,10 +364,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -390,10 +390,10 @@
 ;;
 ;; function u0:20(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -416,10 +416,10 @@
 ;;
 ;; function u0:21(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -442,10 +442,10 @@
 ;;
 ;; function u0:22(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -468,10 +468,10 @@
 ;;
 ;; function u0:23(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -494,10 +494,10 @@
 ;;
 ;; function u0:24(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -520,10 +520,10 @@
 ;;
 ;; function u0:25(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -546,10 +546,10 @@
 ;;
 ;; function u0:26(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -572,10 +572,10 @@
 ;;
 ;; function u0:27(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -598,10 +598,10 @@
 ;;
 ;; function u0:28(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -624,10 +624,10 @@
 ;;
 ;; function u0:29(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -650,10 +650,10 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -676,10 +676,10 @@
 ;;
 ;; function u0:30(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -702,10 +702,10 @@
 ;;
 ;; function u0:31(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -728,10 +728,10 @@
 ;;
 ;; function u0:32(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -754,10 +754,10 @@
 ;;
 ;; function u0:33(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -780,10 +780,10 @@
 ;;
 ;; function u0:3(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -806,10 +806,10 @@
 ;;
 ;; function u0:4(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -830,10 +830,10 @@
 ;;
 ;; function u0:5(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -856,10 +856,10 @@
 ;;
 ;; function u0:6(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -882,10 +882,10 @@
 ;;
 ;; function u0:7(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -908,10 +908,10 @@
 ;;
 ;; function u0:8(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -932,10 +932,10 @@
 ;;
 ;; function u0:9(i64 vmctx, i64, i8x16) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1207959552 "VMMemoryDefinition+0x0"
-;;     region3 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region4 = 402653184 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 603979776 "VMMemoryDefinition+0x0"
+;;     region3 = 603979784 "VMMemoryDefinition+0x8"
+;;     region4 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/simd.wat
+++ b/tests/disas/simd.wat
@@ -32,7 +32,7 @@
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -50,7 +50,7 @@
 ;;
 ;; function u0:1(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -71,7 +71,7 @@
 ;;
 ;; function u0:2(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -90,7 +90,7 @@
 ;;
 ;; function u0:3(i64 vmctx, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/simple.wat
+++ b/tests/disas/simple.wat
@@ -20,7 +20,7 @@
 )
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -37,7 +37,7 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -51,7 +51,7 @@
 ;;
 ;; function u0:2(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/stack-switching/resume-suspend-data-passing.wat
+++ b/tests/disas/stack-switching/resume-suspend-data-passing.wat
@@ -40,10 +40,10 @@
 ;; function u0:0(i64 vmctx, i64) tail {
 ;;     ss0 = explicit_slot 16, align = 65536
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217816 "VMStoreContext+0x58"
-;;     region3 = 2147483648 "VMContRef+0x0"
-;;     region4 = 2281701376 "ContinuationStackMemory+0x0"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108952 "VMStoreContext+0x58"
+;;     region3 = 1073741824 "VMContRef+0x0"
+;;     region4 = 1140850688 "ContinuationStackMemory+0x0"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -151,11 +151,11 @@
 ;; function u0:1(i64 vmctx, i64) tail {
 ;;     ss0 = explicit_slot 8, align = 256
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 2147483648 "VMContRef+0x0"
-;;     region3 = 134217816 "VMStoreContext+0x58"
-;;     region4 = 134217800 "VMStoreContext+0x48"
-;;     region5 = 2281701376 "ContinuationStackMemory+0x0"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 1073741824 "VMContRef+0x0"
+;;     region3 = 67108952 "VMStoreContext+0x58"
+;;     region4 = 67108936 "VMStoreContext+0x48"
+;;     region5 = 1140850688 "ContinuationStackMemory+0x0"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/stack-switching/resume-suspend.wat
+++ b/tests/disas/stack-switching/resume-suspend.wat
@@ -24,10 +24,10 @@
 
 ;; function u0:0(i64 vmctx, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 134217816 "VMStoreContext+0x58"
-;;     region3 = 2147483648 "VMContRef+0x0"
-;;     region4 = 2281701376 "ContinuationStackMemory+0x0"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108952 "VMStoreContext+0x58"
+;;     region3 = 1073741824 "VMContRef+0x0"
+;;     region4 = 1140850688 "ContinuationStackMemory+0x0"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -112,11 +112,11 @@
 ;; function u0:1(i64 vmctx, i64) tail {
 ;;     ss0 = explicit_slot 8, align = 256
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 2147483648 "VMContRef+0x0"
-;;     region3 = 134217816 "VMStoreContext+0x58"
-;;     region4 = 134217800 "VMStoreContext+0x48"
-;;     region5 = 2281701376 "ContinuationStackMemory+0x0"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 1073741824 "VMContRef+0x0"
+;;     region3 = 67108952 "VMStoreContext+0x58"
+;;     region4 = 67108936 "VMStoreContext+0x48"
+;;     region5 = 1140850688 "ContinuationStackMemory+0x0"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/stack-switching/symmetric-switch.wat
+++ b/tests/disas/stack-switching/symmetric-switch.wat
@@ -28,12 +28,12 @@
 ;; function u0:0(i64 vmctx, i64) tail {
 ;;     ss0 = explicit_slot 24, align = 256
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 2147483648 "VMContRef+0x0"
-;;     region3 = 134217816 "VMStoreContext+0x58"
-;;     region4 = 2281701376 "ContinuationStackMemory+0x0"
-;;     region5 = 134217800 "VMStoreContext+0x48"
-;;     region6 = 3087007744 "Stack(ss0)"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 1073741824 "VMContRef+0x0"
+;;     region3 = 67108952 "VMStoreContext+0x58"
+;;     region4 = 1140850688 "ContinuationStackMemory+0x0"
+;;     region5 = 67108936 "VMStoreContext+0x48"
+;;     region6 = 1543503872 "Stack(ss0)"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -237,7 +237,7 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i128) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -253,11 +253,11 @@
 ;; function u0:2(i64 vmctx, i64) tail {
 ;;     ss0 = explicit_slot 8, align = 256
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 2147483648 "VMContRef+0x0"
-;;     region3 = 134217816 "VMStoreContext+0x58"
-;;     region4 = 134217800 "VMStoreContext+0x48"
-;;     region5 = 2281701376 "ContinuationStackMemory+0x0"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 1073741824 "VMContRef+0x0"
+;;     region3 = 67108952 "VMStoreContext+0x58"
+;;     region4 = 67108936 "VMStoreContext+0x48"
+;;     region5 = 1140850688 "ContinuationStackMemory+0x0"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/startup-data-active.wat
+++ b/tests/disas/startup-data-active.wat
@@ -10,10 +10,10 @@
 )
 ;; function u2415919104:1(i64 vmctx, i64, i64, i64) -> i8 system_v {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217800 "VMStoreContext+0x48"
-;;     region2 = 134217792 "VMStoreContext+0x40"
-;;     region3 = 134217808 "VMStoreContext+0x50"
-;;     region4 = 134217864 "VMStoreContext+0x88"
+;;     region1 = 67108936 "VMStoreContext+0x48"
+;;     region2 = 67108928 "VMStoreContext+0x40"
+;;     region3 = 67108944 "VMStoreContext+0x50"
+;;     region4 = 67109000 "VMStoreContext+0x88"
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     fn0 = colocated u2415919104:0 sig0
 ;;
@@ -44,8 +44,8 @@
 ;; function u2415919104:0(i64 vmctx, i64) tail {
 ;;     region0 = 112 "VMContext+0x70"
 ;;     region1 = 120 "VMContext+0x78"
-;;     region2 = 1207959560 "VMMemoryDefinition+0x8"
-;;     region3 = 1207959552 "VMMemoryDefinition+0x0"
+;;     region2 = 603979784 "VMMemoryDefinition+0x8"
+;;     region3 = 603979776 "VMMemoryDefinition+0x0"
 ;;     sig0 = (i64 vmctx, i64, i64, i64) tail
 ;;     fn0 = colocated u805306368:1 sig0
 ;;

--- a/tests/disas/startup-elem-active.wat
+++ b/tests/disas/startup-elem-active.wat
@@ -14,10 +14,10 @@
 )
 ;; function u2415919104:1(i64 vmctx, i64, i64, i64) -> i8 system_v {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217800 "VMStoreContext+0x48"
-;;     region2 = 134217792 "VMStoreContext+0x40"
-;;     region3 = 134217808 "VMStoreContext+0x50"
-;;     region4 = 134217864 "VMStoreContext+0x88"
+;;     region1 = 67108936 "VMStoreContext+0x48"
+;;     region2 = 67108928 "VMStoreContext+0x40"
+;;     region3 = 67108944 "VMStoreContext+0x50"
+;;     region4 = 67109000 "VMStoreContext+0x88"
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     fn0 = colocated u2415919104:0 sig0
 ;;
@@ -46,9 +46,9 @@
 ;; }
 ;;
 ;; function u2415919104:0(i64 vmctx, i64) tail {
-;;     region0 = 1342177280 "VMTableDefinition+0x0"
-;;     region1 = 1342177288 "VMTableDefinition+0x8"
-;;     region2 = 671088640 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region0 = 671088640 "VMTableDefinition+0x0"
+;;     region1 = 671088648 "VMTableDefinition+0x8"
+;;     region2 = 335544320 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;
 ;; block0(v0: i64, v1: i64):
 ;;     v4 = load.i64 notrap aligned region1 v0+56

--- a/tests/disas/startup-global.wat
+++ b/tests/disas/startup-global.wat
@@ -7,10 +7,10 @@
 )
 ;; function u2415919104:1(i64 vmctx, i64, i64, i64) -> i8 system_v {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217800 "VMStoreContext+0x48"
-;;     region2 = 134217792 "VMStoreContext+0x40"
-;;     region3 = 134217808 "VMStoreContext+0x50"
-;;     region4 = 134217864 "VMStoreContext+0x88"
+;;     region1 = 67108936 "VMStoreContext+0x48"
+;;     region2 = 67108928 "VMStoreContext+0x40"
+;;     region3 = 67108944 "VMStoreContext+0x50"
+;;     region4 = 67109000 "VMStoreContext+0x88"
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     fn0 = colocated u2415919104:0 sig0
 ;;
@@ -39,7 +39,7 @@
 ;; }
 ;;
 ;; function u2415919104:0(i64 vmctx, i64) tail {
-;;     region0 = 939524096 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
+;;     region0 = 469762048 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
 ;;
 ;; block0(v0: i64, v1: i64):
 ;;     v2 = iconst.i64 0

--- a/tests/disas/startup-passive-segment.wat
+++ b/tests/disas/startup-passive-segment.wat
@@ -8,10 +8,10 @@
 )
 ;; function u2415919104:1(i64 vmctx, i64, i64, i64) -> i8 system_v {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217800 "VMStoreContext+0x48"
-;;     region2 = 134217792 "VMStoreContext+0x40"
-;;     region3 = 134217808 "VMStoreContext+0x50"
-;;     region4 = 134217864 "VMStoreContext+0x88"
+;;     region1 = 67108936 "VMStoreContext+0x48"
+;;     region2 = 67108928 "VMStoreContext+0x40"
+;;     region3 = 67108944 "VMStoreContext+0x50"
+;;     region4 = 67109000 "VMStoreContext+0x88"
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     fn0 = colocated u2415919104:0 sig0
 ;;
@@ -40,7 +40,7 @@
 ;; }
 ;;
 ;; function u2415919104:0(i64 vmctx, i64) tail {
-;;     region0 = 1073741824 "GcHeap"
+;;     region0 = 536870912 "GcHeap"
 ;;     sig0 = (i64 vmctx, i32) -> i64 tail
 ;;     fn0 = colocated u805306368:4 sig0
 ;;

--- a/tests/disas/startup-start.wat
+++ b/tests/disas/startup-start.wat
@@ -8,10 +8,10 @@
 )
 ;; function u2415919104:1(i64 vmctx, i64, i64, i64) -> i8 system_v {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217800 "VMStoreContext+0x48"
-;;     region2 = 134217792 "VMStoreContext+0x40"
-;;     region3 = 134217808 "VMStoreContext+0x50"
-;;     region4 = 134217864 "VMStoreContext+0x88"
+;;     region1 = 67108936 "VMStoreContext+0x48"
+;;     region2 = 67108928 "VMStoreContext+0x40"
+;;     region3 = 67108944 "VMStoreContext+0x50"
+;;     region4 = 67109000 "VMStoreContext+0x88"
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     fn0 = colocated u2415919104:0 sig0
 ;;

--- a/tests/disas/startup-table-initial-value.wat
+++ b/tests/disas/startup-table-initial-value.wat
@@ -8,10 +8,10 @@
 )
 ;; function u2415919104:1(i64 vmctx, i64, i64, i64) -> i8 system_v {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217800 "VMStoreContext+0x48"
-;;     region2 = 134217792 "VMStoreContext+0x40"
-;;     region3 = 134217808 "VMStoreContext+0x50"
-;;     region4 = 134217864 "VMStoreContext+0x88"
+;;     region1 = 67108936 "VMStoreContext+0x48"
+;;     region2 = 67108928 "VMStoreContext+0x40"
+;;     region3 = 67108944 "VMStoreContext+0x50"
+;;     region4 = 67109000 "VMStoreContext+0x88"
 ;;     sig0 = (i64 vmctx, i64) tail
 ;;     fn0 = colocated u2415919104:0 sig0
 ;;
@@ -40,9 +40,9 @@
 ;; }
 ;;
 ;; function u2415919104:0(i64 vmctx, i64) tail {
-;;     region0 = 1342177280 "VMTableDefinition+0x0"
-;;     region1 = 1342177288 "VMTableDefinition+0x8"
-;;     region2 = 671088640 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region0 = 671088640 "VMTableDefinition+0x0"
+;;     region1 = 671088648 "VMTableDefinition+0x8"
+;;     region2 = 335544320 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
 ;;
 ;; block0(v0: i64, v1: i64):
 ;;     v9 = load.i64 notrap aligned region1 v0+56

--- a/tests/disas/sub-global.wat
+++ b/tests/disas/sub-global.wat
@@ -14,8 +14,8 @@
 
 ;; function u0:0(i64 vmctx, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 939524096 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 469762048 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/table-copy.wat
+++ b/tests/disas/table-copy.wat
@@ -25,7 +25,7 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -40,7 +40,7 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32, i32, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -55,7 +55,7 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32, i32, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -70,11 +70,11 @@
 ;;
 ;; function u0:3(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 2684354560 "VMTableImport+0x0"
-;;     region3 = 1342177280 "VMTableDefinition+0x0"
-;;     region4 = 1342177288 "VMTableDefinition+0x8"
-;;     region5 = 536870912 "PublicTable"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 1342177280 "VMTableImport+0x0"
+;;     region3 = 671088640 "VMTableDefinition+0x0"
+;;     region4 = 671088648 "VMTableDefinition+0x8"
+;;     region5 = 268435456 "PublicTable"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -210,11 +210,11 @@
 ;;
 ;; function u0:4(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1342177280 "VMTableDefinition+0x0"
-;;     region3 = 2684354560 "VMTableImport+0x0"
-;;     region4 = 1342177288 "VMTableDefinition+0x8"
-;;     region5 = 536870912 "PublicTable"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 671088640 "VMTableDefinition+0x0"
+;;     region3 = 1342177280 "VMTableImport+0x0"
+;;     region4 = 671088648 "VMTableDefinition+0x8"
+;;     region5 = 268435456 "PublicTable"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/table-get-fixed-size.wat
+++ b/tests/disas/table-get-fixed-size.wat
@@ -17,9 +17,9 @@
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1342177280 "VMTableDefinition+0x0"
-;;     region3 = 536870912 "PublicTable"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 671088640 "VMTableDefinition+0x0"
+;;     region3 = 268435456 "PublicTable"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -45,9 +45,9 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1342177280 "VMTableDefinition+0x0"
-;;     region3 = 536870912 "PublicTable"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 671088640 "VMTableDefinition+0x0"
+;;     region3 = 268435456 "PublicTable"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/table-get.wat
+++ b/tests/disas/table-get.wat
@@ -16,10 +16,10 @@
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1342177280 "VMTableDefinition+0x0"
-;;     region3 = 1342177288 "VMTableDefinition+0x8"
-;;     region4 = 536870912 "PublicTable"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 671088640 "VMTableDefinition+0x0"
+;;     region3 = 671088648 "VMTableDefinition+0x8"
+;;     region4 = 268435456 "PublicTable"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -46,10 +46,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1342177280 "VMTableDefinition+0x0"
-;;     region3 = 1342177288 "VMTableDefinition+0x8"
-;;     region4 = 536870912 "PublicTable"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 671088640 "VMTableDefinition+0x0"
+;;     region3 = 671088648 "VMTableDefinition+0x8"
+;;     region4 = 268435456 "PublicTable"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/table-set-fixed-size.wat
+++ b/tests/disas/table-set-fixed-size.wat
@@ -18,9 +18,9 @@
     table.set 0))
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1342177280 "VMTableDefinition+0x0"
-;;     region3 = 536870912 "PublicTable"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 671088640 "VMTableDefinition+0x0"
+;;     region3 = 268435456 "PublicTable"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -46,9 +46,9 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1342177280 "VMTableDefinition+0x0"
-;;     region3 = 536870912 "PublicTable"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 671088640 "VMTableDefinition+0x0"
+;;     region3 = 268435456 "PublicTable"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/table-set.wat
+++ b/tests/disas/table-set.wat
@@ -18,10 +18,10 @@
 
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1342177280 "VMTableDefinition+0x0"
-;;     region3 = 1342177288 "VMTableDefinition+0x8"
-;;     region4 = 536870912 "PublicTable"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 671088640 "VMTableDefinition+0x0"
+;;     region3 = 671088648 "VMTableDefinition+0x8"
+;;     region4 = 268435456 "PublicTable"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -48,10 +48,10 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1342177280 "VMTableDefinition+0x0"
-;;     region3 = 1342177288 "VMTableDefinition+0x8"
-;;     region4 = 536870912 "PublicTable"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 671088640 "VMTableDefinition+0x0"
+;;     region3 = 671088648 "VMTableDefinition+0x8"
+;;     region4 = 268435456 "PublicTable"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/typed-funcrefs-eager-init.wat
+++ b/tests/disas/typed-funcrefs-eager-init.wat
@@ -115,7 +115,7 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -130,11 +130,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1342177280 "VMTableDefinition+0x0"
-;;     region3 = 671088640 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
-;;     region4 = 3221225480 "VMFuncRef+0x8"
-;;     region5 = 3221225496 "VMFuncRef+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 671088640 "VMTableDefinition+0x0"
+;;     region3 = 335544320 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region4 = 1610612744 "VMFuncRef+0x8"
+;;     region5 = 1610612760 "VMFuncRef+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -164,11 +164,11 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1342177280 "VMTableDefinition+0x0"
-;;     region3 = 671088640 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
-;;     region4 = 3221225480 "VMFuncRef+0x8"
-;;     region5 = 3221225496 "VMFuncRef+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 671088640 "VMTableDefinition+0x0"
+;;     region3 = 335544320 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region4 = 1610612744 "VMFuncRef+0x8"
+;;     region5 = 1610612760 "VMFuncRef+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -198,11 +198,11 @@
 ;;
 ;; function u0:3(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 939524096 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
-;;     region3 = 3221225480 "VMFuncRef+0x8"
-;;     region4 = 3221225496 "VMFuncRef+0x18"
-;;     region5 = 939524097 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(1))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 469762048 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
+;;     region3 = 1610612744 "VMFuncRef+0x8"
+;;     region4 = 1610612760 "VMFuncRef+0x18"
+;;     region5 = 469762049 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(1))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/typed-funcrefs.wat
+++ b/tests/disas/typed-funcrefs.wat
@@ -115,7 +115,7 @@
 
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -130,11 +130,11 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1342177280 "VMTableDefinition+0x0"
-;;     region3 = 671088640 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
-;;     region4 = 3221225480 "VMFuncRef+0x8"
-;;     region5 = 3221225496 "VMFuncRef+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 671088640 "VMTableDefinition+0x0"
+;;     region3 = 335544320 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region4 = 1610612744 "VMFuncRef+0x8"
+;;     region5 = 1610612760 "VMFuncRef+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -188,11 +188,11 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 1342177280 "VMTableDefinition+0x0"
-;;     region3 = 671088640 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
-;;     region4 = 3221225480 "VMFuncRef+0x8"
-;;     region5 = 3221225496 "VMFuncRef+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 671088640 "VMTableDefinition+0x0"
+;;     region3 = 335544320 "DefinedTable(StaticModuleIndex(0), DefinedTableIndex(0))"
+;;     region4 = 1610612744 "VMFuncRef+0x8"
+;;     region5 = 1610612760 "VMFuncRef+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -246,11 +246,11 @@
 ;;
 ;; function u0:3(i64 vmctx, i64, i32, i32, i32, i32) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
-;;     region2 = 939524096 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
-;;     region3 = 3221225480 "VMFuncRef+0x8"
-;;     region4 = 3221225496 "VMFuncRef+0x18"
-;;     region5 = 939524097 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(1))"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 469762048 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(0))"
+;;     region3 = 1610612744 "VMFuncRef+0x8"
+;;     region4 = 1610612760 "VMFuncRef+0x18"
+;;     region5 = 469762049 "DefinedGlobal(StaticModuleIndex(0), DefinedGlobalIndex(1))"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/unreachable_code.wat
+++ b/tests/disas/unreachable_code.wat
@@ -80,7 +80,7 @@
 
 ;; function u0:0(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -92,7 +92,7 @@
 ;;
 ;; function u0:1(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -107,7 +107,7 @@
 ;;
 ;; function u0:2(i64 vmctx, i64) -> i32 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -141,7 +141,7 @@
 ;;
 ;; function u0:3(i64 vmctx, i64) tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24

--- a/tests/disas/x64-simd-round-without-sse41.wat
+++ b/tests/disas/x64-simd-round-without-sse41.wat
@@ -13,7 +13,7 @@
 )
 ;; function u0:0(i64 vmctx, i64, i8x16) -> i8x16 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -46,7 +46,7 @@
 ;;
 ;; function u0:1(i64 vmctx, i64, i8x16) -> i8x16 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -79,7 +79,7 @@
 ;;
 ;; function u0:2(i64 vmctx, i64, i8x16) -> i8x16 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -112,7 +112,7 @@
 ;;
 ;; function u0:3(i64 vmctx, i64, i8x16) -> i8x16 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -145,7 +145,7 @@
 ;;
 ;; function u0:4(i64 vmctx, i64, i8x16) -> i8x16 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -172,7 +172,7 @@
 ;;
 ;; function u0:5(i64 vmctx, i64, i8x16) -> i8x16 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -199,7 +199,7 @@
 ;;
 ;; function u0:6(i64 vmctx, i64, i8x16) -> i8x16 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -226,7 +226,7 @@
 ;;
 ;; function u0:7(i64 vmctx, i64, i8x16) -> i8x16 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -253,7 +253,7 @@
 ;;
 ;; function u0:8(i64 vmctx, i64, i8x16) -> i8x16 tail {
 ;;     region0 = 8 "VMContext+0x8"
-;;     region1 = 134217752 "VMStoreContext+0x18"
+;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24


### PR DESCRIPTION
This also bumped the AliasRegionKey's kind bits up to 6, which triggered a mass renumbering in the disas tests.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
