### PR TITLE
Migrate from `cfg-if` crate to `cfg_select!`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1027,7 +1027,6 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "capstone",
- "cfg-if",
  "clap",
  "cranelift",
  "cranelift-codegen",
@@ -4569,7 +4568,6 @@ dependencies = [
  "bumpalo",
  "bytes",
  "cc",
- "cfg-if",
  "cranelift-native",
  "encoding_rs",
  "env_logger 0.11.5",
@@ -4671,7 +4669,6 @@ dependencies = [
  "bytes",
  "bytesize",
  "capstone",
- "cfg-if",
  "clap",
  "clap_complete",
  "cranelift-codegen",
@@ -4937,7 +4934,6 @@ dependencies = [
 name = "wasmtime-internal-cranelift"
 version = "48.0.0"
 dependencies = [
- "cfg-if",
  "cranelift-codegen",
  "cranelift-control",
  "cranelift-entity",
@@ -4991,7 +4987,6 @@ version = "48.0.0"
 dependencies = [
  "backtrace",
  "cc",
- "cfg-if",
  "libc",
  "rustix 1.1.4",
  "wasmtime-environ",
@@ -5033,7 +5028,6 @@ dependencies = [
 name = "wasmtime-internal-jit-icache-coherence"
 version = "48.0.0"
 dependencies = [
- "cfg-if",
  "libc",
  "wasmtime-internal-core",
  "windows-sys 0.61.2",
@@ -5043,7 +5037,6 @@ dependencies = [
 name = "wasmtime-internal-unwinder"
 version = "48.0.0"
 dependencies = [
- "cfg-if",
  "cranelift-codegen",
  "log",
  "object 0.39.0",
@@ -5132,7 +5125,6 @@ dependencies = [
  "bytes",
  "cap-fs-ext",
  "cap-primitives",
- "cfg-if",
  "env_logger 0.11.5",
  "futures",
  "rand 0.10.1",
@@ -5240,7 +5232,6 @@ name = "wasmtime-wasi-tls"
 version = "48.0.0"
 dependencies = [
  "bytes",
- "cfg-if",
  "futures",
  "native-tls",
  "openssl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,6 @@ smallvec = { workspace = true }
 
 async-trait = { workspace = true }
 bytes = { workspace = true }
-cfg-if = { workspace = true }
 tokio = { workspace = true, optional = true, features = [ "signal", "macros" ] }
 hyper = { workspace = true, optional = true }
 http = { workspace = true, optional = true }
@@ -415,7 +414,6 @@ serde_json = "1.0.80"
 glob = "0.3.3"
 libfuzzer-sys = "0.4.10"
 walkdir = "2.5.0"
-cfg-if = "1.0"
 tempfile = "3.27.0"
 filecheck = "0.5.0"
 libc = { version = "0.2.185", default-features = true }

--- a/cranelift/Cargo.toml
+++ b/cranelift/Cargo.toml
@@ -18,7 +18,6 @@ name = "clif-util"
 path = "src/clif-util.rs"
 
 [dependencies]
-cfg-if = { workspace = true }
 cranelift-codegen = { workspace = true, features = [
     "disas",
     "trace-log",

--- a/cranelift/src/disasm.rs
+++ b/cranelift/src/disasm.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use cfg_if::cfg_if;
 use cranelift_codegen::ir::Function;
 use cranelift_codegen::ir::function::FunctionParameters;
 use cranelift_codegen::isa::TargetIsa;
@@ -36,8 +35,8 @@ pub fn print_traps(traps: &[MachTrap]) -> String {
     text
 }
 
-cfg_if! {
-    if #[cfg(feature = "disas")] {
+cfg_select! {
+    feature = "disas" => {
         pub fn print_disassembly(func: &Function, isa: &dyn TargetIsa, mem: &[u8]) -> Result<()> {
             #[cfg(feature = "pulley")]
             let is_pulley = match isa.triple().architecture {
@@ -89,7 +88,8 @@ cfg_if! {
             }
             Ok(())
         }
-    } else {
+    }
+    _ => {
         pub fn print_disassembly(_: &Function, _: &dyn TargetIsa, _: &[u8]) -> Result<()> {
             println!("\nNo disassembly available.");
             Ok(())

--- a/crates/cranelift/Cargo.toml
+++ b/crates/cranelift/Cargo.toml
@@ -27,7 +27,6 @@ gimli = { workspace = true, features = ['std'] }
 object = { workspace = true, features = ['write', 'std'] }
 smallvec = { workspace = true }
 thiserror = { workspace = true }
-cfg-if = { workspace = true }
 wasmtime-versioned-export-macros = { workspace = true }
 itertools = { workspace = true }
 pulley-interpreter = { workspace = true, optional = true }

--- a/crates/fiber/Cargo.toml
+++ b/crates/fiber/Cargo.toml
@@ -12,7 +12,6 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
-cfg-if = { workspace = true }
 wasmtime-environ = { workspace = true }
 wasmtime-versioned-export-macros = { workspace = true }
 

--- a/crates/fiber/src/lib.rs
+++ b/crates/fiber/src/lib.rs
@@ -18,22 +18,26 @@ use core::marker::PhantomData;
 use core::ops::Range;
 use wasmtime_environ::error::Error;
 
-cfg_if::cfg_if! {
-    if #[cfg(not(feature = "std"))] {
+cfg_select! {
+    not(feature = "std") => {
         mod nostd;
         use nostd as imp;
         mod stackswitch;
-    } else if #[cfg(miri)] {
+    }
+    miri => {
         mod miri;
         use miri as imp;
-    } else if #[cfg(windows)] {
+    }
+    windows => {
         mod windows;
         use windows as imp;
-    } else if #[cfg(unix)] {
+    }
+    unix => {
         mod unix;
         use unix as imp;
         mod stackswitch;
-    } else {
+    }
+    _ => {
         mod nostd;
         use nostd as imp;
         mod stackswitch;

--- a/crates/fiber/src/stackswitch.rs
+++ b/crates/fiber/src/stackswitch.rs
@@ -4,44 +4,53 @@
 // included modules below; their symbols are visible in the binary and
 // accessed via the `extern "C"` declarations below that.
 
-cfg_if::cfg_if! {
-    if #[cfg(target_arch = "aarch64")] {
+cfg_select! {
+    target_arch = "aarch64" => {
         mod aarch64;
         pub(crate) use supported::*;
         pub(crate) use aarch64::*;
-    } else if #[cfg(target_arch = "x86_64")] {
+    }
+    target_arch = "x86_64" => {
         mod x86_64;
         pub(crate) use supported::*;
         pub(crate) use x86_64::*;
-    } else if #[cfg(target_arch = "x86")] {
+    }
+    target_arch = "x86" => {
         mod x86;
         pub(crate) use supported::*;
         pub(crate) use x86::*;
-    } else if #[cfg(target_arch = "arm")] {
+    }
+    target_arch = "arm" => {
         mod arm;
         pub(crate) use supported::*;
         pub(crate) use arm::*;
-    } else if #[cfg(target_arch = "s390x")] {
+    }
+    target_arch = "s390x" => {
         mod s390x;
         pub(crate) use supported::*;
         pub(crate) use s390x::*;
-    } else if #[cfg(target_arch = "riscv64")]  {
+    }
+    target_arch = "riscv64" => {
         mod riscv64;
         pub(crate) use supported::*;
         pub(crate) use riscv64::*;
-    } else if #[cfg(all(target_arch = "riscv32", not(target_feature = "f"), not(target_feature = "v")))] {
+    }
+    all(target_arch = "riscv32", not(target_feature = "f"), not(target_feature = "v")) => {
         mod riscv32imac;
         pub(crate) use supported::*;
         pub(crate) use riscv32imac::*;
-    } else if #[cfg(target_arch = "loongarch64")]  {
+    }
+    target_arch = "loongarch64" => {
         mod loongarch64;
         pub(crate) use supported::*;
         pub(crate) use loongarch64::*;
-    } else if #[cfg(feature = "custom")] {
+    }
+    feature = "custom" => {
         mod custom;
         pub(crate) use supported::*;
         pub(crate) use custom::*;
-    } else {
+    }
+    _ => {
         // No support for this platform. Don't fail compilation though and
         // instead defer the error to happen at runtime when a fiber is created.
         // Should help keep compiles working and narrows the failure to only

--- a/crates/jit-icache-coherence/Cargo.toml
+++ b/crates/jit-icache-coherence/Cargo.toml
@@ -13,7 +13,6 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
-cfg-if = { workspace = true }
 wasmtime-core = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies.windows-sys]

--- a/crates/jit-icache-coherence/src/lib.rs
+++ b/crates/jit-icache-coherence/src/lib.rs
@@ -76,14 +76,16 @@
 
 use std::ffi::c_void;
 
-cfg_if::cfg_if! {
-    if #[cfg(target_os = "windows")] {
+cfg_select! {
+    target_os = "windows" => {
         mod win;
         use win as imp;
-    } else if #[cfg(miri)] {
+    }
+    miri => {
         mod miri;
         use crate::miri as imp;
-    } else {
+    }
+    _ => {
         mod libc;
         use crate::libc as imp;
     }

--- a/crates/jit-icache-coherence/src/libc.rs
+++ b/crates/jit-icache-coherence/src/libc.rs
@@ -102,15 +102,16 @@ mod details {
 
 #[cfg(all(target_arch = "riscv64", target_os = "linux"))]
 fn riscv_flush_icache(start: u64, end: u64) -> Result<()> {
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "one-core")] {
+    cfg_select! {
+        feature = "one-core" => {
             use std::arch::asm;
             let _ = (start, end);
             unsafe {
                 asm!("fence.i");
             };
             Ok(())
-        } else {
+        }
+        _ => {
             #[expect(non_upper_case_globals, reason = "matching C style")]
             match unsafe {
                 libc::syscall(

--- a/crates/unwinder/Cargo.toml
+++ b/crates/unwinder/Cargo.toml
@@ -18,7 +18,6 @@ workspace = true
 [dependencies]
 cranelift-codegen = { workspace = true, optional = true }
 log = { workspace = true }
-cfg-if = { workspace = true }
 object = { workspace = true }
 wasmtime-environ = { workspace = true }
 

--- a/crates/unwinder/src/arch/mod.rs
+++ b/crates/unwinder/src/arch/mod.rs
@@ -7,32 +7,36 @@
 //! All architectures have the same interface when exposed to the rest of the
 //! crate.
 
-cfg_if::cfg_if! {
-    if #[cfg(target_arch = "x86_64")] {
+cfg_select! {
+    target_arch = "x86_64" => {
         mod x86;
         use x86 as imp;
-    } else if #[cfg(target_arch = "aarch64")] {
+    }
+    target_arch = "aarch64" => {
         mod aarch64;
         use aarch64 as imp;
-    } else if #[cfg(target_arch = "s390x")] {
+    }
+    target_arch = "s390x" => {
         mod s390x;
         use s390x as imp;
-    } else if #[cfg(target_arch = "riscv64")] {
+    }
+    target_arch = "riscv64" => {
         mod riscv64;
         use riscv64 as imp;
     }
+    _ => {}
 }
 
 // Re re-export functions from the `imp` module with one set of `pub
 // use` declarations here so we can share doc-comments.
 
-cfg_if::cfg_if! {
-    if #[cfg(any(
+cfg_select! {
+    any(
         target_arch = "x86_64",
         target_arch = "aarch64",
         target_arch = "s390x",
-        target_arch = "riscv64"
-    ))] {
+        target_arch = "riscv64",
+    ) => {
         /// Get the current stack pointer (at the time this function is
         /// executing). This may be used to check, e.g., approximate space
         /// remaining on a stack, but cannot be relied upon for anything exact
@@ -140,4 +144,5 @@ cfg_if::cfg_if! {
             }
         }
     }
+    _ => {}
 }

--- a/crates/wasi-tls/Cargo.toml
+++ b/crates/wasi-tls/Cargo.toml
@@ -33,7 +33,6 @@ tokio = { workspace = true, features = [
 wasmtime = { workspace = true, features = ["runtime", "component-model"] }
 wasmtime-wasi = { workspace = true }
 tracing = { workspace = true, optional = true }
-cfg-if = { workspace = true }
 tokio-rustls = { workspace = true, optional = true }
 rustls = { workspace = true, optional = true }
 webpki-roots = { workspace = true, optional = true }

--- a/crates/wasi-tls/src/providers/mod.rs
+++ b/crates/wasi-tls/src/providers/mod.rs
@@ -15,14 +15,17 @@ mod nativetls;
 #[cfg(feature = "nativetls")]
 pub use nativetls::NativeTlsProvider;
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "rustls")] {
+cfg_select! {
+    feature = "rustls" => {
         pub use RustlsProvider as DefaultProvider;
-    } else if #[cfg(feature = "openssl")] {
+    }
+    feature = "openssl" => {
         pub use OpenSslProvider as DefaultProvider;
-    } else if #[cfg(feature = "nativetls")] {
+    }
+    feature = "nativetls" => {
         pub use NativeTlsProvider as DefaultProvider;
-    } else {
+    }
+    _ => {
         pub use UnsupportedProvider as DefaultProvider;
     }
 }

--- a/crates/wasi/Cargo.toml
+++ b/crates/wasi/Cargo.toml
@@ -33,7 +33,6 @@ async-trait = { workspace = true }
 futures = { workspace = true }
 url = { workspace = true }
 rand = { workspace = true, features = ['std_rng', 'thread_rng'] }
-cfg-if = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["time", "sync", "io-std", "io-util", "rt", "rt-multi-thread", "net", "macros", "fs"] }

--- a/crates/wasi/src/filesystem/unix.rs
+++ b/crates/wasi/src/filesystem/unix.rs
@@ -34,8 +34,8 @@ pub(crate) fn get_flags(file: &File) -> io::Result<DescriptorFlags> {
 }
 
 pub(crate) fn advise(file: &File, offset: u64, len: u64, advice: Advice) -> io::Result<()> {
-    cfg_if::cfg_if! {
-        if #[cfg(target_vendor = "apple")] {
+    cfg_select! {
+        target_vendor = "apple" => {
             match advice {
                 Advice::WillNeed => {
                     rustix::fs::fcntl_rdadvise(file, offset, len)?;
@@ -46,7 +46,8 @@ pub(crate) fn advise(file: &File, offset: u64, len: u64, advice: Advice) -> io::
                 Advice::DontNeed |
                 Advice::NoReuse => {}
             }
-        } else if #[cfg(any(target_os = "linux", target_os = "android"))] {
+        }
+        any(target_os = "linux", target_os = "android") => {
             use std::num::NonZeroU64;
             let advice = match advice {
                 Advice::Normal => rustix::fs::Advice::Normal,
@@ -57,7 +58,8 @@ pub(crate) fn advise(file: &File, offset: u64, len: u64, advice: Advice) -> io::
                 Advice::NoReuse => rustix::fs::Advice::NoReuse,
             };
             rustix::fs::fadvise(file, offset, NonZeroU64::new(len), advice)?;
-        } else {
+        }
+        _ => {
             // noop on other platforms
             let _ = (file, offset, len, advice);
         }

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -39,7 +39,6 @@ wasm-compose = { workspace = true, optional = true }
 wit-parser = { workspace = true, optional = true }
 tempfile = { workspace = true, optional = true }
 libc = { workspace = true }
-cfg-if = { workspace = true }
 log = { workspace = true }
 wat = { workspace = true, optional = true }
 serde = { workspace = true }

--- a/crates/wasmtime/src/profiling_agent.rs
+++ b/crates/wasmtime/src/profiling_agent.rs
@@ -1,10 +1,11 @@
 use crate::prelude::*;
 
-cfg_if::cfg_if! {
-    if #[cfg(all(feature = "profiling", target_os = "linux"))] {
+cfg_select! {
+    all(feature = "profiling", target_os = "linux") => {
         mod jitdump;
         pub use jitdump::new as new_jitdump;
-    } else {
+    }
+    _ => {
         pub fn new_jitdump() -> Result<Box<dyn ProfilingAgent>> {
             if cfg!(feature = "profiling") {
                 bail!("jitdump is not supported on this platform");
@@ -15,21 +16,22 @@ cfg_if::cfg_if! {
     }
 }
 
-cfg_if::cfg_if! {
-    if #[cfg(all(unix, feature = "std"))] {
+cfg_select! {
+    all(unix, feature = "std") => {
         mod perfmap;
         pub use perfmap::new as new_perfmap;
-    } else {
+    }
+    _ => {
         pub fn new_perfmap() -> Result<Box<dyn ProfilingAgent>> {
             bail!("perfmap support not supported on this platform");
         }
     }
 }
 
-cfg_if::cfg_if! {
+cfg_select! {
     // Note that the `#[cfg]` here should be kept in sync with the
     // corresponding dependency directive on `ittapi` in `Cargo.toml`.
-    if #[cfg(all(
+    all(
         feature = "profiling",
         target_arch = "x86_64",
         any(
@@ -37,10 +39,11 @@ cfg_if::cfg_if! {
             target_os = "macos",
             target_os = "linux",
         ),
-    ))] {
+    ) => {
         mod vtune;
         pub use vtune::new as new_vtune;
-    } else {
+    }
+    _ => {
         pub fn new_vtune() -> Result<Box<dyn ProfilingAgent>> {
             if cfg!(feature = "profiling") {
                 bail!("VTune is not supported on this platform.");
@@ -51,11 +54,12 @@ cfg_if::cfg_if! {
     }
 }
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "profile-pulley")] {
+cfg_select! {
+    feature = "profile-pulley" => {
         mod pulley;
         pub use pulley::new as new_pulley;
-    } else {
+    }
+    _ => {
         pub fn new_pulley() -> Result<Box<dyn ProfilingAgent>> {
             bail!("pulley profiling support disabled at compile time.");
         }

--- a/crates/wasmtime/src/runtime.rs
+++ b/crates/wasmtime/src/runtime.rs
@@ -68,16 +68,20 @@ pub(crate) mod vm;
 #[cfg(feature = "component-model")]
 pub mod component;
 
-cfg_if::cfg_if! {
-    if #[cfg(miri)] {
+cfg_select! {
+    miri => {
         // no extensions on miri
-    } else if #[cfg(not(feature = "std"))] {
+    }
+    not(feature = "std") => {
         // no extensions on no-std
-    } else if #[cfg(unix)] {
+    }
+    unix => {
         pub mod unix;
-    } else if #[cfg(windows)] {
+    }
+    windows => {
         pub mod windows;
-    } else {
+    }
+    _ => {
         // ... unknown os!
     }
 }

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -2020,8 +2020,8 @@ impl StoreOpaque {
             return fault;
         }
 
-        cfg_if::cfg_if! {
-            if #[cfg(feature = "std")] {
+        cfg_select! {
+            feature = "std" => {
                 // With the standard library a rich error can be printed here
                 // to stderr and the native abort path is used.
                 eprintln!(
@@ -2045,14 +2045,16 @@ at https://bytecodealliance.org/security.
 "
                 );
                 std::process::abort();
-            } else if #[cfg(panic = "abort")] {
+            }
+            panic = "abort" => {
                 // Without the standard library but with `panic=abort` then
                 // it's safe to panic as that's known to halt execution. For
                 // now avoid the above error message as well since without
                 // `std` it's probably best to be a bit more size-conscious.
                 let _ = pc;
                 panic!("invalid fault");
-            } else {
+            }
+            _ => {
                 // Without `std` and with `panic = "unwind"` there's no
                 // dedicated API to abort the process portably, so manufacture
                 // this with a double-panic.

--- a/crates/wasmtime/src/runtime/v128.rs
+++ b/crates/wasmtime/src/runtime/v128.rs
@@ -74,8 +74,6 @@ impl Ord for V128 {
     }
 }
 
-// Note that this trait is conditionally implemented which is intentional. See
-// the documentation above in the `cfg_if!` for why this is conditional.
 unsafe impl WasmTy for V128 {
     #[inline]
     fn valtype() -> ValType {

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -159,12 +159,13 @@ mod send_sync_unsafe_cell;
 #[allow(unused, reason = "hard to cfg on/off, weird feature interactions")]
 pub use send_sync_unsafe_cell::SendSyncUnsafeCell;
 
-cfg_if::cfg_if! {
-    if #[cfg(has_virtual_memory)] {
+cfg_select! {
+    has_virtual_memory => {
         pub use crate::runtime::vm::byte_count::*;
         pub use crate::runtime::vm::mmap::{Mmap, MmapOffset};
         pub use self::cow::{MemoryImage, MemoryImageSlot, ModuleMemoryImages};
-    } else {
+    }
+    _ => {
         pub use self::cow_disabled::{MemoryImage, MemoryImageSlot, ModuleMemoryImages};
     }
 }

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling.rs
@@ -33,10 +33,11 @@ mod generic_stack_pool;
 mod unix_stack_pool;
 
 #[cfg(all(feature = "async"))]
-cfg_if::cfg_if! {
-    if #[cfg(all(unix, not(miri), not(asan)))] {
+cfg_select! {
+    all(unix, not(miri), not(asan)) => {
         use unix_stack_pool as stack_pool;
-    } else {
+    }
+    _ => {
         use generic_stack_pool as stack_pool;
     }
 }

--- a/crates/wasmtime/src/runtime/vm/mpk/mod.rs
+++ b/crates/wasmtime/src/runtime/vm/mpk/mod.rs
@@ -29,18 +29,19 @@
 //! On any other kind of machine, this module exposes noop implementations of
 //! the public interface.
 
-cfg_if::cfg_if! {
-    if #[cfg(all(
+cfg_select! {
+    all(
         target_arch = "x86_64",
         target_os = "linux",
         feature = "memory-protection-keys",
         not(miri),
-    ))] {
+    ) => {
         mod enabled;
         mod pkru;
         mod sys;
         pub use enabled::*;
-    } else {
+    }
+    _ => {
         mod disabled;
         pub use disabled::*;
     }

--- a/crates/wasmtime/src/runtime/vm/stack_switching/stack.rs
+++ b/crates/wasmtime/src/runtime/vm/stack_switching/stack.rs
@@ -7,11 +7,12 @@ use core::ops::Range;
 use crate::runtime::vm::stack_switching::VMHostArray;
 use crate::runtime::vm::{VMContext, VMFuncRef, ValRaw};
 
-cfg_if::cfg_if! {
-    if #[cfg(all(feature = "stack-switching", unix, target_arch = "x86_64"))] {
+cfg_select! {
+    all(feature = "stack-switching", unix, target_arch = "x86_64") => {
         mod unix;
         use unix as imp;
-    } else {
+    }
+    _ => {
         mod dummy;
         use dummy as imp;
     }

--- a/crates/wasmtime/src/runtime/vm/stack_switching/stack/unix.rs
+++ b/crates/wasmtime/src/runtime/vm/stack_switching/stack/unix.rs
@@ -363,11 +363,12 @@ unsafe extern "C" fn fiber_start(
     }
 }
 
-cfg_if::cfg_if! {
-    if #[cfg(target_arch = "x86_64")] {
+cfg_select! {
+    target_arch = "x86_64" => {
         mod x86_64;
         use x86_64::*;
-    } else {
+    }
+    _ => {
         // Note that this should be unreachable: In stack.rs, we currently select
         // the module defined in the current file only if we are on unix AND
         // x86_64.

--- a/crates/wasmtime/src/runtime/vm/sys/mod.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/mod.rs
@@ -49,20 +49,24 @@ fn empty_mmap() -> SendSyncPtr<[u8]> {
     SendSyncPtr::from(empty)
 }
 
-cfg_if::cfg_if! {
-    if #[cfg(miri)] {
+cfg_select! {
+    miri => {
         mod miri;
         pub use miri::*;
-    } else if #[cfg(not(feature = "std"))] {
+    }
+    not(feature = "std") => {
         mod custom;
         pub use custom::*;
-    } else if #[cfg(windows)] {
+    }
+    windows => {
         mod windows;
         pub use windows::*;
-    } else if #[cfg(unix)] {
+    }
+    unix => {
         mod unix;
         pub use unix::*;
-    } else {
+    }
+    _ => {
         mod custom;
         pub use custom::*;
     }

--- a/crates/wasmtime/src/runtime/vm/sys/unix/machports.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/machports.rs
@@ -311,8 +311,8 @@ unsafe fn handle_exception(request: &mut ExceptionRequest) -> bool {
     //   parameters as the first two arguments.
     // * `thread_state` - a fresh instance of `ThreadState` to read into
     // * `thread_state_count` - the size to pass to `mach_msg`.
-    cfg_if::cfg_if! {
-        if #[cfg(target_arch = "x86_64")] {
+    cfg_select! {
+        target_arch = "x86_64" => {
             use mach2::structs::x86_thread_state64_t;
             use mach2::thread_status::x86_THREAD_STATE64;
 
@@ -359,7 +359,8 @@ unsafe fn handle_exception(request: &mut ExceptionRequest) -> bool {
                 state.__r8 = trap.as_u8().into();
             };
             let mut thread_state = ThreadState::new();
-        } else if #[cfg(target_arch = "aarch64")] {
+        }
+        target_arch = "aarch64" => {
             type ThreadState = mach2::structs::arm_thread_state64_t;
 
             let thread_state_flavor = ARM_THREAD_STATE64;
@@ -386,7 +387,8 @@ unsafe fn handle_exception(request: &mut ExceptionRequest) -> bool {
                 state.__pc = (unwind as *const ()).addr() as u64;
             };
             let mut thread_state = unsafe { mem::zeroed::<ThreadState>() };
-        } else {
+        }
+        _ => {
             compile_error!("unsupported target architecture");
         }
     }

--- a/crates/wasmtime/src/runtime/vm/sys/unix/mmap.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/mmap.rs
@@ -18,8 +18,8 @@ pub struct Mmap {
     memory: SendSyncPtr<[u8]>,
 }
 
-cfg_if::cfg_if! {
-    if #[cfg(any(target_os = "illumos", target_os = "linux"))] {
+cfg_select! {
+    any(target_os = "illumos", target_os = "linux") => {
         // On illumos, by default, mmap reserves what it calls "swap space" ahead of time, so that
         // memory accesses a`re guaranteed not to fail once mmap succeeds. NORESERVE is for cases
         // where that memory is never meant to be accessed -- e.g. memory that's used as guard
@@ -30,7 +30,8 @@ cfg_if::cfg_if! {
         // physical memory.
         pub(super) const MMAP_NORESERVE_FLAG: rustix::mm::MapFlags =
             rustix::mm::MapFlags::NORESERVE;
-    } else {
+    }
+    _ => {
         pub(super) const MMAP_NORESERVE_FLAG: rustix::mm::MapFlags = rustix::mm::MapFlags::empty();
     }
 }

--- a/crates/wasmtime/src/runtime/vm/sys/unix/signals.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/signals.rs
@@ -238,26 +238,29 @@ pub fn abort_stack_overflow() -> ! {
     reason = "too fiddly to handle and wouldn't help much anyway"
 )]
 unsafe fn get_trap_registers(cx: *mut libc::c_void, _signum: libc::c_int) -> TrapRegisters {
-    cfg_if::cfg_if! {
-        if #[cfg(all(any(target_os = "linux", target_os = "android", target_os = "illumos"), target_arch = "x86_64"))] {
+    cfg_select! {
+        all(any(target_os = "linux", target_os = "android", target_os = "illumos"), target_arch = "x86_64") => {
             let cx = unsafe { &*(cx as *const libc::ucontext_t) };
             TrapRegisters {
                 pc: cx.uc_mcontext.gregs[libc::REG_RIP as usize] as usize,
                 fp: cx.uc_mcontext.gregs[libc::REG_RBP as usize] as usize,
             }
-        } else if #[cfg(all(target_os = "linux", target_arch = "x86"))] {
+        }
+        all(target_os = "linux", target_arch = "x86") => {
             let cx = unsafe { &*(cx as *const libc::ucontext_t) };
             TrapRegisters {
                 pc: cx.uc_mcontext.gregs[libc::REG_EIP as usize] as usize,
                 fp: cx.uc_mcontext.gregs[libc::REG_EBP as usize] as usize,
             }
-        } else if #[cfg(all(any(target_os = "linux", target_os = "android"), target_arch = "aarch64"))] {
+        }
+        all(any(target_os = "linux", target_os = "android"), target_arch = "aarch64") => {
             let cx = unsafe { &*(cx as *const libc::ucontext_t) };
             TrapRegisters {
                 pc: cx.uc_mcontext.pc as usize,
                 fp: cx.uc_mcontext.regs[29] as usize,
             }
-        } else if #[cfg(all(target_os = "linux", target_arch = "s390x"))] {
+        }
+        all(target_os = "linux", target_arch = "s390x") => {
             // On s390x, SIGILL and SIGFPE are delivered with the PSW address
             // pointing *after* the faulting instruction, while SIGSEGV and
             // SIGBUS are delivered with the PSW address pointing *to* the
@@ -279,7 +282,8 @@ unsafe fn get_trap_registers(cx: *mut libc::c_void, _signum: libc::c_int) -> Tra
                     fp: *(cx.uc_mcontext.gregs[15] as *const usize),
                 }
             }
-        } else if #[cfg(all(target_vendor = "apple", target_arch = "x86_64"))] {
+        }
+        all(target_vendor = "apple", target_arch = "x86_64") => {
             unsafe {
                 let cx = &*(cx as *const libc::ucontext_t);
                 TrapRegisters {
@@ -287,7 +291,8 @@ unsafe fn get_trap_registers(cx: *mut libc::c_void, _signum: libc::c_int) -> Tra
                     fp: (*cx.uc_mcontext).__ss.__rbp as usize,
                 }
             }
-        } else if #[cfg(all(target_vendor = "apple", target_arch = "aarch64"))] {
+        }
+        all(target_vendor = "apple", target_arch = "aarch64") => {
             unsafe {
                 let cx = &*(cx as *const libc::ucontext_t);
                 TrapRegisters {
@@ -295,37 +300,43 @@ unsafe fn get_trap_registers(cx: *mut libc::c_void, _signum: libc::c_int) -> Tra
                     fp: (*cx.uc_mcontext).__ss.__fp as usize,
                 }
             }
-        } else if #[cfg(all(target_os = "freebsd", target_arch = "x86_64"))] {
+        }
+        all(target_os = "freebsd", target_arch = "x86_64") => {
             let cx = unsafe { &*(cx as *const libc::ucontext_t) };
             TrapRegisters {
                 pc: cx.uc_mcontext.mc_rip as usize,
                 fp: cx.uc_mcontext.mc_rbp as usize,
             }
-        } else if #[cfg(all(target_os = "linux", target_arch = "riscv64"))] {
+        }
+        all(target_os = "linux", target_arch = "riscv64") => {
             let cx = unsafe { &*(cx as *const libc::ucontext_t) };
             TrapRegisters {
                 pc: cx.uc_mcontext.__gregs[libc::REG_PC] as usize,
                 fp: cx.uc_mcontext.__gregs[libc::REG_S0] as usize,
             }
-        } else if #[cfg(all(target_os = "freebsd", target_arch = "aarch64"))] {
+        }
+        all(target_os = "freebsd", target_arch = "aarch64") => {
             let cx = unsafe { &*(cx as *const libc::ucontext_t) };
             TrapRegisters {
                 pc: cx.uc_mcontext.mc_gpregs.gp_elr as usize,
                 fp: cx.uc_mcontext.mc_gpregs.gp_x[29] as usize,
             }
-        } else if #[cfg(all(target_os = "openbsd", target_arch = "x86_64"))] {
+        }
+        all(target_os = "openbsd", target_arch = "x86_64") => {
             let cx = unsafe { &*(cx as *const libc::ucontext_t) };
             TrapRegisters {
                 pc: cx.sc_rip as usize,
                 fp: cx.sc_rbp as usize,
             }
-        } else if #[cfg(all(target_os = "linux", target_arch = "arm"))] {
+        }
+        all(target_os = "linux", target_arch = "arm") => {
             let cx = unsafe { &*(cx as *const libc::ucontext_t) };
             TrapRegisters {
                 pc: cx.uc_mcontext.arm_pc as usize,
                 fp: cx.uc_mcontext.arm_fp as usize,
             }
-        } else {
+        }
+        _ => {
             compile_error!("unsupported platform");
             panic!();
         }
@@ -335,28 +346,31 @@ unsafe fn get_trap_registers(cx: *mut libc::c_void, _signum: libc::c_int) -> Tra
 /// Updates the siginfo context stored in `cx` to resume to `handler` up on
 /// resumption while returning from the signal handler.
 unsafe fn store_handler_in_ucontext(cx: *mut libc::c_void, handler: &Handler) {
-    cfg_if::cfg_if! {
-        if #[cfg(all(any(target_os = "linux", target_os = "android", target_os = "illumos"), target_arch = "x86_64"))] {
+    cfg_select! {
+        all(any(target_os = "linux", target_os = "android", target_os = "illumos"), target_arch = "x86_64") => {
             let cx = unsafe { cx.cast::<libc::ucontext_t>().as_mut().unwrap() };
             cx.uc_mcontext.gregs[libc::REG_RIP as usize] = handler.pc as _;
             cx.uc_mcontext.gregs[libc::REG_RSP as usize] = handler.sp as _;
             cx.uc_mcontext.gregs[libc::REG_RBP as usize] = handler.fp as _;
             cx.uc_mcontext.gregs[libc::REG_RAX as usize] = 0;
             cx.uc_mcontext.gregs[libc::REG_RDX as usize] = 0;
-        } else if #[cfg(all(any(target_os = "linux", target_os = "android"), target_arch = "aarch64"))] {
+        }
+        all(any(target_os = "linux", target_os = "android"), target_arch = "aarch64") => {
             let cx = unsafe { cx.cast::<libc::ucontext_t>().as_mut().unwrap() };
             cx.uc_mcontext.pc = handler.pc as _;
             cx.uc_mcontext.sp = handler.sp as _;
             cx.uc_mcontext.regs[29] = handler.fp as _;
             cx.uc_mcontext.regs[0] = 0;
             cx.uc_mcontext.regs[1] = 0;
-        } else if #[cfg(all(target_os = "linux", target_arch = "s390x"))] {
+        }
+        all(target_os = "linux", target_arch = "s390x") => {
             let cx = unsafe { cx.cast::<libc::ucontext_t>().as_mut().unwrap() };
             cx.uc_mcontext.psw.addr = handler.pc as _;
             cx.uc_mcontext.gregs[15] = handler.sp as _;
             cx.uc_mcontext.gregs[6] = 0;
             cx.uc_mcontext.gregs[7] = 0;
-        } else if #[cfg(all(target_vendor = "apple", target_arch = "x86_64"))] {
+        }
+        all(target_vendor = "apple", target_arch = "x86_64") => {
             unsafe {
                 let cx = cx.cast::<libc::ucontext_t>().as_mut().unwrap();
                 let cx = cx.uc_mcontext.as_mut().unwrap();
@@ -366,7 +380,8 @@ unsafe fn store_handler_in_ucontext(cx: *mut libc::c_void, handler: &Handler) {
                 cx.__ss.__rax = 0;
                 cx.__ss.__rdx = 0;
             }
-        } else if #[cfg(all(target_vendor = "apple", target_arch = "aarch64"))] {
+        }
+        all(target_vendor = "apple", target_arch = "aarch64") => {
             unsafe {
                 let cx = cx.cast::<libc::ucontext_t>().as_mut().unwrap();
                 let cx = cx.uc_mcontext.as_mut().unwrap();
@@ -376,35 +391,40 @@ unsafe fn store_handler_in_ucontext(cx: *mut libc::c_void, handler: &Handler) {
                 cx.__ss.__x[0] = 0;
                 cx.__ss.__x[1] = 0;
             }
-        } else if #[cfg(all(target_os = "freebsd", target_arch = "x86_64"))] {
+        }
+        all(target_os = "freebsd", target_arch = "x86_64") => {
             let cx = unsafe { cx.cast::<libc::ucontext_t>().as_mut().unwrap() };
             cx.uc_mcontext.mc_rip = handler.pc as _;
             cx.uc_mcontext.mc_rbp = handler.fp as _;
             cx.uc_mcontext.mc_rsp = handler.sp as _;
             cx.uc_mcontext.mc_rax = 0;
             cx.uc_mcontext.mc_rdx = 0;
-        } else if #[cfg(all(target_os = "freebsd", target_arch = "aarch64"))] {
+        }
+        all(target_os = "freebsd", target_arch = "aarch64") => {
             let cx = unsafe { cx.cast::<libc::ucontext_t>().as_mut().unwrap() };
             cx.uc_mcontext.mc_gpregs.gp_elr = handler.pc as _;
             cx.uc_mcontext.mc_gpregs.gp_sp = handler.sp as _;
             cx.uc_mcontext.mc_gpregs.gp_x[29] = handler.fp as _;
             cx.uc_mcontext.mc_gpregs.gp_x[0] = 0;
             cx.uc_mcontext.mc_gpregs.gp_x[1] = 0;
-        } else if #[cfg(all(target_os = "openbsd", target_arch = "x86_64"))] {
+        }
+        all(target_os = "openbsd", target_arch = "x86_64") => {
             let cx = unsafe { cx.cast::<libc::ucontext_t>().as_mut().unwrap() };
             cx.sc_rip = handler.pc as _;
             cx.sc_rbp = handler.fp as _;
             cx.sc_rsp = handler.sp as _;
             cx.sc_rax = 0;
             cx.sc_rdx = 0;
-        } else if #[cfg(all(target_os = "linux", target_arch = "riscv64"))] {
+        }
+        all(target_os = "linux", target_arch = "riscv64") => {
             let cx = unsafe { cx.cast::<libc::ucontext_t>().as_mut().unwrap() };
             cx.uc_mcontext.__gregs[libc::REG_PC] = handler.pc as _;
             cx.uc_mcontext.__gregs[libc::REG_S0] = handler.fp as _;
             cx.uc_mcontext.__gregs[libc::REG_SP] = handler.sp as _;
             cx.uc_mcontext.__gregs[libc::REG_A0] = 0;
             cx.uc_mcontext.__gregs[libc::REG_A0 + 1] = 0;
-        } else {
+        }
+        _ => {
             compile_error!("unsupported platform");
             panic!();
         }

--- a/crates/wasmtime/src/runtime/vm/sys/unix/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/traphandlers.rs
@@ -1,5 +1,5 @@
-cfg_if::cfg_if! {
-    if #[cfg(not(has_native_signals))] {
+cfg_select! {
+    not(has_native_signals) => {
         // If signals-based traps are disabled statically then there's no
         // platform signal handler and no per-thread init, so stub these both
         // out.
@@ -7,7 +7,8 @@ cfg_if::cfg_if! {
 
         #[inline]
         pub fn lazy_per_thread_init() {}
-    } else if #[cfg(target_vendor = "apple")] {
+    }
+    target_vendor = "apple" => {
         // On macOS a dynamic decision is made to use mach ports or signals at
         // process initialization time.
 
@@ -51,7 +52,8 @@ cfg_if::cfg_if! {
                 }
             }
         }
-    } else {
+    }
+    _ => {
         // Otherwise unix platforms use the signals-based implementation of
         // these functions.
         pub use super::signals::{TrapHandler, SignalHandler, lazy_per_thread_init};

--- a/crates/wasmtime/src/runtime/vm/sys/unix/unwind.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/unwind.rs
@@ -9,7 +9,7 @@ pub struct UnwindRegistration {
     registrations: TryVec<SendSyncPtr<u8>>,
 }
 
-cfg_if::cfg_if! {
+cfg_select! {
     // FIXME: at least on the `gcc-arm-linux-gnueabihf` toolchain on Ubuntu
     // these symbols are not provided by default like they are on other targets.
     // I'm not ARM expert so I don't know why. For now though consider this an
@@ -17,13 +17,14 @@ cfg_if::cfg_if! {
     // to do nothing which won't break any tests it just means that
     // runtime-generated backtraces won't have the same level of fidelity they
     // do on other targets.
-    if #[cfg(target_arch = "arm")] {
+    target_arch = "arm" => {
         unsafe extern "C" fn __register_frame(_: *const u8) {}
         unsafe extern "C" fn __deregister_frame(_: *const u8) {}
         unsafe extern "C" fn wasmtime_using_libunwind() -> bool {
             false
         }
-    } else {
+    }
+    _ => {
         unsafe extern "C" {
             // libunwind import
             fn __register_frame(fde: *const u8);

--- a/crates/wasmtime/src/runtime/vm/sys/unix/vm.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/unix/vm.rs
@@ -63,14 +63,15 @@ pub unsafe fn decommit_pages(iov: &[iovec]) -> io::Result<()> {
         }
 
         unsafe {
-            cfg_if::cfg_if! {
-                if #[cfg(target_os = "linux")] {
+            cfg_select! {
+                target_os = "linux" => {
                     use rustix::mm::{madvise, Advice};
 
                     // On Linux, this is enough to cause the kernel to initialize
                     // the pages to 0 on next access
                     madvise(iov.iov_base, iov.iov_len, Advice::LinuxDontNeed)?;
-                } else {
+                }
+                _ => {
                     // By creating a new mapping at the same location, this will
                     // discard the mapping for the pages in the given range.
                     // The new mapping will be to the CoW zero page, so this

--- a/crates/wasmtime/src/runtime/vm/sys/windows/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/windows/traphandlers.rs
@@ -2,10 +2,11 @@ pub fn lazy_per_thread_init() {
     // unused on Windows
 }
 
-cfg_if::cfg_if! {
-    if #[cfg(has_native_signals)] {
+cfg_select! {
+    has_native_signals => {
         pub use super::vectored_exceptions::{TrapHandler, SignalHandler };
-    } else {
+    }
+    _ => {
         pub enum SignalHandler {}
     }
 }

--- a/crates/wasmtime/src/runtime/vm/sys/windows/vectored_exceptions.rs
+++ b/crates/wasmtime/src/runtime/vm/sys/windows/vectored_exceptions.rs
@@ -206,18 +206,20 @@ unsafe extern "system" fn exception_handler(exception_info: *mut EXCEPTION_POINT
             None => return EXCEPTION_CONTINUE_SEARCH,
         };
         let context = unsafe { exception_info.ContextRecord.as_ref().unwrap() };
-        cfg_if::cfg_if! {
-            if #[cfg(target_arch = "x86_64")] {
+        cfg_select! {
+            target_arch = "x86_64" => {
                 let regs = TrapRegisters {
                     pc: context.Rip as usize,
                     fp: context.Rbp as usize,
                 };
-            } else if #[cfg(target_arch = "aarch64")] {
+            }
+            target_arch = "aarch64" => {
                 let regs = TrapRegisters {
                     pc: context.Pc as usize,
                     fp: unsafe { context.Anonymous.Anonymous.Fp as usize },
                 };
-            } else {
+            }
+            _ => {
                 compile_error!("unsupported platform");
             }
         }
@@ -237,20 +239,22 @@ unsafe extern "system" fn exception_handler(exception_info: *mut EXCEPTION_POINT
             TrapTest::Trap(handler) => {
                 let context = unsafe { exception_info.ContextRecord.as_mut().unwrap() };
                 LAST_EXCEPTION_PC.with(|s| s.set(handler.pc));
-                cfg_if::cfg_if! {
-                    if #[cfg(target_arch = "x86_64")] {
+                cfg_select! {
+                    target_arch = "x86_64" => {
                         context.Rip = handler.pc as _;
                         context.Rbp = handler.fp as _;
                         context.Rsp = handler.sp as _;
                         context.Rax = 0;
                         context.Rdx = 0;
-                    } else if #[cfg(target_arch = "aarch64")] {
+                    }
+                    target_arch = "aarch64" => {
                         context.Pc = handler.pc as _;
                         context.Sp = handler.sp as _;
                         context.Anonymous.Anonymous.Fp = handler.fp as _;
                         context.Anonymous.Anonymous.X0 = 0;
                         context.Anonymous.Anonymous.X1 = 0;
-                    } else {
+                    }
+                    _ => {
                         compile_error!("unsupported platform");
                     }
                 }
@@ -271,12 +275,14 @@ unsafe extern "system" fn continue_handler(exception_info: *mut EXCEPTION_POINTE
     let context = unsafe { &(*(*exception_info).ContextRecord) };
     let last_exception_pc = LAST_EXCEPTION_PC.with(|s| s.replace(0));
 
-    cfg_if::cfg_if! {
-        if #[cfg(target_arch = "x86_64")] {
+    cfg_select! {
+        target_arch = "x86_64" => {
             let context_pc = context.Rip as usize;
-        } else if #[cfg(target_arch = "aarch64")] {
+        }
+        target_arch = "aarch64" => {
             let context_pc = context.Pc as usize;
-        } else {
+        }
+        _ => {
             compile_error!("unsupported platform");
         }
     }

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -502,10 +502,11 @@ impl RunCommand {
                 }
                 if e.is::<wasmtime::Trap>() {
                     eprintln!("Error: {e:?}");
-                    cfg_if::cfg_if! {
-                        if #[cfg(unix)] {
+                    cfg_select! {
+                        unix => {
                             std::process::exit(rustix::process::EXIT_SIGNALED_SIGABRT);
-                        } else if #[cfg(windows)] {
+                        }
+                        windows => {
                             // https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/abort?view=vs-2019
                             std::process::exit(3);
                         }


### PR DESCRIPTION
This macro was stabilized in the standard library in Rust 1.95 and is now available for use in Wasmtime with our updated MSRV. Helps prune a dependency from the tree, this'll probably integrate better with `rustfmt`, and it's an end of an era...

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
