### PR TITLE
winch: Reclassify unsupported immediate error

### DIFF
--- a/winch/codegen/src/codegen/error.rs
+++ b/winch/codegen/src/codegen/error.rs
@@ -35,6 +35,9 @@ pub(crate) enum CodeGenError {
     /// Unsupported eager initialization of tables.
     #[error("Unsupported eager initialization of tables")]
     UnsupportedTableEagerInit,
+    /// Unsupported immediate for instruction.
+    #[error("Unsupported immediate")]
+    UnsupportedImm,
     /// An internal error.
     ///
     /// This error means that an internal invariant was not met and usually
@@ -91,9 +94,6 @@ pub(crate) enum InternalError {
     /// Invalid local offset.
     #[error("Invalid local offset")]
     InvalidLocalOffset,
-    /// Unsupported immediate for instruction.
-    #[error("Unsupported immediate")]
-    UnsupportedImm,
     /// Invalid operand combination.
     #[error("Invalid operand combination")]
     InvalidOperandCombination,
@@ -180,7 +180,7 @@ impl CodeGenError {
     }
 
     pub(crate) const fn unsupported_imm() -> Self {
-        Self::Internal(InternalError::UnsupportedImm)
+        Self::UnsupportedImm
     }
 
     pub(crate) const fn invalid_two_arg_form() -> Self {

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -6,7 +6,7 @@ use super::{
     regs::{self, scratch_fpr_bitset, scratch_gpr_bitset},
 };
 use crate::{
-    Result,
+    Context, Result,
     abi::{self, align_to, calculate_frame_adjustment, local::LocalSlot, vmctx},
     bail,
     codegen::{CodeGenContext, CodeGenError, Emission, FuncEnv, ptr_type_from_ptr_size},
@@ -521,7 +521,10 @@ impl Masm for MacroAssembler {
                     self.asm.mov_ir(dst, imm, imm.size());
                     Ok(())
                 }
-                I::V128(_) => bail!(CodeGenError::unsupported_imm()),
+                I::V128(_) => Err(CodeGenError::unsupported_imm()).context(
+                    "v128 immediates are not supported in winch+aarch64; the SIMD and \
+                     relaxed-SIMD proposals are unimplemented for this target",
+                ),
             },
             (RegImm::Reg(rs), rd) => match (rs.class(), rd.to_reg().class()) {
                 (RegClass::Int, RegClass::Int) => Ok(self.asm.mov_rr(rs, rd, size)),


### PR DESCRIPTION
Prior to this commit the `UnsupportedImm` error was classified as an internal error. Internal errors mean a compiler bug. This commit reclassifies this error as a missing feature rather than a compiler bug.

Additionally, this change attaches backend-specific context to the error.

This is related to https://github.com/bytecodealliance/wasmtime/issues/13856

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
