### PR TITLE
Ungate component-model-async with Winch

### DIFF
--- a/crates/test-util/src/wast.rs
+++ b/crates/test-util/src/wast.rs
@@ -410,7 +410,6 @@ impl Compiler {
                     || config.legacy_exceptions()
                     || config.stack_switching()
                     || config.legacy_exceptions()
-                    || config.component_model_async()
                 {
                     return true;
                 }

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -2442,8 +2442,7 @@ impl Config {
                     | WasmFeatures::GC_TYPES
                     | WasmFeatures::EXCEPTIONS
                     | WasmFeatures::LEGACY_EXCEPTIONS
-                    | WasmFeatures::STACK_SWITCHING
-                    | WasmFeatures::CM_ASYNC;
+                    | WasmFeatures::STACK_SWITCHING;
                 match self.compiler_target().architecture {
                     target_lexicon::Architecture::Aarch64(_) => {
                         unsupported |= WasmFeatures::THREADS;

--- a/tests/misc_testsuite/component-model/async/backpressure-deadlock.wast
+++ b/tests/misc_testsuite/component-model/async/backpressure-deadlock.wast
@@ -1,6 +1,5 @@
 ;;! component_model_async = true
 ;;! reference_types = true
-;;! gc_types = true
 ;;! multi_memory = true
 
 ;; - Component B asks component A to enable backpressure
@@ -43,30 +42,30 @@
       (export "f" (func async))
       (export "turn-on-backpressure" (func))
     ))
-    
+
     (core module $libc (memory (export "mem") 1))
     (core instance $libc (instantiate $libc))
-  
+
     (core func $f (canon lower (func $A "f") async (memory $libc "mem")))
     (core func $turn-on-backpressure (canon lower (func $A "turn-on-backpressure")))
     (core func $waitable-set.new (canon waitable-set.new))
     (core func $waitable.join (canon waitable.join))
     (core func $waitable-set.wait (canon waitable-set.wait (memory $libc "mem")))
-  
+
     (core module $m
       (import "" "f" (func $f (result i32)))
       (import "" "turn-on-backpressure" (func $turn-on-backpressure))
       (import "" "waitable-set.new" (func $waitable-set.new (result i32)))
       (import "" "waitable.join" (func $waitable.join (param i32 i32)))
       (import "" "waitable-set.wait" (func $waitable-set.wait (param i32 i32) (result i32)))
-  
+
       (func (export "f")
         (local $status i32)
         (local $set i32)
         call $turn-on-backpressure
-  
+
         (local.set $status (call $f))
-  
+
         ;; low 4 bits should be "STARTING == 0"
         (i32.ne
           (i32.const 0)
@@ -74,19 +73,19 @@
             (local.get $status)
             (i32.const 0xf)))
         if unreachable end
-  
+
         ;; make a new waitable set and join our subtask into it
         (local.set $set (call $waitable-set.new))
         (call $waitable.join
           (i32.shr_u (local.get $status) (i32.const 4))
           (local.get $set))
-  
+
         ;; block waiting for our task, which should deadlock (?)
         (call $waitable-set.wait (local.get $set) (i32.const 0))
         unreachable
       )
     )
-  
+
     (core instance $i (instantiate $m
       (with "" (instance
         (export "f" (func $f))
@@ -96,13 +95,13 @@
         (export "waitable-set.wait" (func $waitable-set.wait))
       ))
     ))
-  
+
     (func (export "f") async (canon lift (core func $i "f")))
   )
 
   (instance $B (instantiate $B (with "A" (instance $A))))
 
-  (func (export "f") (alias export $B "f"))  
+  (func (export "f") (alias export $B "f"))
 )
 
 (assert_trap (invoke "f") "deadlock detected")

--- a/tests/misc_testsuite/component-model/async/fused.wast
+++ b/tests/misc_testsuite/component-model/async/fused.wast
@@ -1,6 +1,5 @@
 ;;! component_model_async = true
 ;;! reference_types = true
-;;! gc_types = true
 ;;! multi_memory = true
 
 

