### PR TITLE
[47.0.x] Exclude large directories from publishing 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,21 @@ readme = "README.md"
 edition.workspace = true
 default-run = "wasmtime"
 rust-version.workspace = true
+exclude = [
+  'tests/disas',
+  'tests/wasi-testsuite',
+  'tests/spec_testsuite',
+  'tests/misc_testsuite',
+  'tests/component-model',
+  'supply-chain',
+  'docs',
+  'examples/*.c',
+  'examples/*.cc',
+  'ci',
+  '.github',
+  '.claude',
+  '.agents',
+]
 
 [package.metadata.binstall]
 pkg-url = "{repo}/releases/download/v{version}/wasmtime-v{version}-{target-arch}-{target-family}{archive-suffix}"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,14 @@
+## 47.0.1
+
+Released 2026-07-20.
+
+### Fixed
+
+* Fixed publication of `wasmtime-cli` to crates.io.
+  [#13902](https://github.com/bytecodealliance/wasmtime/pull/13902)
+
+--------------------------------------------------------------------------------
+
 ## 47.0.0
 
 Released 2026-07-20.


### PR DESCRIPTION
Backport of #13902
