### PR TITLE
Fix precedence in `AliasRegionKey` module bits assert

### DIFF
--- a/crates/cranelift/src/alias_region.rs
+++ b/crates/cranelift/src/alias_region.rs
@@ -209,7 +209,7 @@ impl AliasRegionKey {
             AliasRegionKey::PublicMemory => Self::IMPORTED_MEMORY_KIND,
             AliasRegionKey::DefinedMemory { module, index } => {
                 debug_assert_eq!(
-                    module.as_u32() & !Self::MODULE_MASK >> Self::MODULE_OFFSET,
+                    module.as_u32() & !(Self::MODULE_MASK >> Self::MODULE_OFFSET),
                     0
                 );
                 debug_assert_eq!(index.as_u32() & !Self::INDEX_MASK, 0);
@@ -220,7 +220,7 @@ impl AliasRegionKey {
             AliasRegionKey::PublicTable => Self::IMPORTED_TABLE_KIND,
             AliasRegionKey::DefinedTable { module, index } => {
                 debug_assert_eq!(
-                    module.as_u32() & !Self::MODULE_MASK >> Self::MODULE_OFFSET,
+                    module.as_u32() & !(Self::MODULE_MASK >> Self::MODULE_OFFSET),
                     0
                 );
                 debug_assert_eq!(index.as_u32() & !Self::INDEX_MASK, 0);
@@ -229,7 +229,7 @@ impl AliasRegionKey {
             AliasRegionKey::PublicGlobal => Self::IMPORTED_GLOBAL_KIND,
             AliasRegionKey::DefinedGlobal { module, index } => {
                 debug_assert_eq!(
-                    module.as_u32() & !Self::MODULE_MASK >> Self::MODULE_OFFSET,
+                    module.as_u32() & !(Self::MODULE_MASK >> Self::MODULE_OFFSET),
                     0
                 );
                 debug_assert_eq!(index.as_u32() & !Self::INDEX_MASK, 0);


### PR DESCRIPTION
The `debug_assert` parsed as `module & (!MODULE_MASK >> MODULE_OFFSET)` rather than the intended `module & !(MODULE_MASK >> MODULE_OFFSET)`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
