### PR TITLE
Support re-opening a `LinkerInstance` in `component::Linker`

### DIFF
--- a/crates/wasmtime/src/runtime/component/linker.rs
+++ b/crates/wasmtime/src/runtime/component/linker.rs
@@ -13,7 +13,7 @@ use alloc::sync::Arc;
 use core::marker;
 #[cfg(feature = "component-model-async")]
 use core::pin::Pin;
-use wasmtime_environ::component::NameMap;
+use wasmtime_environ::component::{NameMap, NameMapIntern};
 use wasmtime_environ::{Atom, PrimaryMap, StringPool};
 
 /// A type used to instantiate [`Component`]s.
@@ -908,13 +908,28 @@ impl<T: 'static> LinkerInstance<'_, T> {
     /// Same as [`LinkerInstance::instance`] except with different lifetime
     /// parameters.
     pub fn into_instance(mut self, name: &str) -> Result<Self> {
-        let name = self.insert(name, Definition::Instance(NameMap::default()))?;
-        self.map = match self.map.raw_get_mut(&name) {
+        let atom = self.strings.intern(name)?;
+
+        // If this item is already an instance then don't stomp over it with a
+        // new empty instance (or fail due to shadowing being disallowed).
+        // Instead continue through to below to explicitly allow re-opening an
+        // instance multiple times over separate API calls.
+        //
+        // If this item isn't defined, or is defined as anything other than an
+        // instance, however, the insert a fresh new instance and see what
+        // happens as a result.
+        match self.map.raw_get_mut(&atom) {
+            Some(Definition::Instance(_)) => {}
+            _ => {
+                self.insert(name, Definition::Instance(NameMap::default()))?;
+            }
+        }
+        self.map = match self.map.raw_get_mut(&atom) {
             Some(Definition::Instance(map)) => map,
             _ => unreachable!(),
         };
         self.path.truncate(self.path_len);
-        self.path.push(name);
+        self.path.push(atom);
         self.path_len += 1;
         Ok(self)
     }

--- a/tests/all/component_model/linker.rs
+++ b/tests/all/component_model/linker.rs
@@ -1,7 +1,7 @@
 use wasmtime::Result;
 use wasmtime::component::types::ComponentItem;
 use wasmtime::component::{Component, Linker, ResourceType};
-use wasmtime::{Config, Engine, Store};
+use wasmtime::{Config, Engine, Module, Store};
 
 #[test]
 fn old_import_importing_new_item() -> Result<()> {
@@ -208,6 +208,23 @@ fn linker_fails_to_define_unknown_core_module_imports_as_traps() -> Result<()> {
         )"#,
     )?;
     assert!(linker.define_unknown_imports_as_traps(&component).is_err());
+
+    Ok(())
+}
+
+#[test]
+fn open_instance_twice() -> Result<()> {
+    let engine = Engine::default();
+    let mut linker = Linker::<()>::new(&engine);
+
+    let module = Module::new(&engine, "(module)")?;
+    linker.instance("foo")?.module("a", &module)?;
+    linker.instance("foo")?.module("b", &module)?;
+    assert!(linker.instance("foo")?.module("a", &module).is_err());
+    assert!(linker.instance("foo")?.module("b", &module).is_err());
+    linker.instance("foo")?.module("c", &module)?;
+    assert!(linker.root().module("foo", &module).is_err());
+    linker.instance("foo")?.module("d", &module)?;
 
     Ok(())
 }


### PR DESCRIPTION
Previously an instance within a linker had to be defined all-in-one go. This isn't the most ergonomic, however, and isn't compatible with situations where this may be partially defined over time. One example is in #13896 where the implementation of `define_unknown_imports_as_traps` mistakenly didn't work for components where instance were already defined. The goal of this commit is to make the `Linker` more builder-like by supporting incremental definitions such that nothing ever stomps over previous definitions (unless shadowing is enabled).

Closes #13896

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
