### PR TITLE
Fix `AlwaysMut<T>` docs

### DIFF
--- a/crates/wasmtime/src/runtime/vm/always_mut.rs
+++ b/crates/wasmtime/src/runtime/vm/always_mut.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 
-/// A helper types that is `Send` if `T` is `Sync`.
+/// A helper type to make `T` become `Sync` if it is `Send`.
 ///
 /// This structure is a newtype wrapper around the `T` type parameter. What
 /// makes this a utility is the fact that it contains an `unsafe impl Sync`


### PR DESCRIPTION
Was previously saying it made `T` be `Send` when it is already `Sync`, but it is actually the other way around.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
