### PR TITLE
[wasi-nn] Update openvino-rs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1030,7 +1030,7 @@ jobs:
     - uses: ./.github/actions/install-rust
 
     # Install OpenVINO
-    - uses: abrown/install-openvino-action@v10
+    - uses: abrown/install-openvino-action@v12
       if: runner.arch == 'X64'
 
     # Install WinML for testing wasi-nn WinML backend. WinML is only available

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2719,9 +2719,9 @@ dependencies = [
 
 [[package]]
 name = "openvino"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3308ec088481c27b5b521598ced2d5d5f67253d9639f5a3cce5a2ea4c4062a94"
+checksum = "118567863ab1a45b3e9b2df6ebf988dd6164752ef5099160a412f754b95b75a7"
 dependencies = [
  "openvino-finder",
  "openvino-sys",
@@ -2729,9 +2729,9 @@ dependencies = [
 
 [[package]]
 name = "openvino-finder"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bba5393f3522f98d9c4703a6a73afc7feff2bf9cc00a0722957b54c44ecda5fe"
+checksum = "a527e1414732f5bcad520b9febf29fd92ef4bba100588b4591cba8370ab6cbda"
 dependencies = [
  "cfg-if",
  "log",
@@ -2739,9 +2739,9 @@ dependencies = [
 
 [[package]]
 name = "openvino-sys"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da7d035914ff5c8e12d7e05982929fb275e6f06eafcbe529f316001760b08786"
+checksum = "637459f74d22a7bb772af9d3a5df61c88608d8daaa6fefe950849c7aabf891c3"
 dependencies = [
  "env_logger 0.11.5",
  "libloading",

--- a/crates/wasi-nn/Cargo.toml
+++ b/crates/wasi-nn/Cargo.toml
@@ -36,7 +36,7 @@ ort = { version = "2.0.0-rc.10", default-features = false, features = [
 tch = { version = "0.17.0", default-features = false, optional = true}
 
 [target.'cfg(target_pointer_width = "64")'.dependencies]
-openvino = { version = "0.9.0", features = [
+openvino = { version = "0.11.0", features = [
     "runtime-linking",
 ], optional = true }
 

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -4159,6 +4159,12 @@ who = "Andrew Brown <andrew.brown@intel.com>"
 criteria = "safe-to-deploy"
 delta = "0.8.0 -> 0.9.0"
 
+[[audits.openvino]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.9.0 -> 0.11.0"
+notes = "Unsafe bindings, but comes with the territory. Nothing awry."
+
 [[audits.openvino-finder]]
 who = "Matthew Tamayo-Rios <matthew@geekbeast.com>"
 criteria = "safe-to-deploy"
@@ -4193,6 +4199,12 @@ who = "Andrew Brown <andrew.brown@intel.com>"
 criteria = "safe-to-deploy"
 delta = "0.8.0 -> 0.9.0"
 
+[[audits.openvino-finder]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.9.0 -> 0.11.0"
+notes = "Just some paths changing here, nothing major"
+
 [[audits.openvino-sys]]
 who = "Matthew Tamayo-Rios <matthew@geekbeast.com>"
 criteria = "safe-to-deploy"
@@ -4226,6 +4238,12 @@ notes = "This diff simply re-generates slightly newer C headers with a slightly 
 who = "Andrew Brown <andrew.brown@intel.com>"
 criteria = "safe-to-deploy"
 delta = "0.8.0 -> 0.9.0"
+
+[[audits.openvino-sys]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.9.0 -> 0.11.0"
+notes = "Nothing unexpected for a sys crate update"
 
 [[audits.ort]]
 who = "Andrew Brown <andrew.brown@intel.com>"


### PR DESCRIPTION
Updates openvino-rs to `0.11.0` i.e. openvino native updated to `2026.1.2`

I have been trying to repro some [wasi-nn CI failures](https://github.com/bytecodealliance/wasmtime/actions/runs/29387076691/job/87262505798#step:8:296) on windows runners with error `Illegal Instruction`, and I believe updating Openvino dependency is possibly a good way to address that.
Its tricky to root cause this, as but I have been running isolated runs of openvino tests and winml tests on windows-2025 runners ([in my fork](https://github.com/rahulchaphalkar/wasmtime/actions/runs/29540796962/job/87768306008)) but haven't hit it yet. (The original failing winml tests ran both openvino and winml).

In short, OneDNN which is a dependency of openvino uses JIT to generate some code, checking the underlying CPU capabilities. This is one of the strongest possibilities for ISA mismatch on a github runner. Updating openvino also updates OneDNN from `3.6.2` to `3.10.2`. I see a couple of fixes during that timeframe in OneDNN for illegal instructions, [[1]](https://github.com/uxlfoundation/oneDNN/pull/3884/changes), [[2]](https://github.com/uxlfoundation/oneDNN/pull/2706#issue-2856422748)

If we still see these failures after this patch (and I have not been to repro it in my fork till then) then I can introduce additional logging and/or separation of threads/jobs for winml and openvino to identify it.

@alexcrichton this should fail cargo-vet test