### PR TITLE
wasi: return NotPermitted for stream open permission failures

### DIFF
--- a/crates/test-programs/src/bin/p2_file_stream_not_permitted.rs
+++ b/crates/test-programs/src/bin/p2_file_stream_not_permitted.rs
@@ -1,0 +1,83 @@
+//! Stream open paths must return `not-permitted` when the preopen denies the
+//! access mode, matching non-stream `read`/`write` (not `bad-descriptor`).
+
+use test_programs::wasi::filesystem::preopens;
+use test_programs::wasi::filesystem::types::{DescriptorFlags, ErrorCode, OpenFlags, PathFlags};
+
+fn main() {
+    let preopens = preopens::get_directories();
+
+    // --- readonly preopen: write/append streams denied, read stream allowed ---
+    let (readonly_dir, _) = preopens
+        .iter()
+        .find(|(_, path)| path == "readonly")
+        .expect("find preopen named readonly");
+
+    let file = readonly_dir
+        .open_at(
+            PathFlags::empty(),
+            "stream-perms.txt",
+            OpenFlags::empty(),
+            DescriptorFlags::READ,
+        )
+        .expect("open for reading");
+
+    let err = file
+        .write_via_stream(0)
+        .expect_err("write_via_stream without write permission");
+    assert_eq!(
+        err,
+        ErrorCode::NotPermitted,
+        "write_via_stream should return not-permitted, got {err:?}"
+    );
+
+    let err = file
+        .append_via_stream()
+        .expect_err("append_via_stream without write permission");
+    assert_eq!(
+        err,
+        ErrorCode::NotPermitted,
+        "append_via_stream should return not-permitted, got {err:?}"
+    );
+
+    let stream = file
+        .read_via_stream(0)
+        .expect("read_via_stream with read permission");
+    let contents = stream.blocking_read(100).expect("read file contents");
+    drop(stream);
+    drop(file);
+    assert_eq!(contents, b"stream permission test\n");
+
+    // --- writeonly preopen: read stream denied, write stream allowed ---
+    let (writeonly_dir, _) = preopens
+        .iter()
+        .find(|(_, path)| path == "writeonly")
+        .expect("find preopen named writeonly");
+
+    let file = writeonly_dir
+        .open_at(
+            PathFlags::empty(),
+            "stream-write.txt",
+            OpenFlags::empty(),
+            DescriptorFlags::WRITE,
+        )
+        .expect("open for writing");
+
+    let err = file
+        .read_via_stream(0)
+        .expect_err("read_via_stream without read permission");
+    assert_eq!(
+        err,
+        ErrorCode::NotPermitted,
+        "read_via_stream should return not-permitted, got {err:?}"
+    );
+
+    let stream = file
+        .write_via_stream(0)
+        .expect("write_via_stream with write permission");
+    stream
+        .blocking_write_and_flush(b"ok")
+        .expect("write stream contents");
+    drop(stream);
+    drop(file);
+}

--- a/crates/wasi/src/p2/host/filesystem.rs
+++ b/crates/wasi/src/p2/host/filesystem.rs
@@ -378,7 +378,7 @@ impl HostDescriptor for WasiFilesystemCtxView<'_> {
         let f = self.table.get(&fd)?.file()?;
 
         if !f.perms.contains(FilePerms::READ) {
-            Err(types::ErrorCode::BadDescriptor)?;
+            Err(types::ErrorCode::NotPermitted)?;
         }
 
         // Create a stream view for it.
@@ -399,7 +399,7 @@ impl HostDescriptor for WasiFilesystemCtxView<'_> {
         let f = self.table.get(&fd)?.file()?;
 
         if !f.perms.contains(FilePerms::WRITE) {
-            Err(types::ErrorCode::BadDescriptor)?;
+            Err(types::ErrorCode::NotPermitted)?;
         }
 
         // Create a stream view for it.
@@ -420,7 +420,7 @@ impl HostDescriptor for WasiFilesystemCtxView<'_> {
         let f = self.table.get(&fd)?.file()?;
 
         if !f.perms.contains(FilePerms::WRITE) {
-            Err(types::ErrorCode::BadDescriptor)?;
+            Err(types::ErrorCode::NotPermitted)?;
         }
 
         // Create a stream view for it.

