### PR TITLE
remove unused `MachInst::ref_type_regclass()` function

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -1179,10 +1179,6 @@ impl MachInst for Inst {
         128
     }
 
-    fn ref_type_regclass(_: &settings::Flags) -> RegClass {
-        RegClass::Int
-    }
-
     fn gen_block_start(
         is_indirect_branch_target: bool,
         is_forward_edge_cfi_enabled: bool,

--- a/cranelift/codegen/src/isa/pulley_shared/inst/mod.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/inst/mod.rs
@@ -599,10 +599,6 @@ where
         32
     }
 
-    fn ref_type_regclass(_settings: &settings::Flags) -> RegClass {
-        RegClass::Int
-    }
-
     fn function_alignment() -> FunctionAlignment {
         FunctionAlignment {
             minimum: 1,

--- a/cranelift/codegen/src/isa/riscv64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/mod.rs
@@ -867,10 +867,6 @@ impl MachInst for Inst {
         128
     }
 
-    fn ref_type_regclass(_settings: &settings::Flags) -> RegClass {
-        RegClass::Int
-    }
-
     fn function_alignment() -> FunctionAlignment {
         FunctionAlignment {
             minimum: 2,

--- a/cranelift/codegen/src/isa/s390x/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/emit_tests.rs
@@ -1,6 +1,7 @@
 use crate::ir::{MachMemFlags, TrapCode};
 use crate::isa::s390x::inst::*;
 use crate::isa::s390x::settings as s390x_settings;
+use crate::settings;
 
 #[cfg(test)]
 fn simm20_zero() -> SImm20 {

--- a/cranelift/codegen/src/isa/s390x/inst/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/mod.rs
@@ -5,7 +5,7 @@ use crate::ir::{ExternalName, MemFlagsData, Type, types};
 use crate::isa::s390x::abi::S390xMachineDeps;
 use crate::isa::{CallConv, FunctionAlignment};
 use crate::machinst::*;
-use crate::{CodegenError, CodegenResult, settings};
+use crate::{CodegenError, CodegenResult};
 use alloc::boxed::Box;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
@@ -1267,10 +1267,6 @@ impl MachInst for Inst {
 
     fn worst_case_island_growth() -> CodeOffset {
         0
-    }
-
-    fn ref_type_regclass(_: &settings::Flags) -> RegClass {
-        RegClass::Int
     }
 
     fn gen_dummy_use(reg: Reg) -> Inst {

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -1467,10 +1467,6 @@ impl MachInst for Inst {
         0
     }
 
-    fn ref_type_regclass(_: &settings::Flags) -> RegClass {
-        RegClass::Int
-    }
-
     fn is_safepoint(&self) -> bool {
         match self {
             Inst::CallKnown { .. } | Inst::CallUnknown { .. } => true,

--- a/cranelift/codegen/src/machinst/mod.rs
+++ b/cranelift/codegen/src/machinst/mod.rs
@@ -52,7 +52,6 @@ use crate::ir::{
 use crate::isa::FunctionAlignment;
 use crate::result::CodegenResult;
 use crate::settings;
-use crate::settings::Flags;
 use crate::value_label::ValueLabelsRanges;
 use alloc::string::String;
 use alloc::vec::Vec;
@@ -384,10 +383,6 @@ pub trait MachInst: Clone + Debug {
     /// label-use kinds always have wide enough range that islands are
     /// never required may leave this at zero.
     fn worst_case_island_growth() -> CodeOffset;
-
-    /// What is the register class used for reference types (GC-observable pointers)? Can
-    /// be dependent on compilation flags.
-    fn ref_type_regclass(_flags: &Flags) -> RegClass;
 
     /// Is this a safepoint?
     fn is_safepoint(&self) -> bool;


### PR DESCRIPTION
Was wondering what this function does, apparently unused. 

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
