### PR TITLE
Exclude large directories from publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,21 @@ readme = "README.md"
 edition.workspace = true
 default-run = "wasmtime"
 rust-version.workspace = true
+exclude = [
+  'tests/disas',
+  'tests/wasi-testsuite',
+  'tests/spec_testsuite',
+  'tests/misc_testsuite',
+  'tests/component-model',
+  'supply-chain',
+  'docs',
+  'examples/*.c',
+  'examples/*.cc',
+  'ci',
+  '.github',
+  '.claude',
+  '.agents',
+]
 
 [package.metadata.binstall]
 pkg-url = "{repo}/releases/download/v{version}/wasmtime-v{version}-{target-arch}-{target-family}{archive-suffix}"


### PR DESCRIPTION
Turns out the `wasmtime-cli` `*.crate` file has ballooned to 250M+ and it's subsequently, and rightfully, failing to publish on crates.io. Exclude a whole bunch of directories not needed for building to bring the size down by quite a bit.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
