### PR TITLE
Add a tunable knob for the GC heap initial size

### DIFF
--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -86,6 +86,9 @@ wasmtime_option_group! {
         /// Size, in bytes, of guard pages for the GC heap.
         pub gc_heap_guard_size: Option<u64>,
 
+        /// Initial allocated size for the GC heap.
+        pub gc_heap_initial_size: Option<u64>,
+
         /// Indicates whether an unmapped region of memory is placed before all
         /// linear memories.
         pub guard_before_linear_memory: Option<bool>,
@@ -977,6 +980,12 @@ impl CommonOptions {
         if let Some(size) = self.opts.gc_heap_reservation_for_growth {
             config.gc_heap_reservation_for_growth(size);
         }
+
+        #[cfg(feature = "gc")]
+        if let Some(size) = self.opts.gc_heap_initial_size {
+            config.gc_heap_initial_size(size);
+        }
+
         if let Some(enable) = self.opts.table_lazy_init {
             config.table_lazy_init(enable);
         }
@@ -1329,6 +1338,7 @@ impl CommonOptions {
                 gc_heap_reservation: Some(engine.get_gc_heap_reservation()),
                 gc_heap_reservation_for_growth: Some(engine.get_gc_heap_reservation_for_growth()),
                 gc_heap_guard_size: Some(engine.get_gc_heap_guard_size()),
+                gc_heap_initial_size: engine.get_gc_heap_initial_size(),
                 guard_before_linear_memory: Some(engine.get_guard_before_linear_memory()),
                 table_lazy_init: Some(engine.get_table_lazy_init()),
                 memory_init_cow: Some(engine.get_memory_init_cow()),

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -981,7 +981,6 @@ impl CommonOptions {
             config.gc_heap_reservation_for_growth(size);
         }
 
-        #[cfg(feature = "gc")]
         if let Some(size) = self.opts.gc_heap_initial_size {
             config.gc_heap_initial_size(size);
         }
@@ -1338,7 +1337,7 @@ impl CommonOptions {
                 gc_heap_reservation: Some(engine.get_gc_heap_reservation()),
                 gc_heap_reservation_for_growth: Some(engine.get_gc_heap_reservation_for_growth()),
                 gc_heap_guard_size: Some(engine.get_gc_heap_guard_size()),
-                gc_heap_initial_size: engine.get_gc_heap_initial_size(),
+                gc_heap_initial_size: Some(engine.get_gc_heap_initial_size()),
                 guard_before_linear_memory: Some(engine.get_guard_before_linear_memory()),
                 table_lazy_init: Some(engine.get_table_lazy_init()),
                 memory_init_cow: Some(engine.get_memory_init_cow()),

--- a/crates/environ/src/tunables.rs
+++ b/crates/environ/src/tunables.rs
@@ -179,6 +179,9 @@ define_tunables! {
         /// heaps.
         pub gc_heap_reservation_for_growth: u64,
 
+        /// The size, in bytes, to set as the minimum for GC heaps.
+        pub gc_heap_initial_size: u64,
+
         /// Whether or not GC heaps are allowed to be reallocated after initial
         /// allocation at runtime.
         ///
@@ -279,6 +282,7 @@ impl Tunables {
             gc_heap_guard_size: 0,
             gc_heap_reservation_for_growth: 0,
             gc_heap_may_move: true,
+            gc_heap_initial_size: 0,
             metadata_for_internal_asserts: false,
             metadata_for_gc_heap_corruption: true,
             branch_hinting: false,
@@ -341,15 +345,17 @@ impl Tunables {
 
     /// Get the GC heap's memory type, given our configured tunables.
     pub fn gc_heap_memory_type(&self) -> Memory {
+        // We *could* try to match the target architecture's page size, but that
+        // would require exercising a page size for memories that we don't
+        // otherwise support for Wasm; we conservatively avoid that, and just
+        // use the default Wasm page size, for now.
+        let page_size_log2 = 16;
+        let min = self.gc_heap_initial_size.div_ceil(1 << page_size_log2);
         Memory {
             idx_type: IndexType::I32,
-            limits: Limits { min: 0, max: None },
+            limits: Limits { min, max: None },
             shared: false,
-            // We *could* try to match the target architecture's page size, but that
-            // would require exercising a page size for memories that we don't
-            // otherwise support for Wasm; we conservatively avoid that, and just
-            // use the default Wasm page size, for now.
-            page_size_log2: 16,
+            page_size_log2,
         }
     }
 }

--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -862,7 +862,7 @@ impl WasmtimeConfig {
 
         // When using the pooling allocator, GC heap tunables must match memory
         // tunables.
-        if let InstanceAllocationStrategy::Pooling(_) = &self.strategy {
+        if let InstanceAllocationStrategy::Pooling(pcfg) = &self.strategy {
             let reservation = mcfg.gc_heap_reservation.max(mcfg.memory_reservation);
             mcfg.gc_heap_reservation = reservation;
             mcfg.memory_reservation = reservation;
@@ -880,6 +880,12 @@ impl WasmtimeConfig {
             // memory_may_move is not in MemoryConfig, but gc_heap_may_move
             // must not conflict. Set it to None so the default matches.
             mcfg.gc_heap_may_move = None;
+
+            // Don't let the initial size of a GC heap exceed the maximum
+            // allowed by the pooling allocator.
+            if let Some(amt) = mcfg.gc_heap_initial_size {
+                mcfg.gc_heap_initial_size = Some(amt.min(pcfg.max_memory_size as u64));
+            }
         }
 
         if !self.debug_symbols {

--- a/crates/fuzzing/src/generators/memory.rs
+++ b/crates/fuzzing/src/generators/memory.rs
@@ -128,6 +128,7 @@ pub struct MemoryConfig {
     pub gc_heap_guard_size: Option<u64>,
     pub gc_heap_reservation_for_growth: Option<u64>,
     pub gc_heap_may_move: Option<bool>,
+    pub gc_heap_initial_size: Option<u64>,
 }
 
 impl<'a> Arbitrary<'a> for MemoryConfig {
@@ -152,6 +153,7 @@ impl<'a> Arbitrary<'a> for MemoryConfig {
             gc_heap_guard_size: interesting_virtual_memory_size(u, 32)?,
             gc_heap_reservation_for_growth: interesting_virtual_memory_size(u, 30)?,
             gc_heap_may_move: u.arbitrary()?,
+            gc_heap_initial_size: interesting_virtual_memory_size(u, 22)?,
         })
     }
 }
@@ -195,6 +197,7 @@ impl MemoryConfig {
         cfg.opts.gc_heap_guard_size = self.gc_heap_guard_size;
         cfg.opts.gc_heap_reservation_for_growth = self.gc_heap_reservation_for_growth;
         cfg.opts.gc_heap_may_move = self.gc_heap_may_move;
+        cfg.opts.gc_heap_initial_size = self.gc_heap_initial_size;
 
         if let Some(enable) = self.cranelift_enable_heap_access_spectre_mitigations {
             cfg.codegen.cranelift.push((

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -162,8 +162,6 @@ pub struct Config {
     target: Option<target_lexicon::Triple>,
     #[cfg(feature = "gc")]
     collector: Collector,
-    #[cfg(feature = "gc")]
-    pub(crate) gc_heap_initial_size: u64,
     profiling_strategy: ProfilingStrategy,
     tunables: ConfigTunables,
 
@@ -278,8 +276,6 @@ impl Config {
             target: None,
             #[cfg(feature = "gc")]
             collector: Collector::default(),
-            #[cfg(feature = "gc")]
-            gc_heap_initial_size: 0,
             #[cfg(feature = "cache")]
             cache: None,
             profiling_strategy: ProfilingStrategy::None,
@@ -1420,18 +1416,25 @@ impl Config {
 
     /// Configures the initial size, in bytes, of each store's GC heap.
     ///
-    /// Wasm modules that use linear memories can set the memories' initial size,
-    /// to reduce the need for repeated growths before reaching a steady state.
-    /// Wasm modules that use GC heaps can't do so. To still avoid repeated
-    /// collect-and-grow ramp-up, this setting can be used to configure the
-    /// initial size of the GC heap. This is particularly useful in combination
-    /// with the pooling allocator, where allocated memory pages are still
-    /// committed lazily, meaning that the memory is not immediately backed by
-    /// physical pages.
+    /// By default all GC heaps start out at 0 bytes in size and must grow
+    /// upwards from there. Growth happens incrementally as GC pressure happens
+    /// and memory runs out. The amount being grown by is additionally a
+    /// heuristic of the size of the failed allocation. By providing an initial
+    /// size of a store's GC heap embedders can more tightly control initial
+    /// parameters to optimize workloads that might have a predictable pattern.
+    /// For example if workloads frequently have less than a certain threshold
+    /// of size then that could be configured as the initial size here to avoid
+    /// growths happening over time.
     ///
-    /// The size is rounded up to the GC heap's page size. Note that the
-    /// copying collector divides its heap into two semi-spaces, so only half
-    /// of the configured size is available for allocation under that
+    /// Note that like WebAssembly linear memories the GC heap does not start
+    /// with committed memory equal to this size. Instead memory is reserved,
+    /// but then lazily allocated by the OS on access. In other words it should
+    /// be relatively cheap to increase this value to help amortize initial
+    /// startup cost of wasm modules.
+    ///
+    /// The `bytse` size is rounded up to the GC heap's page size. Also note
+    /// that the copying collector divides its heap into two semi-spaces, so
+    /// only half of the configured size is available for allocation under that
     /// collector.
     ///
     /// This only configures the initially-allocated size of the GC heap; the
@@ -1441,9 +1444,8 @@ impl Config {
     /// in place).
     ///
     /// The default value for this is 0.
-    #[cfg(feature = "gc")]
     pub fn gc_heap_initial_size(&mut self, bytes: u64) -> &mut Self {
-        self.gc_heap_initial_size = bytes;
+        self.tunables.gc_heap_initial_size = Some(bytes);
         self
     }
 
@@ -4791,11 +4793,8 @@ impl Engine {
     }
 
     /// Returns the configured [`Config::gc_heap_initial_size`] value.
-    pub fn get_gc_heap_initial_size(&self) -> Option<u64> {
-        #[cfg(feature = "gc")]
-        return Some(self.config().gc_heap_initial_size);
-        #[cfg(not(feature = "gc"))]
-        return None;
+    pub fn get_gc_heap_initial_size(&self) -> u64 {
+        self.tunables().gc_heap_initial_size
     }
 
     /// Returns the configured [`Config::gc_heap_reservation_for_growth`] value.

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -162,6 +162,8 @@ pub struct Config {
     target: Option<target_lexicon::Triple>,
     #[cfg(feature = "gc")]
     collector: Collector,
+    #[cfg(feature = "gc")]
+    pub(crate) gc_heap_initial_size: u64,
     profiling_strategy: ProfilingStrategy,
     tunables: ConfigTunables,
 
@@ -276,6 +278,8 @@ impl Config {
             target: None,
             #[cfg(feature = "gc")]
             collector: Collector::default(),
+            #[cfg(feature = "gc")]
+            gc_heap_initial_size: 0,
             #[cfg(feature = "cache")]
             cache: None,
             profiling_strategy: ProfilingStrategy::None,
@@ -1411,6 +1415,35 @@ impl Config {
     #[cfg(feature = "gc")]
     pub fn collector(&mut self, collector: Collector) -> &mut Self {
         self.collector = collector;
+        self
+    }
+
+    /// Configures the initial size, in bytes, of each store's GC heap.
+    ///
+    /// Wasm modules that use linear memories can set the memories' initial size,
+    /// to reduce the need for repeated growths before reaching a steady state.
+    /// Wasm modules that use GC heaps can't do so. To still avoid repeated
+    /// collect-and-grow ramp-up, this setting can be used to configure the
+    /// initial size of the GC heap. This is particularly useful in combination
+    /// with the pooling allocator, where allocated memory pages are still
+    /// committed lazily, meaning that the memory is not immediately backed by
+    /// physical pages.
+    ///
+    /// The size is rounded up to the GC heap's page size. Note that the
+    /// copying collector divides its heap into two semi-spaces, so only half
+    /// of the configured size is available for allocation under that
+    /// collector.
+    ///
+    /// This only configures the initially-allocated size of the GC heap; the
+    /// heap can still grow beyond it on demand. It is separate from
+    /// [`Config::gc_heap_reservation`], which configures the size of the
+    /// virtual-memory reservation (and therefore how far the heap can grow
+    /// in place).
+    ///
+    /// The default value for this is 0.
+    #[cfg(feature = "gc")]
+    pub fn gc_heap_initial_size(&mut self, bytes: u64) -> &mut Self {
+        self.gc_heap_initial_size = bytes;
         self
     }
 
@@ -4755,6 +4788,14 @@ impl Engine {
     /// Returns the configured [`Config::gc_heap_reservation`] value.
     pub fn get_gc_heap_reservation(&self) -> u64 {
         self.tunables().gc_heap_reservation
+    }
+
+    /// Returns the configured [`Config::gc_heap_initial_size`] value.
+    pub fn get_gc_heap_initial_size(&self) -> Option<u64> {
+        #[cfg(feature = "gc")]
+        return Some(self.config().gc_heap_initial_size);
+        #[cfg(not(feature = "gc"))]
+        return None;
     }
 
     /// Returns the configured [`Config::gc_heap_reservation_for_growth`] value.

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -1432,10 +1432,7 @@ impl Config {
     /// be relatively cheap to increase this value to help amortize initial
     /// startup cost of wasm modules.
     ///
-    /// The `bytse` size is rounded up to the GC heap's page size. Also note
-    /// that the copying collector divides its heap into two semi-spaces, so
-    /// only half of the configured size is available for allocation under that
-    /// collector.
+    /// The `bytes` size is rounded up to the GC heap's page size.
     ///
     /// This only configures the initially-allocated size of the GC heap; the
     /// heap can still grow beyond it on demand. It is separate from

--- a/crates/wasmtime/src/engine/serialization.rs
+++ b/crates/wasmtime/src/engine/serialization.rs
@@ -334,6 +334,7 @@ impl Metadata<'_> {
             gc_heap_reservation,
             gc_heap_guard_size,
             gc_heap_may_move,
+            gc_heap_initial_size,
 
             // This doesn't affect compilation, it's just a runtime setting.
             gc_heap_reservation_for_growth: _,
@@ -432,6 +433,11 @@ impl Metadata<'_> {
             gc_heap_guard_size,
             other.gc_heap_guard_size,
             "GC heap guard size",
+        )?;
+        Self::check_int(
+            gc_heap_initial_size,
+            other.gc_heap_initial_size,
+            "GC heap initial size",
         )?;
         Self::check_bool(gc_heap_may_move, other.gc_heap_may_move, "GC heap may move")?;
 

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -1841,12 +1841,7 @@ impl StoreOpaque {
             use wasmtime_environ::packed_option::ReservedValue;
 
             let engine = store.engine();
-            let mut mem_ty = engine.tunables().gc_heap_memory_type();
-            let initial_bytes = engine.config().gc_heap_initial_size;
-            if initial_bytes > 0 {
-                let page_size = mem_ty.page_size();
-                mem_ty.limits.min = initial_bytes.div_ceil(page_size);
-            }
+            let mem_ty = engine.tunables().gc_heap_memory_type();
 
             ensure!(
                 engine.features().gc_types(),

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -1841,7 +1841,13 @@ impl StoreOpaque {
             use wasmtime_environ::packed_option::ReservedValue;
 
             let engine = store.engine();
-            let mem_ty = engine.tunables().gc_heap_memory_type();
+            let mut mem_ty = engine.tunables().gc_heap_memory_type();
+            let initial_bytes = engine.config().gc_heap_initial_size;
+            if initial_bytes > 0 {
+                let page_size = mem_ty.page_size();
+                mem_ty.limits.min = initial_bytes.div_ceil(page_size);
+            }
+
             ensure!(
                 engine.features().gc_types(),
                 "cannot allocate a GC store when GC is disabled at configuration time"

--- a/crates/wasmtime/src/runtime/store/gc.rs
+++ b/crates/wasmtime/src/runtime/store/gc.rs
@@ -929,6 +929,7 @@ fn should_collect_first(
 #[cfg(test)]
 mod tests {
     use super::should_collect_first;
+    use crate::{AsContextMut, Config, Engine, ExternRef, Result, Store};
 
     #[test]
     fn test_should_collect_first() {
@@ -965,5 +966,18 @@ mod tests {
         // enough space, and we want to amortize the cost of collections, so
         // grow first.
         assert_eq!(should_collect_first(16, 1024, 512), false);
+    }
+
+    #[test]
+    fn gc_heap_initial_size() -> Result<()> {
+        let mut config = Config::new();
+        config.gc_heap_initial_size(1 << 20);
+        let engine = Engine::new(&config)?;
+        let mut store = Store::new(&engine, ());
+        ExternRef::new(&mut store, 1)?;
+
+        let gc_store = store.as_context_mut().0.unwrap_gc_store();
+        assert_eq!(gc_store.gc_heap_capacity(), 1 << 20);
+        Ok(())
     }
 }

--- a/tests/all/gc.rs
+++ b/tests/all/gc.rs
@@ -3774,3 +3774,17 @@ fn pooling_gc_heap_failure_does_not_leak_memory_slot() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn initial_size_larger_than_reservation() -> Result<()> {
+    // This shouldn't panic/corrupt/etc, it should just allocate a larger heap.
+    let mut config = Config::new();
+    config.gc_heap_initial_size(4096 * 20);
+    config.gc_heap_reservation(4096);
+    let engine = Engine::new(&config)?;
+
+    let mut store = Store::new(&engine, ());
+    ExternRef::new(&mut store, 1)?;
+
+    Ok(())
+}


### PR DESCRIPTION
Splitting this out of #13822 with some fuzzing/testing integration, updated to be a `Tunable` field, and some edits to comments.