### PR TITLE
winch: Remove x64 specific cfg

### DIFF
--- a/tests/all/winch_engine_features.rs
+++ b/tests/all/winch_engine_features.rs
@@ -1,7 +1,3 @@
-// Skip entirely on unsupported architectures as different error messages will
-// be reported.
-#![cfg(target_arch = "x86_64")]
-
 use wasmtime::*;
 use wasmtime_test_macros::wasmtime_test;
 


### PR DESCRIPTION
The `wasmtime_test` macro already takes care of handling non-supported architectures per backend.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
