### PR TITLE
Set initial epoch deadline to `1` in `HostHandlerState::instantiate`

### DIFF
--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -1018,6 +1018,7 @@ fn setup_epoch_handler(
     // Profiling disabled but there's a global request timeout
     if cmd.run.common.wasm.timeout.is_some() || cmd.run.common.debug.debugger.is_some() {
         store.epoch_deadline_async_yield_and_update(1);
+        store.set_epoch_deadline(1);
     }
 
     Ok(Box::new(|_store| {}))


### PR DESCRIPTION
Setting the initial epoch deadline to `1` instead of the default `0` means that the deadline check doesn't immediately trigger. In local testing, this essentially eliminates the performance difference between `wasmtime serve` and `wasmtime serve -W timeout=1` for a Rust Hello World WASIp2 component. In absolute terms, that means it goes from about 120k RPS to 155k RPS.