### PR TITLE
Update wasm-tools dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -609,7 +609,7 @@ dependencies = [
  "test-programs-artifacts",
  "tokio",
  "wasm-compose",
- "wasmparser 0.253.0",
+ "wasmparser 0.254.0",
  "wasmtime",
  "wasmtime-wasi",
 ]
@@ -2236,14 +2236,14 @@ dependencies = [
 
 [[package]]
 name = "json-from-wast"
-version = "0.253.0"
+version = "0.254.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e0660a87ff1378828bc1b1466f44a3269470c7f25d4c5da7fa7bcddc5849ad"
+checksum = "d3864e5a6e08aeab6da27eca9dedaefe8c27fd9e28dd402ee00ea66416023a9f"
 dependencies = [
  "anyhow",
  "serde",
  "serde_derive",
- "wast 253.0.0",
+ "wast 254.0.0",
 ]
 
 [[package]]
@@ -3803,7 +3803,7 @@ dependencies = [
  "wasmtime",
  "wasmtime-test-util",
  "wat",
- "wit-component 0.253.0",
+ "wit-component 0.254.0",
 ]
 
 [[package]]
@@ -4257,7 +4257,7 @@ name = "verify-component-adapter"
 version = "48.0.0"
 dependencies = [
  "anyhow",
- "wasmparser 0.253.0",
+ "wasmparser 0.254.0",
  "wat",
 ]
 
@@ -4334,7 +4334,7 @@ dependencies = [
  "byte-array-literals",
  "object 0.39.0",
  "wasip1",
- "wasm-encoder 0.253.0",
+ "wasm-encoder 0.254.0",
  "wit-bindgen-rust-macro 0.59.0",
 ]
 
@@ -4364,9 +4364,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-compose"
-version = "0.253.0"
+version = "0.254.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00572a13a43b4754066ddeb46aec65091cd4cdb5b632768295a4236574da28a"
+checksum = "8fd717357bff09b5f1ea49aea8ed1cd149b0c521823a1cc70bc2ac16b90b651a"
 dependencies = [
  "anyhow",
  "heck",
@@ -4374,8 +4374,8 @@ dependencies = [
  "log",
  "petgraph",
  "smallvec 1.15.1",
- "wasm-encoder 0.253.0",
- "wasmparser 0.253.0",
+ "wasm-encoder 0.254.0",
+ "wasmparser 0.254.0",
  "wat",
 ]
 
@@ -4397,6 +4397,16 @@ checksum = "59972d6cd272259de647b7c1f1912e45e289c75ffd4be04e10695507cd7e1b59"
 dependencies = [
  "leb128fmt",
  "wasmparser 0.253.0",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.254.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09480d646178e5fdd12bb06e812d0af9a3a191dbc9cd697fdc86687beade7393"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.254.0",
 ]
 
 [[package]]
@@ -4424,31 +4434,43 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-mutate"
-version = "0.253.0"
+name = "wasm-metadata"
+version = "0.254.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5111322c954d3980d87b1f36dbf4dc2360e049e087193f89628ca2af30dab7c6"
+checksum = "b01df5f3b4ca7881e843f3bc0fb8a3905d79c68692250dcb8e33e698705ccdb6"
+dependencies = [
+ "anyhow",
+ "indexmap 2.14.0",
+ "wasm-encoder 0.254.0",
+ "wasmparser 0.254.0",
+]
+
+[[package]]
+name = "wasm-mutate"
+version = "0.254.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ceea435895a94a7c1dcbcfce7c2612007daebfafdf9851a86d0c7b8fb15aaf3"
 dependencies = [
  "egg",
  "log",
  "rand 0.10.1",
  "thiserror 2.0.17",
- "wasm-encoder 0.253.0",
- "wasmparser 0.253.0",
+ "wasm-encoder 0.254.0",
+ "wasmparser 0.254.0",
 ]
 
 [[package]]
 name = "wasm-smith"
-version = "0.253.0"
+version = "0.254.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7335822038378faf4d602be116692189ff5bd37b3b3353639c4e18450fa56ce"
+checksum = "310b05df4f1aede74489c0e206d8ea39d884095f708ae2728538f64df4a78665"
 dependencies = [
  "anyhow",
  "arbitrary",
  "flagset",
  "serde",
  "serde_derive",
- "wasm-encoder 0.253.0",
+ "wasm-encoder 0.254.0",
  "wat",
 ]
 
@@ -4462,14 +4484,14 @@ dependencies = [
 
 [[package]]
 name = "wasm-wave"
-version = "0.253.0"
+version = "0.254.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf5d5caa1d6dc81bb26518198e7c3d6b78a944284cb612b3f4b27fa8132eec7"
+checksum = "e112fc0db85e7edf9258a9a0fa07566540c19a6a2af3fbf45a4d45d886bfd7df"
 dependencies = [
  "anyhow",
  "logos",
  "thiserror 2.0.17",
- "wit-parser 0.253.0",
+ "wit-parser 0.254.0",
 ]
 
 [[package]]
@@ -4544,18 +4566,30 @@ dependencies = [
  "hashbrown 0.17.0",
  "indexmap 2.14.0",
  "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.254.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5769a29f799fbab136aaf65b4fe5384cd7d93fe6fc9ba0dcb6c8382a1f16e27"
+dependencies = [
+ "bitflags 2.11.1",
+ "hashbrown 0.17.0",
+ "indexmap 2.14.0",
+ "semver",
  "serde",
 ]
 
 [[package]]
 name = "wasmprinter"
-version = "0.253.0"
+version = "0.254.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cafccdb2ba2cffd9c4f96b88a9710651d63266e858d54be262a141b528b26dac"
+checksum = "64e3ba11e024f504698f87b629b2b66c22a1231758de7607754963f7d198be39"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.253.0",
+ "wasmparser 0.254.0",
 ]
 
 [[package]]
@@ -4597,9 +4631,9 @@ dependencies = [
  "tempfile",
  "tokio",
  "wasm-compose",
- "wasm-encoder 0.253.0",
+ "wasm-encoder 0.254.0",
  "wasm-wave",
- "wasmparser 0.253.0",
+ "wasmparser 0.254.0",
  "wasmtime-environ",
  "wasmtime-internal-cache",
  "wasmtime-internal-component-macro",
@@ -4616,7 +4650,7 @@ dependencies = [
  "wasmtime-test-util",
  "wat",
  "windows-sys 0.61.2",
- "wit-parser 0.253.0",
+ "wit-parser 0.254.0",
 ]
 
 [[package]]
@@ -4707,8 +4741,8 @@ dependencies = [
  "toml",
  "tracing",
  "walkdir",
- "wasm-encoder 0.253.0",
- "wasmparser 0.253.0",
+ "wasm-encoder 0.254.0",
+ "wasmparser 0.254.0",
  "wasmprinter",
  "wasmtime",
  "wasmtime-cli-flags",
@@ -4730,10 +4764,10 @@ dependencies = [
  "wasmtime-wasi-tls",
  "wasmtime-wast",
  "wasmtime-wizer",
- "wast 253.0.0",
+ "wast 254.0.0",
  "wat",
  "windows-sys 0.61.2",
- "wit-component 0.253.0",
+ "wit-component 0.254.0",
 ]
 
 [[package]]
@@ -4776,8 +4810,8 @@ dependencies = [
  "sha2",
  "smallvec 1.15.1",
  "target-lexicon",
- "wasm-encoder 0.253.0",
- "wasmparser 0.253.0",
+ "wasm-encoder 0.254.0",
+ "wasmparser 0.254.0",
  "wasmprinter",
  "wasmtime-internal-component-util",
  "wasmtime-internal-core",
@@ -4791,7 +4825,7 @@ dependencies = [
  "arbitrary",
  "env_logger 0.11.5",
  "libfuzzer-sys",
- "wasmparser 0.253.0",
+ "wasmparser 0.254.0",
  "wasmprinter",
  "wasmtime-environ",
  "wasmtime-test-util",
@@ -4823,7 +4857,7 @@ dependencies = [
  "rand 0.10.1",
  "smallvec 1.15.1",
  "target-lexicon",
- "wasmparser 0.253.0",
+ "wasmparser 0.254.0",
  "wasmtime",
  "wasmtime-fuzzing",
  "wasmtime-internal-core",
@@ -4851,12 +4885,12 @@ dependencies = [
  "tempfile",
  "tokio",
  "v8",
- "wasm-encoder 0.253.0",
+ "wasm-encoder 0.254.0",
  "wasm-mutate",
  "wasm-smith",
  "wasm-spec-interpreter",
  "wasmi",
- "wasmparser 0.253.0",
+ "wasmparser 0.254.0",
  "wasmprinter",
  "wasmtime",
  "wasmtime-cli-flags",
@@ -4913,7 +4947,7 @@ dependencies = [
  "wasmtime",
  "wasmtime-internal-component-util",
  "wasmtime-internal-wit-bindgen",
- "wit-parser 0.253.0",
+ "wit-parser 0.254.0",
 ]
 
 [[package]]
@@ -4947,7 +4981,7 @@ dependencies = [
  "smallvec 1.15.1",
  "target-lexicon",
  "thiserror 2.0.17",
- "wasmparser 0.253.0",
+ "wasmparser 0.254.0",
  "wasmtime-environ",
  "wasmtime-internal-core",
  "wasmtime-internal-unwinder",
@@ -5061,7 +5095,7 @@ dependencies = [
  "log",
  "object 0.39.0",
  "target-lexicon",
- "wasmparser 0.253.0",
+ "wasmparser 0.254.0",
  "wasmtime-environ",
  "wasmtime-internal-cranelift",
  "winch-codegen",
@@ -5075,7 +5109,7 @@ dependencies = [
  "bitflags 2.11.1",
  "heck",
  "indexmap 2.14.0",
- "wit-parser 0.253.0",
+ "wit-parser 0.254.0",
 ]
 
 [[package]]
@@ -5108,7 +5142,7 @@ dependencies = [
  "serde_derive",
  "target-lexicon",
  "toml",
- "wasmparser 0.253.0",
+ "wasmparser 0.254.0",
  "wasmprinter",
  "wasmtime",
  "wasmtime-environ",
@@ -5256,9 +5290,9 @@ dependencies = [
  "object 0.39.0",
  "serde_json",
  "tokio",
- "wasmparser 0.253.0",
+ "wasmparser 0.254.0",
  "wasmtime",
- "wast 253.0.0",
+ "wast 254.0.0",
 ]
 
 [[package]]
@@ -5272,8 +5306,8 @@ dependencies = [
  "rayon",
  "test-programs-artifacts",
  "tokio",
- "wasm-encoder 0.253.0",
- "wasmparser 0.253.0",
+ "wasm-encoder 0.254.0",
+ "wasmparser 0.254.0",
  "wasmprinter",
  "wasmtime",
  "wasmtime-wasi",
@@ -5291,25 +5325,25 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "253.0.0"
+version = "254.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3264542f8965c5d84fb1085d924bfba9a6314bb228eff13a2de14d7627664d0"
+checksum = "e7ed4dfc8f6b9fc38b231065e2cdfbf7359af5ab945990abf09658dcc63c3e32"
 dependencies = [
  "bumpalo",
  "gimli 0.32.3",
  "leb128fmt",
  "memchr",
  "unicode-width 0.2.0",
- "wasm-encoder 0.253.0",
+ "wasm-encoder 0.254.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.253.0"
+version = "1.254.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bfc5ce906144200c972ec617470aa35bd847472e170b26dde3e80541c674055"
+checksum = "7127f7f9b8f127c879991cecd35f494e4628bae1b0874c681414d8d8831e952c"
 dependencies = [
- "wast 253.0.0",
+ "wast 254.0.0",
 ]
 
 [[package]]
@@ -5436,7 +5470,7 @@ dependencies = [
  "smallvec 1.15.1",
  "target-lexicon",
  "thiserror 2.0.17",
- "wasmparser 0.253.0",
+ "wasmparser 0.254.0",
  "wasmtime-environ",
  "wasmtime-internal-core",
  "wasmtime-internal-cranelift",
@@ -5757,6 +5791,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-component"
+version = "0.254.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0e65bb94c369b3c4741ce3d1d2704b1fec93db7c540df0e521a097e7ceeb5be"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.1",
+ "indexmap 2.14.0",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.254.0",
+ "wasm-metadata 0.254.0",
+ "wasmparser 0.254.0",
+ "wit-parser 0.254.0",
+]
+
+[[package]]
 name = "wit-parser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5791,6 +5844,25 @@ dependencies = [
  "serde_json",
  "unicode-ident",
  "wasmparser 0.253.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.254.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1655131e4f7d3f0cb141f6eca71315ca40eff0f3d4de7cff0a82bacedd8c89b4"
+dependencies = [
+ "anyhow",
+ "hashbrown 0.17.0",
+ "id-arena",
+ "indexmap 2.14.0",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-ident",
+ "wasmparser 0.254.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -359,18 +359,18 @@ wit-bindgen = { version = "0.59.0", default-features = false }
 wit-bindgen-rust-macro = { version = "0.59.0", default-features = false }
 
 # wasm-tools family:
-wasmparser = { version = "0.253.0", default-features = false, features = ['simd'] }
-wat = "1.253.0"
-wast = "253.0.0"
-wasmprinter = "0.253.0"
-wasm-encoder = "0.253.0"
-wasm-smith = "0.253.0"
-wasm-mutate = "0.253.0"
-wit-parser = "0.253.0"
-wit-component = "0.253.0"
-wasm-wave = "0.253.0"
-wasm-compose = { version = "0.253.0", default-features = false }
-json-from-wast = "0.253.0"
+wasmparser = { version = "0.254.0", default-features = false, features = ['simd'] }
+wat = "1.254.0"
+wast = "254.0.0"
+wasmprinter = "0.254.0"
+wasm-encoder = "0.254.0"
+wasm-smith = "0.254.0"
+wasm-mutate = "0.254.0"
+wit-parser = "0.254.0"
+wit-component = "0.254.0"
+wasm-wave = "0.254.0"
+wasm-compose = { version = "0.254.0", default-features = false }
+json-from-wast = "0.254.0"
 
 wstd = "0.6.5"
 wasip2 = "1.0"

--- a/crates/environ/src/component/types_builder.rs
+++ b/crates/environ/src/component/types_builder.rs
@@ -22,15 +22,6 @@ use wasmtime_component_util::FlagsSize;
 mod resources;
 pub use resources::ResourcesBuilder;
 
-/// Maximum nesting depth of a type allowed in Wasmtime.
-///
-/// This constant isn't chosen via any scientific means and its main purpose is
-/// to enable most of Wasmtime to handle types via recursion without worrying
-/// about stack overflow.
-///
-/// Some more information about this can be found in #4814
-const MAX_TYPE_DEPTH: u32 = 100;
-
 /// Structure used to build a [`ComponentTypes`] during translation.
 ///
 /// This contains tables to intern any component types found as well as
@@ -430,42 +421,43 @@ impl ComponentTypesBuilder {
         id: ComponentDefinedTypeId,
     ) -> Result<InterfaceType> {
         assert_eq!(types.id(), self.module_types.validator_id());
-        let ret = match &types[id] {
+        Ok(match &types[id] {
             ComponentDefinedType::Primitive(ty) => self.primitive_type(ty)?,
             ComponentDefinedType::Record(e) => InterfaceType::Record(self.record_type(types, e)?),
             ComponentDefinedType::Variant(e) => {
                 InterfaceType::Variant(self.variant_type(types, e)?)
             }
-            ComponentDefinedType::List(e) => InterfaceType::List(self.list_type(types, e)?),
-            ComponentDefinedType::Map(key, value) => {
+            ComponentDefinedType::List { element, .. } => {
+                InterfaceType::List(self.list_type(types, element)?)
+            }
+            ComponentDefinedType::Map { key, value, .. } => {
                 InterfaceType::Map(self.map_type(types, key, value)?)
             }
             ComponentDefinedType::Tuple(e) => InterfaceType::Tuple(self.tuple_type(types, e)?),
             ComponentDefinedType::Flags(e) => InterfaceType::Flags(self.flags_type(e)),
             ComponentDefinedType::Enum(e) => InterfaceType::Enum(self.enum_type(e)),
-            ComponentDefinedType::Option(e) => InterfaceType::Option(self.option_type(types, e)?),
-            ComponentDefinedType::Result { ok, err } => {
+            ComponentDefinedType::Option { ty, .. } => {
+                InterfaceType::Option(self.option_type(types, ty)?)
+            }
+            ComponentDefinedType::Result { ok, err, .. } => {
                 InterfaceType::Result(self.result_type(types, ok, err)?)
             }
             ComponentDefinedType::Own(r) => InterfaceType::Own(self.resource_id(r.resource())),
             ComponentDefinedType::Borrow(r) => {
                 InterfaceType::Borrow(self.resource_id(r.resource()))
             }
-            ComponentDefinedType::Future(ty) => {
+            ComponentDefinedType::Future { ty, .. } => {
                 InterfaceType::Future(self.future_table_type(types, ty)?)
             }
-            ComponentDefinedType::Stream(ty) => {
+            ComponentDefinedType::Stream { ty, .. } => {
                 InterfaceType::Stream(self.stream_table_type(types, ty)?)
             }
-            ComponentDefinedType::FixedLengthList(ty, size) => {
-                InterfaceType::FixedLengthList(self.fixed_length_list_type(types, ty, *size)?)
-            }
-        };
-        let info = self.type_information(&ret);
-        if info.depth > MAX_TYPE_DEPTH {
-            bail!("type nesting is too deep");
-        }
-        Ok(ret)
+            ComponentDefinedType::FixedLengthList {
+                element, length, ..
+            } => InterfaceType::FixedLengthList(
+                self.fixed_length_list_type(types, element, *length)?,
+            ),
+        })
     }
 
     /// Retrieve Wasmtime's type representation of the `error-context` type.
@@ -1002,7 +994,6 @@ struct TypeInformationCache {
 }
 
 struct TypeInformation {
-    depth: u32,
     flat: FlatTypesStorage,
     has_borrow: bool,
 }
@@ -1010,7 +1001,6 @@ struct TypeInformation {
 impl TypeInformation {
     const fn new() -> TypeInformation {
         TypeInformation {
-            depth: 0,
             flat: FlatTypesStorage::new(),
             has_borrow: false,
         }
@@ -1018,7 +1008,6 @@ impl TypeInformation {
 
     const fn primitive(flat: FlatType) -> TypeInformation {
         let mut info = TypeInformation::new();
-        info.depth = 1;
         info.flat.memory32[0] = flat;
         info.flat.memory64[0] = flat;
         info.flat.len = 1;
@@ -1027,7 +1016,6 @@ impl TypeInformation {
 
     const fn string() -> TypeInformation {
         let mut info = TypeInformation::new();
-        info.depth = 1;
         info.flat.memory32[0] = FlatType::I32;
         info.flat.memory32[1] = FlatType::I32;
         info.flat.memory64[0] = FlatType::I64;
@@ -1039,9 +1027,7 @@ impl TypeInformation {
     /// Builds up all flat types internally using the specified representation
     /// for all of the component fields of the record.
     fn build_record<'a>(&mut self, types: impl Iterator<Item = &'a TypeInformation>) {
-        self.depth = 1;
         for info in types {
-            self.depth = self.depth.max(1 + info.depth);
             self.has_borrow = self.has_borrow || info.has_borrow;
             match info.flat.as_flat_types() {
                 Some(types) => {
@@ -1075,16 +1061,14 @@ impl TypeInformation {
     {
         let cases = cases.into_iter();
         self.flat.push(FlatType::I32, FlatType::I32);
-        self.depth = 1;
 
         for info in cases {
             let info = match info {
                 Some(info) => info,
                 // If this case doesn't have a payload then it doesn't change
-                // the depth/flat representation
+                // the flat representation
                 None => continue,
             };
-            self.depth = self.depth.max(1 + info.depth);
             self.has_borrow = self.has_borrow || info.has_borrow;
 
             // If this variant is already unrepresentable in a flat
@@ -1150,7 +1134,6 @@ impl TypeInformation {
 
     fn fixed_length_lists(&mut self, types: &ComponentTypesBuilder, ty: &TypeFixedLengthList) {
         let element_info = types.type_information(&ty.element);
-        self.depth = 1 + element_info.depth;
         self.has_borrow = element_info.has_borrow;
         match element_info.flat.as_flat_types() {
             Some(types) => {
@@ -1167,12 +1150,10 @@ impl TypeInformation {
     }
 
     fn enums(&mut self, _types: &ComponentTypesBuilder, _ty: &TypeEnum) {
-        self.depth = 1;
         self.flat.push(FlatType::I32, FlatType::I32);
     }
 
     fn flags(&mut self, _types: &ComponentTypesBuilder, ty: &TypeFlags) {
-        self.depth = 1;
         match FlagsSize::from_count(ty.names.len()) {
             FlagsSize::Size0 => {}
             FlagsSize::Size1 | FlagsSize::Size2 => {
@@ -1208,18 +1189,15 @@ impl TypeInformation {
     fn lists(&mut self, types: &ComponentTypesBuilder, ty: &TypeList) {
         *self = TypeInformation::string();
         let info = types.type_information(&ty.element);
-        self.depth += info.depth;
         self.has_borrow = info.has_borrow;
     }
 
     fn maps(&mut self, types: &ComponentTypesBuilder, ty: &TypeMap) {
         // Maps are represented as list<tuple<k, v>> in canonical ABI
-        // So we use POINTER_PAIR like lists, and calculate depth/borrow from key and value
+        // So we use POINTER_PAIR like lists, and calculate borrow from key and value
         *self = TypeInformation::string();
         let key_info = types.type_information(&ty.key);
         let value_info = types.type_information(&ty.value);
-        // Depth is max of key/value depths, plus 1 for the extra map layer.
-        self.depth = key_info.depth.max(value_info.depth) + 1;
         self.has_borrow = key_info.has_borrow || value_info.has_borrow;
     }
 }

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1428,8 +1428,8 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.json-from-wast]]
-version = "0.253.0"
-when = "2026-07-07"
+version = "0.254.0"
+when = "2026-07-20"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.libc]]
@@ -1908,8 +1908,8 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wasm-compose]]
-version = "0.253.0"
-when = "2026-07-07"
+version = "0.254.0"
+when = "2026-07-20"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wasm-encoder]]
@@ -1918,13 +1918,13 @@ when = "2026-01-06"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wasm-encoder]]
-version = "0.251.0"
-when = "2026-05-28"
+version = "0.253.0"
+when = "2026-07-07"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wasm-encoder]]
-version = "0.253.0"
-when = "2026-07-07"
+version = "0.254.0"
+when = "2026-07-20"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wasm-metadata]]
@@ -1934,18 +1934,18 @@ user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasm-metadata]]
-version = "0.251.0"
-when = "2026-05-28"
+version = "0.253.0"
+when = "2026-07-07"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wasm-metadata]]
-version = "0.253.0"
-when = "2026-07-07"
+version = "0.254.0"
+when = "2026-07-20"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wasm-wave]]
-version = "0.253.0"
-when = "2026-07-07"
+version = "0.254.0"
+when = "2026-07-20"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wasmparser]]
@@ -1954,18 +1954,18 @@ when = "2026-01-06"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wasmparser]]
-version = "0.251.0"
-when = "2026-05-28"
+version = "0.253.0"
+when = "2026-07-07"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wasmparser]]
-version = "0.253.0"
-when = "2026-07-07"
+version = "0.254.0"
+when = "2026-07-20"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wasmprinter]]
-version = "0.253.0"
-when = "2026-07-07"
+version = "0.254.0"
+when = "2026-07-20"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wasmtime]]
@@ -2119,13 +2119,13 @@ when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wast]]
-version = "253.0.0"
-when = "2026-07-07"
+version = "254.0.0"
+when = "2026-07-20"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wat]]
-version = "1.253.0"
-when = "2026-07-07"
+version = "1.254.0"
+when = "2026-07-20"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wiggle]]
@@ -2409,13 +2409,13 @@ when = "2026-01-06"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wit-component]]
-version = "0.251.0"
-when = "2026-05-28"
+version = "0.253.0"
+when = "2026-07-07"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wit-component]]
-version = "0.253.0"
-when = "2026-07-07"
+version = "0.254.0"
+when = "2026-07-20"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wit-parser]]
@@ -2424,13 +2424,13 @@ when = "2026-01-06"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wit-parser]]
-version = "0.251.0"
-when = "2026-05-28"
+version = "0.253.0"
+when = "2026-07-07"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wit-parser]]
-version = "0.253.0"
-when = "2026-07-07"
+version = "0.254.0"
+when = "2026-07-20"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.witx]]