--- a/tests/misc_testsuite/component-model/async/future-read.wast
+++ b/tests/misc_testsuite/component-model/async/future-read.wast
@@ -1,7 +1,6 @@
 ;;! component_model_async = true
 ;;! component_model_more_async_builtins = true
 ;;! reference_types = true
-;;! gc_types = true
 ;;! multi_memory = true
 
 ;; synchronous future.read; sync lift

--- a/tests/misc_testsuite/component-model/async/many-params-with-retptr.wast
+++ b/tests/misc_testsuite/component-model/async/many-params-with-retptr.wast
@@ -1,6 +1,5 @@
 ;;! component_model_async = true
 ;;! reference_types = true
-;;! gc_types = true
 ;;! multi_memory = true
 ;;! bulk_memory = true
 

--- a/tests/misc_testsuite/component-model/async/partial-stream-copies.wast
+++ b/tests/misc_testsuite/component-model/async/partial-stream-copies.wast
@@ -1,7 +1,6 @@
 ;;! component_model_async = true
 ;;! reference_types = true
 ;;! multi_memory = true
-;;! gc_types = true
 
 ;; This test has two components $C and $D, where $D imports and calls $C.transform
 ;;  $C.transform takes and returns a stream<u8>

--- a/tests/misc_testsuite/component-model/async/reenter-during-yield.wast
+++ b/tests/misc_testsuite/component-model/async/reenter-during-yield.wast
@@ -1,6 +1,5 @@
 ;;! component_model_async = true
 ;;! reference_types = true
-;;! gc_types = true
 ;;! multi_memory = true
 
 (component

--- a/tests/misc_testsuite/component-model/async/stackful.wast
+++ b/tests/misc_testsuite/component-model/async/stackful.wast
@@ -1,7 +1,6 @@
 ;;! component_model_async = true
 ;;! component_model_async_stackful = true
 ;;! reference_types = true
-;;! gc_types = true
 ;;! multi_memory = true
 
 ;; async lift; no callback

--- a/tests/misc_testsuite/component-model/async/subtask-wait.wast
+++ b/tests/misc_testsuite/component-model/async/subtask-wait.wast
@@ -1,6 +1,5 @@
 ;;! component_model_async = true
 ;;! reference_types = true
-;;! gc_types = true
 
 ;; This test previously caused Wasmtime to panic while handling a trap due to an
 ;; improperly disposed fiber.  That bug is fixed now, and this test helps ensure

--- a/tests/misc_testsuite/component-model/async/sync-streams.wast
+++ b/tests/misc_testsuite/component-model/async/sync-streams.wast
@@ -1,7 +1,6 @@
 ;;! component_model_async = true
 ;;! component_model_more_async_builtins = true
 ;;! reference_types = true
-;;! gc_types = true
 
 ;; This test calls sync stream.write in $C.get and sync stream.read in $C.set.
 ;; Both of these calls block because $C is first to the rendezvous. But since

--- a/tests/misc_testsuite/component-model/async/wait-forever.wast
+++ b/tests/misc_testsuite/component-model/async/wait-forever.wast
@@ -1,6 +1,5 @@
 ;;! component_model_async = true
 ;;! reference_types = true
-;;! gc_types = true
 ;;! multi_memory = true
 
 (component
@@ -39,11 +38,11 @@
     (import "child" (instance $child
       (export "run" (func async))
     ))
-             
+
     (core func $child-run (canon lower (func $child "run")))
     (core module $m
       (import "" "child-run" (func $child-run))
-  
+
       (func (export "run")
         (call $child-run))
     )
@@ -52,7 +51,7 @@
         (export "child-run" (func $child-run))
       ))
     ))
-  
+
     (func (export "run") async
       (canon lift (core func $i "run")))
   )

--- a/tests/misc_testsuite/component-model/async/wait-forever2.wast
+++ b/tests/misc_testsuite/component-model/async/wait-forever2.wast
@@ -1,6 +1,5 @@
 ;;! component_model_async = true
 ;;! reference_types = true
-;;! gc_types = true
 ;;! multi_memory = true
 
 (component


### PR DESCRIPTION
This is actually supported since #12940 where more instructions were filled out, so everything can be switched to "expected to work"

Closes #12404

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
