### PR TITLE
Reserve stack space before writing in riscv32imac stackswitching implementation

### DIFF
--- a/crates/fiber/src/stackswitch/riscv32imac.rs
+++ b/crates/fiber/src/stackswitch/riscv32imac.rs
@@ -30,20 +30,20 @@ unsafe extern "C" fn wasmtime_fiber_switch_(top_of_stack: *mut u8 /* a0 */) {
       //
       // Note that this order for saving is important since we use CFI directives
       // below to point to where all the saved registers are.
-      sw ra, -0x4(sp)
-      sw fp, -0x8(sp) // fp is s0
-      sw s1, -0xc(sp)
-      sw s2, -0x10(sp)
-      sw s3, -0x14(sp)
-      sw s4, -0x18(sp)
-      sw s5, -0x1c(sp)
-      sw s6, -0x20(sp)
-      sw s7, -0x24(sp)
-      sw s8, -0x28(sp)
-      sw s9, -0x2c(sp)
-      sw s10, -0x30(sp)
-      sw s11, -0x34(sp)
       addi sp, sp, -0x40 // Choose 0x40 to be 16-byte aligned
+      sw ra, 0x3c(sp)
+      sw fp, 0x38(sp) // fp is s0
+      sw s1, 0x34(sp)
+      sw s2, 0x30(sp)
+      sw s3, 0x2c(sp)
+      sw s4, 0x28(sp)
+      sw s5, 0x24(sp)
+      sw s6, 0x20(sp)
+      sw s7, 0x1c(sp)
+      sw s8, 0x18(sp)
+      sw s9, 0x14(sp)
+      sw s10, 0x10(sp)
+      sw s11, 0xc(sp)
 
       lw t0, -0x8(a0)
       sw sp, -0x8(a0)


### PR DESCRIPTION
The stackswitching implementation for 32-bit RISC-V IMAC ISAs contained a bug. When saving registers to the stack, these registers were first stored below the current stack pointer, then the stack pointer was decreased so all of the saved values were above it. This left relevant data below the stack pointer while the registers were being saved.

If for example an interrupt occured when registers had already been saved, but the stackpointer had not been moved, the interrupt handler might overwrite some of the data previously saved for stack switching. This PR makes this impossible by first moving the stack pointer, only saving the registers values to the reserved stack space afterwards.

I was able to somewhat reliably have the previous bug lead to a device halting execution by having a Wasm program call `async` bindings very often and using fuel instrumentation with a `fuel_async_yield_interval` of 1. I do not currently have the up-to-date version of `main` running on 32-bit RISC-V, so I was only able to test this fix with an older version of Wasmtime. The stackswitching implementation has only been changed by [commit `f3156fe`](https://github.com/bytecodealliance/wasmtime/commit/f3156fe00de0e65374fb6333666e9f63119d5905#diff-c83ba011f4c6a4060f87fa4d8d7774659e5c10272621bf149ddec13e27824fee) since then, those changes do not appear relevant to this fix.

I suspect this bug to be present in other stack switching implementations as well but do not have the hardware available to test a fix. For this reason, I have started a [Zulip topic](https://bytecodealliance.zulipchat.com/#narrow/channel/217126-wasmtime/topic/Bug.20in.20some.20stackswitching.20implementations/with/610815875) about this.


<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
