### PR TITLE
Remove duplicated wasmtime-core/std feature

### DIFF
--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -327,7 +327,6 @@ std = [
   'once_cell',
   'wasmtime-fiber?/std',
   'pulley-interpreter/std',
-  'wasmtime-core/std',
   'addr2line?/std',
   "dep:rustix",
   "wasmtime-jit-icache-coherence",


### PR DESCRIPTION
https://github.com/bytecodealliance/wasmtime/blob/c911bb4155b3c6220a333c2c76e5ea2e1e24c209/crates/wasmtime/Cargo.toml#L325-L330

Left-over from https://github.com/bytecodealliance/wasmtime/pull/12407 . 