### PR TITLE
Fix alias region used when initializing passive segments

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -5927,13 +5927,13 @@ impl FuncEnvironment<'_> {
                     let dst = builder
                         .ins()
                         .iadd_imm_s(base, i64::try_from(i.checked_mul(16).unwrap()).unwrap());
+                    let flags = self.element_segment_memflags(builder.func);
                     match ty.heap_type.top() {
                         WasmHeapTopType::Extern | WasmHeapTopType::Any | WasmHeapTopType::Exn => {
-                            let ty = WasmStorageType::Val(WasmValType::Ref(*ty));
-                            gc::init_field_at_addr(self, builder, ty, dst, val)?;
+                            gc::gc_compiler(self)?
+                                .translate_init_gc_reference(self, builder, *ty, dst, val, flags)?;
                         }
                         WasmHeapTopType::Func | WasmHeapTopType::Cont => {
-                            let flags = self.element_segment_memflags(builder.func);
                             builder.ins().store(
                                 flags,
                                 val,

--- a/tests/disas/startup-passive-segment.wat
+++ b/tests/disas/startup-passive-segment.wat
@@ -40,7 +40,7 @@
 ;; }
 ;;
 ;; function u2415919104:0(i64 vmctx, i64) tail {
-;;     region0 = 536870912 "GcHeap"
+;;     region0 = 2080374784 "ElementSegment"
 ;;     sig0 = (i64 vmctx, i32) -> i64 tail
 ;;     fn0 = colocated u805306368:4 sig0
 ;;
@@ -48,10 +48,10 @@
 ;;     v2 = iconst.i32 0
 ;;     v3 = call fn0(v0, v2)  ; v2 = 0
 ;;     v5 = iconst.i32 1
-;;     store user2 little region0 v5, v3  ; v5 = 1
+;;     store notrap aligned little region0 v5, v3  ; v5 = 1
 ;;     v24 = iconst.i32 3
 ;;     v16 = iconst.i64 16
 ;;     v17 = iadd v3, v16  ; v16 = 16
-;;     store user2 little region0 v24, v17  ; v24 = 3
+;;     store notrap aligned little region0 v24, v17  ; v24 = 3
 ;;     return
 ;; }


### PR DESCRIPTION
This commit fixes a minor mistake to use the right alias region when initializing a passive element segment during startup. This requires using a slightly different helper than was previously done for GC references because the element segment lives in a different region than the default GC heap.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
