### PR TITLE
Fix missing rounding in gc initial size when fuzzing

### DIFF
--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -882,9 +882,14 @@ impl WasmtimeConfig {
             mcfg.gc_heap_may_move = None;
 
             // Don't let the initial size of a GC heap exceed the maximum
-            // allowed by the pooling allocator.
+            // allowed by the pooling allocator. Note that these sizes are
+            // rounded up to the wasm page size used by GC at this time as
+            // that's what happens internally.
             if let Some(amt) = mcfg.gc_heap_initial_size {
-                mcfg.gc_heap_initial_size = Some(amt.min(pcfg.max_memory_size as u64));
+                let page_size = 64 * 1024;
+                let amt = amt.next_multiple_of(page_size);
+                let max = (pcfg.max_memory_size as u64).next_multiple_of(page_size);
+                mcfg.gc_heap_initial_size = Some(amt.min(max));
             }
         }
 


### PR DESCRIPTION
This fixes and oversight from #13841 where the clamping done there during fuzzing was insufficient because the clamping happened pre-rounding which didn't match what Wasmtime did internally.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
