### PR TITLE
fix pulley LoadExtNameFar emitting wrong Reloc

### DIFF
--- a/cranelift/codegen/src/isa/pulley_shared/inst/emit.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/inst/emit.rs
@@ -152,18 +152,18 @@ fn pulley_emit<P>(
         }
 
         Inst::LoadExtNameFar { dst, name, offset } => {
-            let size = match P::pointer_width() {
+            let (reloc, size) = match P::pointer_width() {
                 PointerWidth::PointerWidth32 => {
                     enc::xconst32(sink, dst, 0);
-                    4
+                    (Reloc::Abs4, 4)
                 }
                 PointerWidth::PointerWidth64 => {
                     enc::xconst64(sink, dst, 0);
-                    8
+                    (Reloc::Abs8, 8)
                 }
             };
             let end = sink.cur_offset();
-            sink.add_reloc_at_offset(end - size, Reloc::Abs8, &**name, *offset);
+            sink.add_reloc_at_offset(end - size, reloc, &**name, *offset);
         }
 
         Inst::Call { info } => {


### PR DESCRIPTION
see https://bytecodealliance.zulipchat.com/#narrow/channel/217117-cranelift/topic/pulley32.20Reloc.20Abs8.20vs.20Abs4/with/609020698

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
