### PR TITLE
Lower aarch64 Windows alignment

### DIFF
--- a/crates/environ/src/compile/mod.rs
+++ b/crates/environ/src/compile/mod.rs
@@ -383,6 +383,10 @@ pub trait Compiler: Send + Sync {
                 | OperatingSystem::TvOS(_),
                 Architecture::Aarch64(..),
             ) => 0x4000,
+            // According to
+            // https://devblogs.microsoft.com/oldnewthing/20210510-00/?p=105200
+            // it seems like windows always use a 4k page size.
+            (OperatingSystem::Windows, Architecture::Aarch64(..)) => 0x1000,
             // 64 KB is the maximal page size (i.e. memory translation granule size)
             // supported by the architecture and is used on some platforms.
             (_, Architecture::Aarch64(..)) => 0x10000,


### PR DESCRIPTION
The fallback of 64k isn't necessary on Windows it seems as the page size is always 4k.

Closes #13817

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
