### PR TITLE
[CI] handle wasi-nn CI flaky tests

### DIFF
--- a/crates/wasi-nn/tests/check/mod.rs
+++ b/crates/wasi-nn/tests/check/mod.rs
@@ -10,6 +10,7 @@ use std::{
     process::Command,
     sync::Mutex,
 };
+use wasmtime::bail;
 
 #[cfg(any(feature = "onnx", all(feature = "winml", target_os = "windows")))]
 pub mod onnx;
@@ -35,9 +36,9 @@ fn download(from: &str, to: &Path) -> wasmtime::Result<()> {
     let mut curl = Command::new("curl");
     curl.arg("--location").arg(from).arg("--output").arg(to);
     println!("> downloading: {:?}", &curl);
-    let result = curl.output().unwrap();
+    let result = curl.output()?;
     if !result.status.success() {
-        panic!(
+        bail!(
             "curl failed: {}\n{}",
             result.status,
             String::from_utf8_lossy(&result.stderr)

--- a/crates/wasi-nn/tests/check/mod.rs
+++ b/crates/wasi-nn/tests/check/mod.rs
@@ -34,7 +34,16 @@ pub fn artifacts_dir() -> PathBuf {
 /// Retrieve the bytes at the `from` URL and place them in the `to` file.
 fn download(from: &str, to: &Path) -> wasmtime::Result<()> {
     let mut curl = Command::new("curl");
-    curl.arg("--location").arg(from).arg("--output").arg(to);
+    curl.arg("--location")
+        .arg("--retry")
+        .arg("4")
+        .arg("--retry-delay")
+        .arg("1")
+        .arg("--retry-max-time")
+        .arg("30")
+        .arg(from)
+        .arg("--output")
+        .arg(to);
     println!("> downloading: {:?}", &curl);
     let result = curl.output()?;
     if !result.status.success() {

--- a/crates/wasi-nn/tests/check/onnx.rs
+++ b/crates/wasi-nn/tests/check/onnx.rs
@@ -5,7 +5,7 @@ use wasmtime::{Result, error::Context as _};
 /// Return `Ok` if we find the cached MobileNet test artifacts; this will
 /// download the artifacts if necessary.
 pub fn are_artifacts_available() -> Result<()> {
-    let _exclusively_retrieve_artifacts = DOWNLOAD_LOCK.lock().unwrap();
+    let _exclusively_retrieve_artifacts = DOWNLOAD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
 
     const ONNX_BASE_URL: &str = "https://github.com/onnx/models/raw/bec48b6a70e5e9042c0badbaafefe4454e072d08/validated/vision/classification/mobilenet/model/mobilenetv2-10.onnx?download=";
 

--- a/crates/wasi-nn/tests/check/openvino.rs
+++ b/crates/wasi-nn/tests/check/openvino.rs
@@ -21,7 +21,7 @@ pub fn is_installed() -> Result<()> {
 /// Return `Ok` if we find the cached MobileNet test artifacts; this will
 /// download the artifacts if necessary.
 pub fn are_artifacts_available() -> Result<()> {
-    let _exclusively_retrieve_artifacts = DOWNLOAD_LOCK.lock().unwrap();
+    let _exclusively_retrieve_artifacts = DOWNLOAD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     const BASE_URL: &str = "https://download.01.org/openvinotoolkit/fixtures/mobilenet";
     let artifacts_dir = artifacts_dir();
     if !artifacts_dir.is_dir() {

--- a/crates/wasi-nn/tests/check/pytorch.rs
+++ b/crates/wasi-nn/tests/check/pytorch.rs
@@ -5,7 +5,7 @@ use wasmtime::{Result, error::Context as _};
 /// Return `Ok` if we find the cached MobileNet test artifacts; this will
 /// download the artifacts if necessary.
 pub fn are_artifacts_available() -> Result<()> {
-    let _exclusively_retrieve_artifacts = DOWNLOAD_LOCK.lock().unwrap();
+    let _exclusively_retrieve_artifacts = DOWNLOAD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     const PYTORCH_BASE_URL: &str = "https://github.com/rahulchaphalkar/libtorch-models/releases/download/v0.1/squeezenet1_1.pt";
     let artifacts_dir = artifacts_dir();
     if !artifacts_dir.is_dir() {


### PR DESCRIPTION
- changed `panic!` to `bail!` in `download()` and `.lock().unwrap()` to `.lock().unwrap_or_else(|e| e.into_inner())` in wasi-nn backends. This isolates error caused by a DNS failure in one thread, and not allow it to poison other threads running other tests, [example](https://github.com/bytecodealliance/wasmtime/actions/runs/29350702096/job/87145948188#step:8:368).
- Added retries to `download()` to in an attempt to resolve intermittent network issues reaching the server, [example](https://github.com/bytecodealliance/wasmtime/actions/runs/29350702096/job/87145948188#step:8:328)

Edit - Ready for review
