### PR TITLE
Centralize handling of headers in wasi-http

### DIFF
--- a/crates/test-programs/src/bin/p3_http_forbidden_headers.rs
+++ b/crates/test-programs/src/bin/p3_http_forbidden_headers.rs
@@ -1,0 +1,22 @@
+use test_programs::p3::{
+    service::exports::wasi::http::handler::Guest as Handler,
+    wasi::http::{
+        client,
+        types::{ErrorCode, Request, Response, Scheme},
+    },
+};
+
+struct Component;
+
+test_programs::p3::service::export!(Component);
+
+impl Handler for Component {
+    async fn handle(request: Request) -> Result<Response, ErrorCode> {
+        request.set_scheme(Some(&Scheme::Http)).unwrap();
+        request.set_authority(Some("p3-test")).unwrap();
+        request.set_path_with_query(Some("/")).unwrap();
+        client::send(request).await
+    }
+}
+
+fn main() {}

--- a/crates/wasi-http/src/field_map.rs
+++ b/crates/wasi-http/src/field_map.rs
@@ -1,3 +1,4 @@
+use crate::WasiHttpHooks;
 use http::header::Entry;
 use http::{HeaderMap, HeaderName, HeaderValue};
 use std::fmt;
@@ -35,7 +36,11 @@ enum Limit {
 
 impl Default for FieldMap {
     fn default() -> Self {
-        Self::new_immutable(HeaderMap::default())
+        Self {
+            map: Arc::new(HeaderMap::new()),
+            size: 0,
+            limit: Limit::Immutable,
+        }
     }
 }
 
@@ -45,7 +50,20 @@ impl FieldMap {
     ///
     /// The returned value cannot be mutated and attempting to mutate it will
     /// return an error.
-    pub fn new_immutable(map: HeaderMap) -> Self {
+    pub fn new_immutable(hooks: &mut dyn WasiHttpHooks, mut map: HeaderMap) -> Self {
+        // Strip out all forbidden headers from `map` to ensure they're never
+        // able to enter into a WASI guest.
+        let forbidden_keys = Vec::from_iter(map.keys().filter_map(|name| {
+            if hooks.is_forbidden_header(name) {
+                Some(name.clone())
+            } else {
+                None
+            }
+        }));
+        for name in forbidden_keys {
+            map.remove(&name);
+        }
+
         let size = Self::content_size(&map);
         Self {
             map: Arc::new(map),
@@ -86,9 +104,22 @@ impl FieldMap {
     /// If `values` is empty then this removes the header `key`.
     //
     // FIXME(WebAssembly/WASI#900): is this the right behavior?
-    pub fn set(&mut self, key: HeaderName, values: Vec<HeaderValue>) -> Result<(), FieldMapError> {
+    pub fn set(
+        &mut self,
+        hooks: &mut dyn WasiHttpHooks,
+        key: String,
+        values: Vec<Vec<u8>>,
+    ) -> Result<(), FieldMapError> {
+        let key = key.parse()?;
+        if hooks.is_forbidden_header(&key) {
+            return Err(FieldMapError::Forbidden);
+        }
         let (map, limit, size) = self.mutable()?;
         let key_size = header_name_size(&key);
+        let values = values
+            .into_iter()
+            .map(|v| parse_header_value(&key, v))
+            .collect::<Result<Vec<_>, _>>()?;
         let values_size = values.iter().map(header_value_size).sum::<usize>();
         let mut values = values.into_iter();
         let mut entry = match map.try_entry(key)? {
@@ -124,7 +155,15 @@ impl FieldMap {
     /// Remove all values associated with a key in a map.
     ///
     /// Returns an empty list if the key is not already present within the map.
-    pub fn remove_all(&mut self, key: HeaderName) -> Result<Vec<HeaderValue>, FieldMapError> {
+    pub fn remove_all(
+        &mut self,
+        hooks: &mut dyn WasiHttpHooks,
+        key: String,
+    ) -> Result<Vec<HeaderValue>, FieldMapError> {
+        let key = key.parse()?;
+        if hooks.is_forbidden_header(&key) {
+            return Err(FieldMapError::Forbidden);
+        }
         let (map, _limit, size) = self.mutable()?;
         match map.try_entry(key)? {
             Entry::Vacant { .. } => Ok(Vec::new()),
@@ -152,7 +191,30 @@ impl FieldMap {
     ///
     /// If `key` is already present within the map then `value` is appended to
     /// the list of values it already has.
-    pub fn append(&mut self, key: HeaderName, value: HeaderValue) -> Result<bool, FieldMapError> {
+    pub fn append(
+        &mut self,
+        hooks: &mut dyn WasiHttpHooks,
+        key: String,
+        value: Vec<u8>,
+    ) -> Result<bool, FieldMapError> {
+        let key = key.parse()?;
+        if hooks.is_forbidden_header(&key) {
+            return Err(FieldMapError::Forbidden);
+        }
+        let value = parse_header_value(&key, value)?;
+        self.append_raw(key, value)
+    }
+
+    /// Add a value associated with a key to the map.
+    ///
+    /// If `key` is already present within the map then `value` is appended to
+    /// the list of values it already has.
+    ///  TODO
+    pub fn append_raw(
+        &mut self,
+        key: HeaderName,
+        value: HeaderValue,
+    ) -> Result<bool, FieldMapError> {
         let (map, limit, size) = self.mutable()?;
         let key_size = header_name_size(&key);
         let val_size = header_value_size(&value);
@@ -235,6 +297,10 @@ pub enum FieldMapError {
     TotalSizeTooBig,
     /// An invalid header name was attempted to be added.
     InvalidHeaderName,
+    /// An invalid header value was attempted to be added.
+    InvalidHeaderValue,
+    /// A forbidden header name was used.
+    Forbidden,
 }
 
 impl fmt::Display for FieldMapError {
@@ -244,6 +310,8 @@ impl fmt::Display for FieldMapError {
             FieldMapError::TooManyFields => "too many fields in the field map",
             FieldMapError::TotalSizeTooBig => "total size of fields exceeds limit",
             FieldMapError::InvalidHeaderName => "invalid header name",
+            FieldMapError::InvalidHeaderValue => "invalid header value",
+            FieldMapError::Forbidden => "forbidden header name",
         };
         f.write_str(s)
     }
@@ -263,23 +331,51 @@ impl From<http::header::InvalidHeaderName> for FieldMapError {
     }
 }
 
+impl From<http::header::InvalidHeaderValue> for FieldMapError {
+    fn from(_: http::header::InvalidHeaderValue) -> Self {
+        Self::InvalidHeaderValue
+    }
+}
+
+fn parse_header_value(
+    name: &http::HeaderName,
+    value: Vec<u8>,
+) -> Result<http::HeaderValue, FieldMapError> {
+    if name == http::header::CONTENT_LENGTH {
+        let s = str::from_utf8(value.as_ref()).or(Err(FieldMapError::InvalidHeaderValue))?;
+        // RFC 9110 defines `Content-Length` as `1*DIGIT`. `u64`'s `FromStr` is
+        // more lenient and also accepts a leading `+`, so reject anything that
+        // isn't a non-empty run of decimal digits.
+        if s.is_empty() || !s.bytes().all(|b| b.is_ascii_digit()) {
+            return Err(FieldMapError::InvalidHeaderValue);
+        }
+        let v: u64 = s.parse().or(Err(FieldMapError::InvalidHeaderValue))?;
+        Ok(v.into())
+    } else {
+        let value = value.try_into()?;
+        Ok(value)
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{FieldMap, FieldMapError};
+    use super::{FieldMap, FieldMapError, parse_header_value};
+    use crate::default_hooks;
+    use http::header::{CONTENT_LENGTH, CONTENT_TYPE};
 
     #[test]
     fn test_immutable() {
         let mut map = FieldMap::default();
         assert_eq!(
-            map.set("foo".parse().unwrap(), vec!["bar".parse().unwrap()]),
+            map.set(default_hooks(), "foo".to_owned(), vec![b"bar".to_vec()]),
             Err(FieldMapError::Immutable)
         );
         assert_eq!(
-            map.append("foo".parse().unwrap(), "bar".parse().unwrap()),
+            map.append(default_hooks(), "foo".to_owned(), b"bar".to_vec()),
             Err(FieldMapError::Immutable)
         );
         assert_eq!(
-            map.remove_all("foo".parse().unwrap()),
+            map.remove_all(default_hooks(), "foo".to_owned()),
             Err(FieldMapError::Immutable)
         );
     }
@@ -288,7 +384,7 @@ mod tests {
     fn test_limits() {
         let mut map = FieldMap::new_mutable(100);
         loop {
-            match map.append("foo".parse().unwrap(), "bar".parse().unwrap()) {
+            match map.append(default_hooks(), "foo".to_owned(), b"bar".to_vec()) {
                 Ok(_) => {}
                 Err(FieldMapError::TotalSizeTooBig) => break,
                 Err(e) => panic!("unexpected error: {e}"),
@@ -298,8 +394,9 @@ mod tests {
         map = FieldMap::new_mutable(100);
         for i in 0.. {
             match map.set(
-                "foo".parse().unwrap(),
-                (0..i).map(|j| format!("bar{j}").parse().unwrap()).collect(),
+                default_hooks(),
+                "foo".to_owned(),
+                (0..i).map(|j| format!("bar{j}").into_bytes()).collect(),
             ) {
                 Ok(_) => {}
                 Err(FieldMapError::TotalSizeTooBig) => break,
@@ -309,10 +406,7 @@ mod tests {
 
         map = FieldMap::new_mutable(100);
         for i in 0.. {
-            match map.set(
-                format!("foo{i}").parse().unwrap(),
-                vec!["bar".parse().unwrap()],
-            ) {
+            match map.set(default_hooks(), format!("foo{i}"), vec![b"bar".to_vec()]) {
                 Ok(_) => {}
                 Err(FieldMapError::TotalSizeTooBig) => break,
                 Err(e) => panic!("unexpected error: {e}"),
@@ -323,35 +417,48 @@ mod tests {
     #[test]
     fn test_size() -> Result<(), FieldMapError> {
         let mut map = FieldMap::new_mutable(2000);
-        let name: http::HeaderName = "foo".parse().unwrap();
+        let name = "foo".to_owned();
+        let hooks = default_hooks();
 
-        map.append(name.clone(), "bar".parse().unwrap())?;
+        map.append(hooks, name.clone(), b"bar".to_vec())?;
         assert!(map.size > 0);
-        map.remove_all(name.clone())?;
+        map.remove_all(hooks, name.clone())?;
         assert_eq!(map.size, 0);
 
-        map.set(name.clone(), vec!["bar".parse().unwrap()])?;
+        map.set(hooks, name.clone(), vec![b"bar".to_vec()])?;
         assert!(map.size > 0);
-        map.remove_all(name.clone())?;
+        map.remove_all(hooks, name.clone())?;
         assert_eq!(map.size, 0);
 
-        map.set(name.clone(), vec![])?;
+        map.set(hooks, name.clone(), vec![])?;
         assert_eq!(map.size, 0);
-        map.set(name.clone(), vec!["bar".parse().unwrap()])?;
+        map.set(hooks, name.clone(), vec![b"bar".to_vec()])?;
         assert!(map.size > 0);
-        map.set(name.clone(), vec![])?;
+        map.set(hooks, name.clone(), vec![])?;
         assert_eq!(map.size, 0);
 
-        map.set(name.clone(), vec!["bar".parse().unwrap()])?;
+        map.set(hooks, name.clone(), vec![b"bar".to_vec()])?;
         assert!(map.size > 0);
-        map.set(
-            name.clone(),
-            vec!["bar".parse().unwrap(), "baz".parse().unwrap()],
-        )?;
+        map.set(hooks, name.clone(), vec![b"bar".to_vec(), b"baz".to_vec()])?;
         assert!(map.size > 0);
-        map.remove_all(name.clone())?;
+        map.remove_all(hooks, name.clone())?;
         assert_eq!(map.size, 0);
 
         Ok(())
+    }
+
+    #[test]
+    fn content_length_rejects_non_digits() {
+        assert!(parse_header_value(&CONTENT_LENGTH, b"0".to_vec()).is_ok());
+        assert!(parse_header_value(&CONTENT_LENGTH, b"1234".to_vec()).is_ok());
+
+        // `u64::from_str` accepts these but they are not `1*DIGIT` per RFC 9110.
+        assert!(parse_header_value(&CONTENT_LENGTH, b"+5".to_vec()).is_err());
+        assert!(parse_header_value(&CONTENT_LENGTH, b"-5".to_vec()).is_err());
+        assert!(parse_header_value(&CONTENT_LENGTH, b" 5".to_vec()).is_err());
+        assert!(parse_header_value(&CONTENT_LENGTH, b"".to_vec()).is_err());
+
+        // other header names are unaffected
+        assert!(parse_header_value(&CONTENT_TYPE, b"text/plain".to_vec()).is_ok());
     }
 }

--- a/crates/wasi-http/src/handler.rs
+++ b/crates/wasi-http/src/handler.rs
@@ -997,7 +997,8 @@ impl<'a, T: Send> Prepared<'a, T> {
             Proxy::P3(guest) => {
                 let (request, body) = request.into_parts();
                 let request = http::Request::from_parts(request, body);
-                let (request, request_io_result) = p3::Request::from_http(request);
+                let hooks = view(store.data_mut()).hooks;
+                let (request, request_io_result) = p3::Request::from_http(hooks, request);
                 let request = view(store.data_mut()).table.push(request)?;
 
                 Ok(Prepared::P3 {

--- a/crates/wasi-http/src/p2/error.rs
+++ b/crates/wasi-http/src/p2/error.rs
@@ -117,8 +117,11 @@ impl From<FieldMapError> for HeaderError {
     fn from(err: FieldMapError) -> Self {
         match err {
             FieldMapError::Immutable => types::HeaderError::Immutable.into(),
-            FieldMapError::InvalidHeaderName => types::HeaderError::InvalidSyntax.into(),
+            FieldMapError::InvalidHeaderName | FieldMapError::InvalidHeaderValue => {
+                types::HeaderError::InvalidSyntax.into()
+            }
             FieldMapError::TooManyFields | FieldMapError::TotalSizeTooBig => HeaderError::trap(err),
+            FieldMapError::Forbidden => types::HeaderError::Forbidden.into(),
         }
     }
 }

--- a/crates/wasi-http/src/p2/types.rs
+++ b/crates/wasi-http/src/p2/types.rs
@@ -5,7 +5,7 @@ use crate::p2::{
     bindings::http::types::{self, Method, Scheme},
     body::{HostIncomingBody, HyperIncomingBody, HyperOutgoingBody},
 };
-use crate::{Error, FieldMap, WasiHttpCtxView, WasiHttpHooks};
+use crate::{Error, FieldMap, WasiHttpCtxView};
 use bytes::Bytes;
 use http_body_util::BodyExt;
 use hyper::body::Body;
@@ -13,24 +13,6 @@ use wasmtime::component::Resource;
 use wasmtime::{Result, bail};
 use wasmtime_wasi::p2::Pollable;
 use wasmtime_wasi::runtime::AbortOnDropJoinHandle;
-
-/// Removes forbidden headers from a [`FieldMap`].
-pub(crate) fn remove_forbidden_headers(
-    hooks: &mut dyn WasiHttpHooks,
-    headers: &mut http::HeaderMap,
-) {
-    let forbidden_keys = Vec::from_iter(headers.keys().filter_map(|name| {
-        if hooks.is_forbidden_header(name) {
-            Some(name.clone())
-        } else {
-            None
-        }
-    }));
-
-    for name in forbidden_keys {
-        headers.remove(&name);
-    }
-}
 
 impl From<http::Method> for types::Method {
     fn from(method: http::Method) -> Self {
@@ -100,7 +82,7 @@ impl WasiHttpCtxView<'_> {
         B: Body<Data = Bytes> + Send + 'static,
         B::Error: Into<Error>,
     {
-        let (mut parts, body) = req.into_parts();
+        let (parts, body) = req.into_parts();
         let body = body.map_err(Into::into).boxed_unsync();
         let body = HostIncomingBody::new(body);
         let authority = match parts.uri.authority() {
@@ -111,8 +93,7 @@ impl WasiHttpCtxView<'_> {
             },
         };
 
-        remove_forbidden_headers(self.hooks, &mut parts.headers);
-        let headers = FieldMap::new_immutable(parts.headers);
+        let headers = FieldMap::new_immutable(self.hooks, parts.headers);
 
         let req = HostIncomingRequest {
             method: parts.method,

--- a/crates/wasi-http/src/p2/types_impl.rs
+++ b/crates/wasi-http/src/p2/types_impl.rs
@@ -4,11 +4,11 @@ use crate::p2::bindings::http::types::{self, Method, Scheme, StatusCode, Trailer
 use crate::p2::body::{HostFutureTrailers, HostIncomingBody, HostOutgoingBody, StreamContext};
 use crate::p2::types::{
     HostFutureIncomingResponse, HostIncomingRequest, HostIncomingResponse, HostOutgoingRequest,
-    HostOutgoingResponse, HostResponseOutparam, remove_forbidden_headers,
+    HostOutgoingResponse, HostResponseOutparam,
 };
 use crate::p2::{HeaderError, HeaderResult, HttpError, HttpResult};
 use crate::{FieldMap, WasiHttpCtxView, get_content_length};
-use http::{HeaderName, HeaderValue};
+use http::HeaderName;
 use std::str::FromStr;
 use wasmtime::component::Resource;
 use wasmtime::{error::Context as _, format_err};
@@ -47,12 +47,7 @@ impl types::HostFields for WasiHttpCtxView<'_> {
         let mut fields = FieldMap::new_mutable(self.ctx.field_size_limit);
 
         for (header, value) in entries {
-            let header = HeaderName::from_bytes(header.as_bytes())?;
-            if self.hooks.is_forbidden_header(&header) {
-                return Err(types::HeaderError::Forbidden.into());
-            }
-            let value = HeaderValue::from_bytes(&value)?;
-            fields.append(header, value)?;
+            fields.append(self.hooks, header, value)?;
         }
 
         Ok(self.table.push(fields)?)
@@ -98,33 +93,16 @@ impl types::HostFields for WasiHttpCtxView<'_> {
         &mut self,
         fields: Resource<FieldMap>,
         name: String,
-        byte_values: Vec<Vec<u8>>,
+        values: Vec<Vec<u8>>,
     ) -> HeaderResult<()> {
-        let header = HeaderName::from_bytes(name.as_bytes())?;
-
-        if self.hooks.is_forbidden_header(&header) {
-            return Err(types::HeaderError::Forbidden.into());
-        }
-
-        let mut values = Vec::with_capacity(byte_values.len());
-        for value in byte_values {
-            values.push(HeaderValue::from_bytes(&value)?);
-        }
-
         let fields = self.table.get_mut(&fields)?;
-        fields.set(header, values)?;
+        fields.set(self.hooks, name, values)?;
         Ok(())
     }
 
     fn delete(&mut self, fields: Resource<FieldMap>, name: String) -> HeaderResult<()> {
-        let header = HeaderName::from_bytes(name.as_bytes())?;
-
-        if self.hooks.is_forbidden_header(&header) {
-            return Err(types::HeaderError::Forbidden.into());
-        }
-
         let fields = self.table.get_mut(&fields)?;
-        fields.remove_all(header)?;
+        fields.remove_all(self.hooks, name)?;
         Ok(())
     }
 
@@ -134,16 +112,8 @@ impl types::HostFields for WasiHttpCtxView<'_> {
         name: String,
         value: Vec<u8>,
     ) -> HeaderResult<()> {
-        let header = HeaderName::from_bytes(name.as_bytes())?;
-
-        if self.hooks.is_forbidden_header(&header) {
-            return Err(types::HeaderError::Forbidden.into());
-        }
-
-        let value = HeaderValue::from_bytes(&value)?;
-
         let fields = self.table.get_mut(&fields)?;
-        fields.append(header, value)?;
+        fields.append(self.hooks, name, value)?;
         Ok(())
     }
 
@@ -493,7 +463,7 @@ impl types::HostFutureTrailers for WasiHttpCtxView<'_> {
             _ => unreachable!(),
         };
 
-        let mut fields = match res {
+        let fields = match res {
             Ok(Some(fields)) => fields,
             Ok(None) => return Ok(Some(Ok(Ok(None)))),
             Err(e) => {
@@ -502,9 +472,9 @@ impl types::HostFutureTrailers for WasiHttpCtxView<'_> {
             }
         };
 
-        remove_forbidden_headers(self.hooks, &mut fields);
-
-        let ts = self.table.push(FieldMap::new_immutable(fields))?;
+        let ts = self
+            .table
+            .push(FieldMap::new_immutable(self.hooks, fields))?;
 
         Ok(Some(Ok(Ok(Some(ts)))))
     }
@@ -650,9 +620,8 @@ impl types::HostFutureIncomingResponse for WasiHttpCtxView<'_> {
                 }
             };
 
-        let (mut parts, body) = resp.into_parts();
-        remove_forbidden_headers(self.hooks, &mut parts.headers);
-        let headers = FieldMap::new_immutable(parts.headers);
+        let (parts, body) = resp.into_parts();
+        let headers = FieldMap::new_immutable(self.hooks, parts.headers);
 
         let resp = self.table.push(HostIncomingResponse {
             status: parts.status.as_u16(),

--- a/crates/wasi-http/src/p3/body.rs
+++ b/crates/wasi-http/src/p3/body.rs
@@ -537,7 +537,7 @@ where
                             }
                             Err(Ok(trailers)) => {
                                 let view = (self.getter)(store.data_mut());
-                                let trailers = FieldMap::new_immutable(trailers);
+                                let trailers = FieldMap::new_immutable(view.hooks, trailers);
                                 let trailers = view
                                     .table
                                     .push(trailers)

--- a/crates/wasi-http/src/p3/host/handler.rs
+++ b/crates/wasi-http/src/p3/host/handler.rs
@@ -102,15 +102,15 @@ impl<T> HostWithStore<T> for WasiHttp {
                 body.with_state(io).boxed_unsync()
             }
         };
-        let res = Response {
-            status,
-            headers: FieldMap::new_immutable(headers),
-            body: Body::Host {
-                body,
-                result_tx: res_result_tx,
-            },
-        };
         store.with(|mut store| {
+            let res = Response {
+                status,
+                headers: FieldMap::new_immutable(store.get().hooks, headers),
+                body: Body::Host {
+                    body,
+                    result_tx: res_result_tx,
+                },
+            };
             store
                 .get()
                 .table

--- a/crates/wasi-http/src/p3/host/types.rs
+++ b/crates/wasi-http/src/p3/host/types.rs
@@ -8,7 +8,6 @@ use crate::p3::bindings::http::types::{
 use crate::p3::body::Body;
 use crate::p3::{HeaderResult, HttpError, RequestOptionsResult};
 use crate::{WasiHttp, WasiHttpCtxView};
-use http::header::CONTENT_LENGTH;
 use std::sync::Arc;
 use wasmtime::component::{Access, FutureReader, Resource, ResourceTable, StreamReader};
 use wasmtime::error::Context as _;
@@ -136,25 +135,6 @@ fn parse_authority(authority: String) -> Result<http::uri::Authority, ()> {
     Ok(authority)
 }
 
-fn parse_header_value(
-    name: &http::HeaderName,
-    value: impl AsRef<[u8]>,
-) -> Result<http::HeaderValue, HeaderError> {
-    if name == CONTENT_LENGTH {
-        let s = str::from_utf8(value.as_ref()).or(Err(HeaderError::InvalidSyntax))?;
-        // RFC 9110 defines `Content-Length` as `1*DIGIT`. `u64`'s `FromStr` is
-        // more lenient and also accepts a leading `+`, so reject anything that
-        // isn't a non-empty run of decimal digits.
-        if s.is_empty() || !s.bytes().all(|b| b.is_ascii_digit()) {
-            return Err(HeaderError::InvalidSyntax);
-        }
-        let v: u64 = s.parse().or(Err(HeaderError::InvalidSyntax))?;
-        Ok(v.into())
-    } else {
-        http::HeaderValue::from_bytes(value.as_ref()).or(Err(HeaderError::InvalidSyntax))
-    }
-}
-
 impl HostFields for WasiHttpCtxView<'_> {
     fn new(&mut self) -> wasmtime::Result<Resource<Fields>> {
         push_fields(self.table, FieldMap::new_mutable(self.ctx.field_size_limit))
@@ -166,12 +146,7 @@ impl HostFields for WasiHttpCtxView<'_> {
     ) -> HeaderResult<Resource<Fields>> {
         let mut fields = FieldMap::new_mutable(self.ctx.field_size_limit);
         for (name, value) in entries {
-            let name = name.parse().or(Err(HeaderError::InvalidSyntax))?;
-            if self.hooks.is_forbidden_header(&name) {
-                return Err(HeaderError::Forbidden.into());
-            }
-            let value = parse_header_value(&name, value)?;
-            fields.append(name, value)?;
+            fields.append(self.hooks, name, value)?;
         }
         let fields = push_fields(self.table, fields).map_err(crate::p3::HeaderError::trap)?;
         Ok(fields)
@@ -199,27 +174,14 @@ impl HostFields for WasiHttpCtxView<'_> {
         &mut self,
         fields: Resource<Fields>,
         name: FieldName,
-        value: Vec<FieldValue>,
+        values: Vec<FieldValue>,
     ) -> HeaderResult<()> {
-        let name = name.parse().map_err(|_| HeaderError::InvalidSyntax)?;
-        if self.hooks.is_forbidden_header(&name) {
-            return Err(HeaderError::Forbidden.into());
-        }
-        let mut values = Vec::with_capacity(value.len());
-        for value in value {
-            let value = parse_header_value(&name, value)?;
-            values.push(value);
-        }
-        get_fields_mut(self.table, &fields)?.set(name, values)?;
+        get_fields_mut(self.table, &fields)?.set(self.hooks, name, values)?;
         Ok(())
     }
 
     fn delete(&mut self, fields: Resource<Fields>, name: FieldName) -> HeaderResult<()> {
-        let name = name.parse().map_err(|_| HeaderError::InvalidSyntax)?;
-        if self.hooks.is_forbidden_header(&name) {
-            return Err(HeaderError::Forbidden.into());
-        }
-        get_fields_mut(self.table, &fields)?.remove_all(name)?;
+        get_fields_mut(self.table, &fields)?.remove_all(self.hooks, name)?;
         Ok(())
     }
 
@@ -229,11 +191,8 @@ impl HostFields for WasiHttpCtxView<'_> {
         name: FieldName,
     ) -> HeaderResult<Vec<FieldValue>> {
         let name = name.parse().or(Err(HeaderError::InvalidSyntax))?;
-        if self.hooks.is_forbidden_header(&name) {
-            return Err(HeaderError::Forbidden.into());
-        }
         let values = get_fields_mut(self.table, &fields)?
-            .remove_all(name)?
+            .remove_all(self.hooks, name)?
             .into_iter();
         Ok(values.map(|value| value.as_bytes().into()).collect())
     }
@@ -244,12 +203,7 @@ impl HostFields for WasiHttpCtxView<'_> {
         name: FieldName,
         value: FieldValue,
     ) -> HeaderResult<()> {
-        let name = name.parse().or(Err(HeaderError::InvalidSyntax))?;
-        if self.hooks.is_forbidden_header(&name) {
-            return Err(HeaderError::Forbidden.into());
-        }
-        let value = parse_header_value(&name, value)?;
-        get_fields_mut(self.table, &fields)?.append(name, value)?;
+        get_fields_mut(self.table, &fields)?.append(self.hooks, name, value)?;
         Ok(())
     }
 
@@ -633,24 +587,6 @@ impl Host for WasiHttpCtxView<'_> {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_header_value;
-    use http::header::{CONTENT_LENGTH, CONTENT_TYPE};
-
-    #[test]
-    fn content_length_rejects_non_digits() {
-        assert!(parse_header_value(&CONTENT_LENGTH, "0").is_ok());
-        assert!(parse_header_value(&CONTENT_LENGTH, "1234").is_ok());
-
-        // `u64::from_str` accepts these but they are not `1*DIGIT` per RFC 9110.
-        assert!(parse_header_value(&CONTENT_LENGTH, "+5").is_err());
-        assert!(parse_header_value(&CONTENT_LENGTH, "-5").is_err());
-        assert!(parse_header_value(&CONTENT_LENGTH, " 5").is_err());
-        assert!(parse_header_value(&CONTENT_LENGTH, "").is_err());
-
-        // other header names are unaffected
-        assert!(parse_header_value(&CONTENT_TYPE, "text/plain").is_ok());
-    }
-
     #[test]
     fn authority_accepts_ipv6_and_validates_ports() {
         use super::parse_authority;

--- a/crates/wasi-http/src/p3/mod.rs
+++ b/crates/wasi-http/src/p3/mod.rs
@@ -37,10 +37,13 @@ impl From<FieldMapError> for HeaderError {
     fn from(e: FieldMapError) -> Self {
         match e {
             FieldMapError::Immutable => types::HeaderError::Immutable.into(),
-            FieldMapError::InvalidHeaderName => types::HeaderError::InvalidSyntax.into(),
+            FieldMapError::InvalidHeaderName | FieldMapError::InvalidHeaderValue => {
+                types::HeaderError::InvalidSyntax.into()
+            }
             FieldMapError::TooManyFields | FieldMapError::TotalSizeTooBig => {
                 types::HeaderError::SizeExceeded.into()
             }
+            FieldMapError::Forbidden => types::HeaderError::Forbidden.into(),
         }
     }
 }

--- a/crates/wasi-http/src/p3/request.rs
+++ b/crates/wasi-http/src/p3/request.rs
@@ -1,7 +1,10 @@
 use crate::p3::bindings::http::types::ErrorCode;
 use crate::p3::body::{Body, BodyExt as _, GuestBody};
 use crate::p3::{HttpError, HttpResult};
-use crate::{Error, FieldMap, RequestOptions, WasiHttpCtxView, WasiHttpView, get_content_length};
+use crate::{
+    Error, FieldMap, RequestOptions, WasiHttpCtxView, WasiHttpHooks, WasiHttpView,
+    get_content_length,
+};
 use bytes::Bytes;
 use http::header::HOST;
 use http::uri::{Authority, PathAndQuery, Scheme};
@@ -82,6 +85,7 @@ impl Request {
     ///
     /// Requests constructed this way will not perform any `Content-Length` validation.
     pub fn from_http<T>(
+        hooks: &mut dyn WasiHttpHooks,
         req: http::Request<T>,
     ) -> (
         Self,
@@ -111,7 +115,7 @@ impl Request {
             scheme,
             authority,
             path_and_query,
-            FieldMap::new_immutable(headers),
+            FieldMap::new_immutable(hooks, headers),
             None,
             body,
         )
@@ -209,7 +213,7 @@ impl Request {
             } else {
                 HeaderValue::from_static("")
             };
-            headers.append(HOST, host).map_err(HttpError::trap)?;
+            headers.append_raw(HOST, host).map_err(HttpError::trap)?;
         }
         let scheme = match scheme {
             None => hooks.default_scheme().ok_or(ErrorCode::HttpProtocolError)?,

--- a/crates/wasi-http/src/p3/response.rs
+++ b/crates/wasi-http/src/p3/response.rs
@@ -1,6 +1,6 @@
 use crate::p3::bindings::http::types::ErrorCode;
 use crate::p3::body::{Body, GuestBody};
-use crate::{Error, FieldMap, WasiHttpCtxView, WasiHttpView, get_content_length};
+use crate::{Error, FieldMap, WasiHttpCtxView, WasiHttpHooks, WasiHttpView, get_content_length};
 use bytes::Bytes;
 use http::StatusCode;
 use http_body_util::BodyExt as _;
@@ -90,6 +90,7 @@ impl Response {
 
     /// Convert [http::Response] into [Response].
     pub fn from_http<T>(
+        hooks: &mut dyn WasiHttpHooks,
         res: http::Response<T>,
     ) -> (
         Self,
@@ -104,7 +105,7 @@ impl Response {
 
         let wasi_response = Response {
             status: parts.status,
-            headers: FieldMap::new_immutable(parts.headers),
+            headers: FieldMap::new_immutable(hooks, parts.headers),
             body: Body::Host {
                 body: body.map_err(Into::into).boxed_unsync(),
                 result_tx,
@@ -125,6 +126,7 @@ impl Response {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::default_hooks;
     use core::future::Future;
     use core::pin::pin;
     use core::task::{Context, Poll, Waker};
@@ -138,7 +140,7 @@ mod tests {
             .body(Full::new(Bytes::from_static(b"hello wasm")))
             .unwrap();
 
-        let (wasi_resp, io_future) = Response::from_http(http_response);
+        let (wasi_resp, io_future) = Response::from_http(default_hooks(), http_response);
         assert_eq!(wasi_resp.status, StatusCode::OK);
         assert_eq!(
             wasi_resp.headers.get("x-custom-header").unwrap(),

--- a/crates/wasi-http/tests/all/p3/mod.rs
+++ b/crates/wasi-http/tests/all/p3/mod.rs
@@ -30,7 +30,7 @@ use wasmtime_wasi_http::{
 foreach_p3_http!(assert_test_exists);
 
 struct TestHooks {
-    request_body_tx: Option<oneshot::Sender<WasiBody>>,
+    request_tx: Option<oneshot::Sender<http::Request<WasiBody>>>,
 }
 
 impl WasiHttpHooks for TestHooks {
@@ -56,11 +56,7 @@ impl WasiHttpHooks for TestHooks {
     > {
         _ = fut;
         if let Some("p3-test") = request.uri().authority().map(|v| v.as_str()) {
-            _ = self
-                .request_body_tx
-                .take()
-                .unwrap()
-                .send(request.into_body());
+            _ = self.request_tx.take().unwrap().send(request);
             Box::new(async {
                 Ok((
                     http::Response::new(Default::default()),
@@ -89,13 +85,13 @@ struct Ctx {
 }
 
 impl Ctx {
-    fn new(request_body_tx: oneshot::Sender<WasiBody>) -> Self {
+    fn new(request_tx: oneshot::Sender<http::Request<WasiBody>>) -> Self {
         Self {
             table: ResourceTable::default(),
             wasi: WasiCtxBuilder::new().inherit_stdio().build(),
             http: WasiHttpCtx::new(),
             hooks: TestHooks {
-                request_body_tx: Some(request_body_tx),
+                request_tx: Some(request_tx),
             },
         }
     }
@@ -153,7 +149,7 @@ async fn run_cli(path: &str, server: &Server) -> wasmtime::Result<()> {
 async fn run_http<E: Into<Error> + 'static>(
     component_filename: &str,
     req: http::Request<impl Body<Data = Bytes, Error = E> + Send + Sync + 'static>,
-    request_body_tx: oneshot::Sender<WasiBody>,
+    request_tx: oneshot::Sender<http::Request<WasiBody>>,
 ) -> wasmtime::Result<Result<http::Response<Collected<Bytes>>, Option<ErrorCode>>> {
     let engine = test_programs_artifacts::engine(|config| {
         config.wasm_backtrace_details(wasmtime::WasmBacktraceDetails::Enable);
@@ -161,7 +157,7 @@ async fn run_http<E: Into<Error> + 'static>(
     });
     let component = Component::from_file(&engine, component_filename)?;
 
-    let mut store = Store::new(&engine, Ctx::new(request_body_tx));
+    let mut store = Store::new(&engine, Ctx::new(request_tx));
 
     let mut linker = Linker::new(&engine);
     wasmtime_wasi::p2::add_to_linker_async(&mut linker)
@@ -170,7 +166,7 @@ async fn run_http<E: Into<Error> + 'static>(
     wasmtime_wasi_http::p3::add_to_linker(&mut linker)
         .context("failed to link `wasi:http@0.3.x`")?;
     let service = Service::instantiate_async(&mut store, &component, &linker).await?;
-    let (req, io) = Request::from_http(req);
+    let (req, io) = Request::from_http(&mut store.data_mut().hooks, req);
     store
         .run_concurrent(async |store| {
             let (res, ()) = try_join!(
@@ -575,6 +571,7 @@ async fn p3_http_proxy() -> Result<()> {
             request_body_rx
                 .await
                 .unwrap()
+                .into_body()
                 .collect()
                 .await
                 .unwrap()
@@ -583,6 +580,57 @@ async fn p3_http_proxy() -> Result<()> {
     );
 
     assert_eq!(request_body, body.as_slice());
+    Ok(())
+}
+
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn p3_http_forbidden_headers() -> Result<()> {
+    let request = http::Request::builder()
+        .uri("http://localhost/")
+        .method(http::Method::GET)
+        .header("host", "victim.internal")
+        .header("connection", "close")
+        .header("custom-forbidden-header", "yes")
+        .header("foo", "bar");
+
+    let (request_tx, request_rx) = oneshot::channel();
+    let response = run_http(
+        P3_HTTP_FORBIDDEN_HEADERS_COMPONENT,
+        request.body(Empty::new())?,
+        request_tx,
+    )
+    .await?
+    .unwrap();
+    assert_eq!(response.status().as_u16(), 200);
+
+    // Grab the headers that actually reached the backend and assert that none
+    // of the forbidden inbound headers leaked across the trust boundary.
+    let outbound = request_rx.await.unwrap();
+    let headers = outbound.headers();
+
+    // Forbidden headers shouldn't have gotten forwarded.
+    assert!(
+        !headers
+            .get_all("host")
+            .iter()
+            .any(|v| v == "victim.internal"),
+        "inbound `host` leaked to backend: {headers:?}",
+    );
+    assert!(
+        headers.get("connection").is_none(),
+        "inbound `connection` leaked to backend: {headers:?}",
+    );
+    assert!(
+        headers.get("custom-forbidden-header").is_none(),
+        "inbound `custom-forbidden-header` leaked to backend: {headers:?}",
+    );
+
+    // Other headers, however, get forwarded.
+    assert_eq!(
+        headers.get("foo").map(|v| v.as_bytes()),
+        Some(b"bar".as_slice()),
+    );
+
     Ok(())
 }
 


### PR DESCRIPTION
This commit is a refactoring of the implementation of `wasi:http` to reduce duplication between WASIp2 and WASIp3. The change here is to move all header logic into the `FieldMap` type in `wasmtime-wasi-http` itself rather than duplicating it across WASIp{2,3}.

Closes #13801

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