--- a/tests/misc_testsuite/simd/canonicalize-nan.wast
+++ b/tests/misc_testsuite/simd/canonicalize-nan.wast
@@ -97,14 +97,14 @@
 (assert_return (invoke "reinterpret-and-promote" (i32.const 0xfffefdfc))
                (i64.const 0x7ff8000000000000))
 (assert_return (invoke "copysign-and-demote" (f64.const nan))
-               (f32.const nan:0x7fc00000))
+               (f32.const nan:0x400000))
 (assert_return (invoke "copysign-and-promote" (f32.const nan))
-               (f64.const nan:0x7ff8000000000000))
+               (f64.const nan:0x8000000000000))
 
 (assert_return (invoke "f32x4.demote_f64x2_zero"
                (v128.const i64x2 0xfffefdfccccdcecf 0xfffefdfccccdcecf))
-               (v128.const f32x4 nan:0x7fc00000 nan:0x7fc00000 0 0))
+               (v128.const f32x4 nan:0x400000 nan:0x400000 0 0))
 
 (assert_return (invoke "f64x2.promote_low_f32x4"
                (v128.const i32x4 0xfffefdfc 0xfffefdfc 0 0))
-               (v128.const f64x2 nan:0x7ff8000000000000 nan:0x7ff8000000000000))
+               (v128.const f64x2 nan:0x8000000000000 nan:0x8000000000000))


### PR DESCRIPTION
* Fixes a compile-phase panic when `realloc` is required but not present.
* Fixes a compile-phase stack overflow with deeply nested types in the component model.
* Removes manual depth-limiting in Wasmtime in favor of validation in wasmparser.
* Fixes a soundness mistake in validation for the stack-switching proposal.
* Out-of-range NaN payloads are now rejected in the text format.
* Support for new component model text syntax (not updated here in Wasmtime just yet).

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