--- a/crates/wasi/tests/all/p2/async_.rs
+++ b/crates/wasi/tests/all/p2/async_.rs
@@ -454,6 +454,49 @@ async fn p2_file_rename_across_perms() {
 }
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn p2_file_stream_not_permitted() {
+    file_stream_not_permitted(P2_FILE_STREAM_NOT_PERMITTED_COMPONENT).await
+}
+
+async fn file_stream_not_permitted(component_path: &str) {
+    use wasmtime_wasi::{DirPerms, FilePerms};
+
+    let readonly = tempfile::Builder::new()
+        .prefix("wasi_components_stream_np_ro_")
+        .tempdir()
+        .expect("create readonly tempdir");
+    let writeonly = tempfile::Builder::new()
+        .prefix("wasi_components_stream_np_wo_")
+        .tempdir()
+        .expect("create writeonly tempdir");
+
+    const RO_CONTENTS: &[u8] = b"stream permission test\n";
+    std::fs::write(readonly.path().join("stream-perms.txt"), RO_CONTENTS)
+        .expect("write readonly test file");
+    std::fs::write(writeonly.path().join("stream-write.txt"), b"")
+        .expect("create writeonly test file");
+
+    run(component_path, |b| {
+        b.preopened_dir(
+            readonly.path(),
+            "readonly",
+            DirPerms::READ | DirPerms::MUTATE,
+            FilePerms::READ,
+        )
+        .unwrap();
+        b.preopened_dir(
+            writeonly.path(),
+            "writeonly",
+            DirPerms::READ | DirPerms::MUTATE,
+            FilePerms::WRITE,
+        )
+        .unwrap();
+    })
+    .await
+    .expect("run p2_file_stream_not_permitted guest");
+}
+
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn p2_clocks_zero_wait() {
     run(P2_CLOCKS_ZERO_WAIT_COMPONENT, |_| {}).await.unwrap()
 }

--- a/crates/wasi/tests/all/p2/sync.rs
+++ b/crates/wasi/tests/all/p2/sync.rs
@@ -422,6 +422,48 @@ fn p2_file_rename_across_perms() {
 }
 
 #[test_log::test]
+fn p2_file_stream_not_permitted() {
+    file_stream_not_permitted(P2_FILE_STREAM_NOT_PERMITTED_COMPONENT)
+}
+
+fn file_stream_not_permitted(component_path: &str) {
+    use wasmtime_wasi::{DirPerms, FilePerms};
+
+    let readonly = tempfile::Builder::new()
+        .prefix("wasi_components_stream_np_ro_")
+        .tempdir()
+        .expect("create readonly tempdir");
+    let writeonly = tempfile::Builder::new()
+        .prefix("wasi_components_stream_np_wo_")
+        .tempdir()
+        .expect("create writeonly tempdir");
+
+    const RO_CONTENTS: &[u8] = b"stream permission test\n";
+    std::fs::write(readonly.path().join("stream-perms.txt"), RO_CONTENTS)
+        .expect("write readonly test file");
+    std::fs::write(writeonly.path().join("stream-write.txt"), b"")
+        .expect("create writeonly test file");
+
+    run(component_path, |b| {
+        b.preopened_dir(
+            readonly.path(),
+            "readonly",
+            DirPerms::READ | DirPerms::MUTATE,
+            FilePerms::READ,
+        )
+        .unwrap();
+        b.preopened_dir(
+            writeonly.path(),
+            "writeonly",
+            DirPerms::READ | DirPerms::MUTATE,
+            FilePerms::WRITE,
+        )
+        .unwrap();
+    })
+    .expect("run p2_file_stream_not_permitted guest");
+}
+
+#[test_log::test]
 fn p2_clocks_zero_wait() {
     run(P2_CLOCKS_ZERO_WAIT_COMPONENT, |_| {}).unwrap()
 }


### PR DESCRIPTION
## Summary

`read_via_stream`, `write_via_stream`, and `append_via_stream` returned `ErrorCode::BadDescriptor` when the descriptor lacked the required read/write permission. The non-stream `read` / `write` paths in the same module already return `NotPermitted` for the same condition.

## Why this change is needed

Permission denial should use the permission-denied error code. `BadDescriptor` maps to a different condition (invalid/wrong kind of FD). Guests that branch on `not-permitted` vs `bad-descriptor` currently get the wrong signal when opening a stream view on a file opened without the needed access.

## Change

Three sites in `crates/wasi/src/p2/host/filesystem.rs`:

```diff
- Err(types::ErrorCode::BadDescriptor)?;
+ Err(types::ErrorCode::NotPermitted)?;
```

aligned with:

```rust
// async fn read / write
if !f.perms.contains(FilePerms::READ/WRITE) {
    return Err(ErrorCode::NotPermitted.into());
}
```

## Testing

- `cargo test -p wasmtime-wasi --test all --features p2 p2_file_stream_not_permitted` passes (sync + async harness).
- Guest program `p2_file_stream_not_permitted` covers:
  - read-only preopen (`FilePerms::READ`): `write_via_stream` / `append_via_stream` return `ErrorCode::NotPermitted`; `read_via_stream` still works.
  - write-only preopen (`FilePerms::WRITE`): `read_via_stream` returns `ErrorCode::NotPermitted`; `write_via_stream` still works.
