### PR TITLE
Gc performance improvements, in particular for high-concurrency

### DIFF
--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -86,6 +86,9 @@ wasmtime_option_group! {
         /// Size, in bytes, of guard pages for the GC heap.
         pub gc_heap_guard_size: Option<u64>,
 
+        /// Initial allocated size for the GC heap.
+        pub gc_heap_initial_size: Option<u64>,
+
         /// Indicates whether an unmapped region of memory is placed before all
         /// linear memories.
         pub guard_before_linear_memory: Option<bool>,
@@ -977,6 +980,12 @@ impl CommonOptions {
         if let Some(size) = self.opts.gc_heap_reservation_for_growth {
             config.gc_heap_reservation_for_growth(size);
         }
+
+        #[cfg(feature = "gc")]
+        if let Some(size) = self.opts.gc_heap_initial_size {
+            config.gc_heap_initial_size(size);
+        }
+
         if let Some(enable) = self.opts.table_lazy_init {
             config.table_lazy_init(enable);
         }
@@ -1329,6 +1338,7 @@ impl CommonOptions {
                 gc_heap_reservation: Some(engine.get_gc_heap_reservation()),
                 gc_heap_reservation_for_growth: Some(engine.get_gc_heap_reservation_for_growth()),
                 gc_heap_guard_size: Some(engine.get_gc_heap_guard_size()),
+                gc_heap_initial_size: engine.get_gc_heap_initial_size(),
                 guard_before_linear_memory: Some(engine.get_guard_before_linear_memory()),
                 table_lazy_init: Some(engine.get_table_lazy_init()),
                 memory_init_cow: Some(engine.get_memory_init_cow()),

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -162,6 +162,8 @@ pub struct Config {
     target: Option<target_lexicon::Triple>,
     #[cfg(feature = "gc")]
     collector: Collector,
+    #[cfg(feature = "gc")]
+    pub(crate) gc_heap_initial_size: u64,
     profiling_strategy: ProfilingStrategy,
     tunables: ConfigTunables,
 
@@ -276,6 +278,8 @@ impl Config {
             target: None,
             #[cfg(feature = "gc")]
             collector: Collector::default(),
+            #[cfg(feature = "gc")]
+            gc_heap_initial_size: 0,
             #[cfg(feature = "cache")]
             cache: None,
             profiling_strategy: ProfilingStrategy::None,
@@ -1411,6 +1415,35 @@ impl Config {
     #[cfg(feature = "gc")]
     pub fn collector(&mut self, collector: Collector) -> &mut Self {
         self.collector = collector;
+        self
+    }
+
+    /// Configures the initial size, in bytes, of each store's GC heap.
+    ///
+    /// Wasm modules that use linear memories can set the memories' initial size,
+    /// to reduce the need for repeated growths before reaching a steady state.
+    /// Wasm modules that use GC heaps can't do so. To still avoid repeated
+    /// collect-and-grow ramp-up, this setting can be used to configure the
+    /// initial size of the GC heap. This is particularly useful in combination
+    /// with the pooling allocator, where allocated memory pages are still
+    /// committed lazily, meaning that the memory is not immediately backed by
+    /// physical pages.
+    ///
+    /// The size is rounded up to the GC heap's page size. Note that the
+    /// copying collector divides its heap into two semi-spaces, so only half
+    /// of the configured size is available for allocation under that
+    /// collector.
+    ///
+    /// This only configures the initially-allocated size of the GC heap; the
+    /// heap can still grow beyond it on demand. It is separate from
+    /// [`Config::gc_heap_reservation`], which configures the size of the
+    /// virtual-memory reservation (and therefore how far the heap can grow
+    /// in place).
+    ///
+    /// The default value for this is 0.
+    #[cfg(feature = "gc")]
+    pub fn gc_heap_initial_size(&mut self, bytes: u64) -> &mut Self {
+        self.gc_heap_initial_size = bytes;
         self
     }
 
@@ -4755,6 +4788,14 @@ impl Engine {
     /// Returns the configured [`Config::gc_heap_reservation`] value.
     pub fn get_gc_heap_reservation(&self) -> u64 {
         self.tunables().gc_heap_reservation
+    }
+
+    /// Returns the configured [`Config::gc_heap_initial_size`] value.
+    pub fn get_gc_heap_initial_size(&self) -> Option<u64> {
+        #[cfg(feature = "gc")]
+        return Some(self.config().gc_heap_initial_size);
+        #[cfg(not(feature = "gc"))]
+        return None;
     }
 
     /// Returns the configured [`Config::gc_heap_reservation_for_growth`] value.

--- a/crates/wasmtime/src/runtime/instance.rs
+++ b/crates/wasmtime/src/runtime/instance.rs
@@ -314,9 +314,13 @@ impl Instance {
 
             // Eagerly register trace info for all types in this module.
             if let Some(gc_store) = store.optional_gc_store_mut() {
-                for (_, ty) in module.signatures().as_module_map().iter() {
-                    gc_store.ensure_trace_info(*ty);
-                }
+                gc_store.ensure_trace_infos(
+                    module
+                        .signatures()
+                        .as_module_map()
+                        .iter()
+                        .map(|(_, ty)| *ty),
+                );
             }
         }
 

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -431,6 +431,49 @@ impl<T> DerefMut for StoreInner<T> {
     }
 }
 
+/// A cheap multiplicative hasher for the store-local GC type-metadata caches,
+/// whose keys are `VMSharedTypeIndex`es (or pairs thereof, packed into a
+/// `u64`). These caches are on hot paths such as `ref.cast` and GC-object
+/// allocation, so we want to avoid the default hasher's per-lookup overhead.
+/// Collision-based DoS is not a concern for engine-assigned type indices.
+#[cfg(feature = "gc")]
+#[derive(Default)]
+struct GcTypeCacheHasher(u64);
+
+#[cfg(feature = "gc")]
+impl core::hash::BuildHasher for GcTypeCacheHasher {
+    type Hasher = Self;
+
+    #[inline]
+    fn build_hasher(&self) -> Self {
+        Self::default()
+    }
+}
+
+#[cfg(feature = "gc")]
+impl core::hash::Hasher for GcTypeCacheHasher {
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.0
+    }
+
+    fn write(&mut self, _bytes: &[u8]) {
+        unreachable!("only used with integer keys")
+    }
+
+    #[inline]
+    fn write_u32(&mut self, i: u32) {
+        self.write_u64(i.into());
+    }
+
+    #[inline]
+    fn write_u64(&mut self, i: u64) {
+        // Fibonacci hashing: cheap and mixes the (small integer) type indices
+        // into the high bits that hashbrown uses for its control bytes.
+        self.0 = i.wrapping_mul(0x9E37_79B9_7F4A_7C15);
+    }
+}
+
 /// Monomorphic storage for a `Store<T>`.
 ///
 /// This structure contains the bulk of the metadata about a `Store`. This is
@@ -483,6 +526,16 @@ pub struct StoreOpaque {
     // Types for which the embedder has created an allocator for.
     #[cfg(feature = "gc")]
     gc_host_alloc_types: crate::hash_set::HashSet<crate::type_registry::RegisteredType>,
+    /// A store-local cache of engine-level subtype checks.
+    ///
+    /// Dynamic subtype checks (e.g. for `ref.cast` instructions) consult the
+    /// engine's type registry, which is protected by a read-write lock. Even
+    /// read acquisitions of that lock modify shared cache lines, which
+    /// serializes concurrent stores running on different threads. Caching
+    /// results store-locally keeps the hot path free of shared-memory
+    /// traffic.
+    #[cfg(feature = "gc")]
+    subtype_check_cache: crate::hash_map::HashMap<u64, bool, GcTypeCacheHasher>,
     /// Pending exception, if any. This is also a GC root, because it
     /// needs to be rooted somewhere between the time that a pending
     /// exception is set and the time that the handling code takes the
@@ -758,6 +811,8 @@ impl<T> Store<T> {
             gc_roots_list: GcRootsList::default(),
             #[cfg(feature = "gc")]
             gc_host_alloc_types: Default::default(),
+            #[cfg(feature = "gc")]
+            subtype_check_cache: Default::default(),
             #[cfg(feature = "gc")]
             pending_exception: None,
             modules: ModuleRegistry::default(),
@@ -1960,6 +2015,29 @@ impl StoreOpaque {
     #[cfg(any(feature = "gc-drc", feature = "gc-copying"))]
     pub(crate) fn try_gc_store_mut(&mut self) -> Option<&mut GcStore> {
         self.gc_store.as_mut()
+    }
+
+    /// Is type `sub` a subtype of `sup`?
+    ///
+    /// Equivalent to `self.engine().signatures().is_subtype(sub, sup)` but
+    /// caches results store-locally to avoid contention on the engine's type
+    /// registry lock. See the documentation of the `subtype_check_cache` field
+    /// for details.
+    #[cfg(feature = "gc")]
+    pub(crate) fn is_subtype_cached(
+        &mut self,
+        sub: wasmtime_environ::VMSharedTypeIndex,
+        sup: wasmtime_environ::VMSharedTypeIndex,
+    ) -> bool {
+        if sub == sup {
+            return true;
+        }
+        let key = (u64::from(sub.as_u32()) << 32) | u64::from(sup.as_u32());
+        let engine = &self.engine;
+        *self
+            .subtype_check_cache
+            .entry(key)
+            .or_insert_with(|| engine.signatures().is_subtype(sub, sup))
     }
 
     #[inline]

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -1841,7 +1841,13 @@ impl StoreOpaque {
             use wasmtime_environ::packed_option::ReservedValue;
 
             let engine = store.engine();
-            let mem_ty = engine.tunables().gc_heap_memory_type();
+            let mut mem_ty = engine.tunables().gc_heap_memory_type();
+            let initial_bytes = engine.config().gc_heap_initial_size;
+            if initial_bytes > 0 {
+                let page_size = mem_ty.page_size();
+                mem_ty.limits.min = initial_bytes.div_ceil(page_size);
+            }
+
             ensure!(
                 engine.features().gc_types(),
                 "cannot allocate a GC store when GC is disabled at configuration time"

--- a/crates/wasmtime/src/runtime/type_registry.rs
+++ b/crates/wasmtime/src/runtime/type_registry.rs
@@ -1643,6 +1643,25 @@ impl TypeRegistry {
         inner.type_to_gc_layout.get(index).and_then(|l| l.clone())
     }
 
+    /// Call `f` with the GC layout of each of the given types (`None` for
+    /// types that do not have GC layouts, i.e. function types).
+    ///
+    /// Unlike calling [`Self::layout`] in a loop, this acquires the
+    /// registry's lock only once for the whole batch and hands out borrowed
+    /// layouts rather than deep clones, which matters on hot paths: even read
+    /// acquisitions of the lock modify shared cache lines and therefore
+    /// serialize concurrent stores running on different threads.
+    pub fn for_each_layout(
+        &self,
+        tys: impl IntoIterator<Item = VMSharedTypeIndex>,
+        mut f: impl FnMut(VMSharedTypeIndex, Option<&GcLayout>),
+    ) {
+        let inner = self.0.read();
+        for ty in tys {
+            f(ty, inner.type_to_gc_layout.get(ty).and_then(|l| l.as_ref()));
+        }
+    }
+
     /// Get the trampoline type for the given function type index.
     ///
     /// Panics for non-function type indices.

--- a/crates/wasmtime/src/runtime/vm/gc.rs
+++ b/crates/wasmtime/src/runtime/vm/gc.rs
@@ -305,6 +305,14 @@ impl GcStore {
         self.gc_heap.ensure_trace_info(ty)
     }
 
+    /// Eagerly ensure tracing info is registered for all of the given types.
+    ///
+    /// More efficient than calling [`Self::ensure_trace_info`] in a loop; see
+    /// `GcHeap::ensure_trace_infos`.
+    pub fn ensure_trace_infos(&mut self, mut tys: impl Iterator<Item = VMSharedTypeIndex>) {
+        self.gc_heap.ensure_trace_infos(&mut tys)
+    }
+
     /// Allocate an uninitialized struct with the given type index and layout.
     ///
     /// This does NOT check that the index is currently allocated in the types

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/copying.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/copying.rs
@@ -736,6 +736,10 @@ unsafe impl GcHeap for CopyingHeap {
         self.trace_infos.ensure(ty);
     }
 
+    fn ensure_trace_infos(&mut self, tys: &mut dyn Iterator<Item = VMSharedTypeIndex>) {
+        self.trace_infos.ensure_many(tys);
+    }
+
     fn as_any(&self) -> &dyn Any {
         self as _
     }

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/drc.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/drc.rs
@@ -918,6 +918,10 @@ unsafe impl GcHeap for DrcHeap {
         self.trace_infos.ensure(ty);
     }
 
+    fn ensure_trace_infos(&mut self, tys: &mut dyn Iterator<Item = VMSharedTypeIndex>) {
+        self.trace_infos.ensure_many(tys);
+    }
+
     fn as_any(&self) -> &dyn Any {
         self as _
     }

--- a/crates/wasmtime/src/runtime/vm/gc/enabled/trace_info.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/enabled/trace_info.rs
@@ -133,19 +133,41 @@ impl TraceInfos {
         self.insert_new(ty);
     }
 
-    fn insert_new(&mut self, ty: VMSharedTypeIndex) {
-        debug_assert!(!self.map.contains_key(&ty));
+    /// Ensure that we have tracing information for all of the given types.
+    ///
+    /// More efficient than calling [`Self::ensure`] in a loop: the engine's
+    /// type registry is consulted only once for the whole batch of types that
+    /// are not already present, rather than once per type.
+    pub fn ensure_many(&mut self, tys: impl IntoIterator<Item = VMSharedTypeIndex>) {
+        let missing = tys
+            .into_iter()
+            .filter(|ty| !self.map.contains_key(ty))
+            .collect::<smallvec::SmallVec<[_; 32]>>();
+        if missing.is_empty() {
+            return;
+        }
 
         let engine = self.engine();
-        let Some(gc_layout) = engine.signatures().layout(ty) else {
-            // Not a GC type (e.g. a function type); no trace info needed.
-            return;
-        };
+        let gc_ref_array_elems_offset = self.gc_ref_array_elems_offset;
+        let map = &mut self.map;
+        engine
+            .signatures()
+            .for_each_layout(missing.iter().copied(), |ty, gc_layout| {
+                // Not a GC type (e.g. a function type); no trace info needed.
+                let Some(gc_layout) = gc_layout else {
+                    return;
+                };
+                let info = Self::info_for_layout(gc_layout, gc_ref_array_elems_offset);
+                let old_entry = map.insert(ty, info);
+                debug_assert!(old_entry.is_none());
+            });
+    }
 
-        let info = match gc_layout {
+    fn info_for_layout(gc_layout: &GcLayout, gc_ref_array_elems_offset: u32) -> TraceInfo {
+        match gc_layout {
             GcLayout::Array(l) => {
                 if l.elems_are_gc_refs {
-                    debug_assert_eq!(l.elem_offset(0), Some(self.gc_ref_array_elems_offset));
+                    debug_assert_eq!(l.elem_offset(0), Some(gc_ref_array_elems_offset));
                 }
                 TraceInfo::Array {
                     gc_ref_elems: l.elems_are_gc_refs,
@@ -158,7 +180,19 @@ impl TraceInfos {
                     .filter_map(|f| if f.is_gc_ref { Some(f.offset) } else { None })
                     .collect(),
             },
+        }
+    }
+
+    fn insert_new(&mut self, ty: VMSharedTypeIndex) {
+        debug_assert!(!self.map.contains_key(&ty));
+
+        let engine = self.engine();
+        let Some(gc_layout) = engine.signatures().layout(ty) else {
+            // Not a GC type (e.g. a function type); no trace info needed.
+            return;
         };
+
+        let info = Self::info_for_layout(&gc_layout, self.gc_ref_array_elems_offset);
 
         let old_entry = self.map.insert(ty, info);
         debug_assert!(old_entry.is_none());

--- a/crates/wasmtime/src/runtime/vm/gc/gc_runtime.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/gc_runtime.rs
@@ -122,6 +122,18 @@ pub unsafe trait GcHeap: 'static + Send + Sync {
     /// collector).
     fn ensure_trace_info(&mut self, _ty: VMSharedTypeIndex) {}
 
+    /// Bulk version of [`GcHeap::ensure_trace_info`].
+    ///
+    /// Collectors that derive tracing info from the engine's type registry
+    /// should override this to process the whole batch with a single registry
+    /// access, since acquiring the registry's lock once per type serializes
+    /// concurrent stores running on different threads.
+    fn ensure_trace_infos(&mut self, tys: &mut dyn Iterator<Item = VMSharedTypeIndex>) {
+        for ty in tys {
+            self.ensure_trace_info(ty);
+        }
+    }
+
     ////////////////////////////////////////////////////////////////////////////
     // `Any` methods
 

--- a/crates/wasmtime/src/runtime/vm/libcalls.rs
+++ b/crates/wasmtime/src/runtime/vm/libcalls.rs
@@ -616,7 +616,7 @@ fn is_subtype(
     let actual = VMSharedTypeIndex::from_u32(actual_engine_type);
     let expected = VMSharedTypeIndex::from_u32(expected_engine_type);
 
-    let is_subtype: bool = store.engine().signatures().is_subtype(actual, expected);
+    let is_subtype: bool = store.store_opaque_mut().is_subtype_cached(actual, expected);
 
     log::trace!("is_subtype(actual={actual:?}, expected={expected:?}) -> {is_subtype}",);
     is_subtype as u32


### PR DESCRIPTION
This is a set of commits which, combined, substantially improve GC performance, at least as measured for one mid-sized Kotlin component I've been testing. (Which I unfortunately can't share.)

While single-threaded performance improves substantially with the first commit, the other two only make a real difference when running multiple instances in parallel. In total, performance for 20 concurrent requests improves from 168 RPS to 17680 RPS:

| rev | concurrency=1 | concurrency=20 |
|-------|-----|------------|
|`main` | 239 | 168 |
| initial-heap-size=2MB | 1549 | 1809 |
| batched-trace-info | 1565 | 4050 |
| cached-subtype-checks | 1610 | 17681 |