### PR TITLE
Simplify some wasmtime-core code with Rust 1.95

### DIFF
--- a/crates/core/src/array.rs
+++ b/crates/core/src/array.rs
@@ -51,11 +51,7 @@ pub fn array_try_from_fn<E, T, const N: usize>(
             }
         }
         let mut guard = DropGuard {
-            // Note .as_mut() would be ideal but requires 1.95, so we work around it
-            // SAFETY: We cast from an uninitialized ptr to an array of T to an array of uninitialized T
-            // The bit pattern is identical, and unstable provides the safe function transpose for this
-            // Turning a pointer to uninitialized memory into a mutable reference to uninitialized memory is a valid op
-            slice: unsafe { &mut *(result.as_mut_ptr().cast::<[MaybeUninit<T>; N]>()) },
+            slice: result.as_mut(),
             initialized: 0,
         };
         for (i, slot) in guard.slice.iter_mut().enumerate() {


### PR DESCRIPTION
Now that our MSRV encompasses this standard library function we can remove a stray `unsafe` block.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
