### PR TITLE
Debug assert that all memory instructions have alias regions

### DIFF
--- a/crates/cranelift/src/alias_region.rs
+++ b/crates/cranelift/src/alias_region.rs
@@ -2663,3 +2663,36 @@ where
         )
     }
 }
+
+/// Debug-assert that every CLIF memory instruction in `func` carries an alias
+/// region.
+///
+/// The Wasm-to-CLIF translation in `crates/cranelift/*` tags 100% of the memory
+/// instructions it emits (loads, stores, and atomics) with an alias region.
+/// This helper upholds that invariant; it is called at each
+/// `FunctionBuilder::finalize` site, after finalization so that the stack-map
+/// spills inserted by the safepoint pass (tagged via the
+/// `FunctionBuilder::make_stack_map_alias_region` hook) are checked too.
+pub(crate) fn debug_assert_all_mem_insts_have_alias_regions(func: &ir::Function) {
+    if cfg!(debug_assertions) {
+        for block in func.layout.blocks() {
+            for inst in func.layout.block_insts(block) {
+                // Only loads, stores, and atomics access memory. Some non-memory
+                // instructions (e.g. `bitcast`) also carry `MemFlags` purely for
+                // lane/byte-order and legitimately have no alias region, so they
+                // are excluded here.
+                let opcode = func.dfg.insts[inst].opcode();
+                if !opcode.can_load() && !opcode.can_store() {
+                    continue;
+                }
+                if let Some(flags) = func.dfg.insts[inst].memflags() {
+                    debug_assert!(
+                        func.dfg.mem_flags[flags].alias_region().is_some(),
+                        "CLIF memory instruction emitted without an alias region: {}",
+                        func.dfg.display_inst(inst),
+                    );
+                }
+            }
+        }
+    }
+}

--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -292,6 +292,9 @@ impl Compiler {
         );
         builder.ins().return_(&results);
         builder.finalize(self.isa().frontend_config());
+        crate::alias_region::debug_assert_all_mem_insts_have_alias_regions(
+            &compiler.cx.codegen_context.func,
+        );
 
         Ok(CompiledFunctionBody {
             code: box_dyn_any_compiler_context(Some(compiler.cx)),
@@ -402,6 +405,9 @@ impl Compiler {
             builder.ins().return_(&[]);
         }
         builder.finalize(self.isa().frontend_config());
+        crate::alias_region::debug_assert_all_mem_insts_have_alias_regions(
+            &compiler.cx.codegen_context.func,
+        );
 
         Ok(CompiledFunctionBody {
             code: box_dyn_any_compiler_context(Some(compiler.cx)),
@@ -1573,6 +1579,9 @@ impl Compiler {
         builder.ins().return_(&[false_return]);
 
         builder.finalize(self.isa().frontend_config());
+        crate::alias_region::debug_assert_all_mem_insts_have_alias_regions(
+            &compiler.cx.codegen_context.func,
+        );
 
         Ok(CompiledFunctionBody {
             code: box_dyn_any_compiler_context(Some(compiler.cx)),

--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -1722,6 +1722,9 @@ impl ComponentCompiler for Compiler {
 
         c.translate(&component.trampolines[trampoline_index]);
         c.builder.finalize(c.isa.frontend_config());
+        crate::alias_region::debug_assert_all_mem_insts_have_alias_regions(
+            &compiler.cx.codegen_context.func,
+        );
         compiler.cx.abi = Some(abi);
 
         Ok(CompiledFunctionBody {
@@ -1809,6 +1812,9 @@ impl ComponentCompiler for Compiler {
         }
 
         c.builder.finalize(c.isa.frontend_config());
+        crate::alias_region::debug_assert_all_mem_insts_have_alias_regions(
+            &compiler.cx.codegen_context.func,
+        );
         compiler.cx.abi = Some(abi);
 
         Ok(CompiledFunctionBody {

--- a/crates/cranelift/src/translate/func_translator.rs
+++ b/crates/cranelift/src/translate/func_translator.rs
@@ -118,6 +118,7 @@ impl FuncTranslator {
         parse_function_body(validator, reader, &mut builder, environ)?;
 
         builder.finalize(environ.target_config());
+        crate::alias_region::debug_assert_all_mem_insts_have_alias_regions(func);
         log::trace!("translated Wasm to CLIF:\n{}", func.display());
         Ok(())
     }
@@ -140,6 +141,7 @@ impl FuncTranslator {
         environ.after_translate_function(&mut builder)?;
         builder.ins().return_(&[]);
         builder.finalize(environ.target_config());
+        crate::alias_region::debug_assert_all_mem_insts_have_alias_regions(func);
         Ok(())
     }
 }


### PR DESCRIPTION
We should never emit a load/store instruction that isn't tagged with an alias region.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
