### PR TITLE
Use alignof instead of __alignof in C API val.h assertions

### DIFF
--- a/crates/c-api/include/wasmtime/val.h
+++ b/crates/c-api/include/wasmtime/val.h
@@ -343,6 +343,20 @@ typedef union wasmtime_val_raw {
   void *funcref;
 } wasmtime_val_raw_t;
 
+/**
+ * Portable ABI alignment operator.
+ *
+ * Uses `alignof` (C11/C++11) which returns the ABI alignment, unlike
+ * the GCC extension `__alignof` which returns the preferred alignment.
+ * Falls back to `__alignof` on MSVC which does not support `alignof`
+ * in C mode. Undef'd after use.
+ */
+#if defined(__cplusplus) || !defined(_MSC_VER)
+#define WASMTIME_ALIGNOF(t) alignof(t)
+#else
+#define WASMTIME_ALIGNOF(t) __alignof(t)
+#endif
+
 // Assert that the shape of this type is as expected since it needs to match
 // Rust.
 static inline void __wasmtime_val_assertions() {
@@ -350,12 +364,16 @@ static inline void __wasmtime_val_assertions() {
                     sizeof(wasmtime_valunion_t) <= 24,
                 "should be 16 bytes plus a pointer large (plus alignment on "
                 "some platforms)");
-  static_assert(__alignof(wasmtime_valunion_t) == __alignof(uint64_t),
+  static_assert(WASMTIME_ALIGNOF(wasmtime_valunion_t) ==
+                    WASMTIME_ALIGNOF(uint64_t),
                 "should be aligned to u64");
   static_assert(sizeof(wasmtime_val_raw_t) == 16, "should be 16 bytes large");
-  static_assert(__alignof(wasmtime_val_raw_t) == __alignof(uint64_t),
+  static_assert(WASMTIME_ALIGNOF(wasmtime_val_raw_t) ==
+                    WASMTIME_ALIGNOF(uint64_t),
                 "should be aligned to u64");
 }
+
+#undef WASMTIME_ALIGNOF
 
 /**
  * \typedef wasmtime_val_t


### PR DESCRIPTION
Closes #13733

The `static_assert` check in `val.h` used `__alignof` (a GCC extension), which returns the preferred alignment rather than the ABI alignment. On the i686 architecture, these two alignment values ​​for `uint64_t` differ (8 and 4, respectively), resulting in a false-positive compilation failure. This has been changed to use `alignof` (provided by `<stdalign.h>` in C11 and natively supported in C++11), as it returns the ABI alignment that actually determines struct layout.

samples: https://github.com/crowforkotlin/wasmtime_c_api_32bit_issues
issues & effect : #13733
references: https://en.cppreference.com/c/language/_Alignof
``` shell
> bash qemu-i686-test.sh
Compile OK. Running...
=== i686 (SysV ABI) layout probe ===

__alignof(uint64_t) = 8
_Alignof(uint64_t)  = 4
__alignof(int64_t)  = 8
_Alignof(int64_t)   = 4
__alignof(double)   = 8
_Alignof(double)    = 4

sizeof(wasmtime_val_t)    = 20
_Alignof(wasmtime_val_t)  = 4
__alignof(wasmtime_val_t) = 4
offsetof(kind)            = 0
offsetof(of)              = 4

sizeof(wasmtime_valunion_t)    = 16
_Alignof(wasmtime_valunion_t)  = 4
__alignof(wasmtime_valunion_t) = 4

sizeof(wasmtime_val_raw_t)  = 16
_Alignof(wasmtime_val_raw_t)= 4

=== static_assert passed ===
```
``` shell
> export WASMTIME_DIR=~/develop/github/wasmtime/
> export NDK=/home/crowf/Android/Sdk/ndk/28.2.13676358
> bash qemu-armv7a-test.sh
Compile OK. Running (needs sudo for unshare)...
=== armv7a (AAPCS32) layout probe ===

__alignof(uint64_t) = 8
_Alignof(uint64_t)  = 8
__alignof(int64_t)  = 8
_Alignof(int64_t)   = 8
__alignof(double)   = 8
_Alignof(double)    = 8

sizeof(wasmtime_val_t)    = 24
_Alignof(wasmtime_val_t)  = 8
__alignof(wasmtime_val_t) = 8
offsetof(kind)            = 0
offsetof(of)              = 8

sizeof(wasmtime_valunion_t)    = 16
_Alignof(wasmtime_valunion_t)  = 8
__alignof(wasmtime_valunion_t) = 8

sizeof(wasmtime_val_raw_t)  = 16
_Alignof(wasmtime_val_raw_t)= 8

=== static_assert passed ===
```