### PR TITLE
winch(aarch64): add v128.const support

### DIFF
--- a/crates/test-util/src/wast.rs
+++ b/crates/test-util/src/wast.rs
@@ -416,7 +416,7 @@ impl Compiler {
                 }
 
                 if cfg!(target_arch = "aarch64") {
-                    return (config.simd() && !config.spec_test()) || config.threads();
+                    return config.threads();
                 }
 
                 !cfg!(target_arch = "x86_64")
@@ -556,16 +556,17 @@ impl WastTest {
                     "misc_testsuite/simd/issue_3327_bnot_lowering.wast",
                     "misc_testsuite/simd/load_splat_out_of_bounds.wast",
                     "misc_testsuite/simd/replace-lane-preserve.wast",
+                    "misc_testsuite/simd/riscv64-replicated-imm5-works.wast",
                     "misc_testsuite/simd/spillslot-size-fuzzbug.wast",
                     "misc_testsuite/simd/sse-cannot-fold-unaligned-loads.wast",
                     "misc_testsuite/simd/unaligned-load.wast",
+                    "misc_testsuite/simd/v128-equal.wast",
                     "misc_testsuite/simd/v128-select.wast",
                     "misc_testsuite/winch/issue-10331.wast",
                     "misc_testsuite/winch/issue-10357.wast",
                     "misc_testsuite/winch/issue-10460.wast",
                     "misc_testsuite/winch/replace_lane.wast",
                     "misc_testsuite/winch/simd_multivalue.wast",
-                    "misc_testsuite/winch/v128_load_lane_invalid_address.wast",
                     "spec_testsuite/proposals/annotations/simd_lane.wast",
                     "spec_testsuite/proposals/multi-memory/simd_memory-multi.wast",
                     "spec_testsuite/simd_address.wast",

--- a/crates/test-util/src/wast.rs
+++ b/crates/test-util/src/wast.rs
@@ -416,7 +416,7 @@ impl Compiler {
                 }
 
                 if cfg!(target_arch = "aarch64") {
-                    return config.threads();
+                    return (config.simd() && !config.spec_test()) || config.threads();
                 }
 
                 !cfg!(target_arch = "x86_64")
@@ -512,6 +512,13 @@ impl WastTest {
             }
         }
 
+        if config.compiler == Compiler::Winch && cfg!(target_arch = "aarch64") {
+            let now_supported = ["misc_testsuite/winch/v128_load_lane_invalid_address.wast"];
+            if now_supported.iter().any(|part| self.path.ends_with(part)) {
+                return false;
+            }
+        }
+
         if config.compiler.should_fail(&self.config) {
             return true;
         }
@@ -556,11 +563,9 @@ impl WastTest {
                     "misc_testsuite/simd/issue_3327_bnot_lowering.wast",
                     "misc_testsuite/simd/load_splat_out_of_bounds.wast",
                     "misc_testsuite/simd/replace-lane-preserve.wast",
-                    "misc_testsuite/simd/riscv64-replicated-imm5-works.wast",
                     "misc_testsuite/simd/spillslot-size-fuzzbug.wast",
                     "misc_testsuite/simd/sse-cannot-fold-unaligned-loads.wast",
                     "misc_testsuite/simd/unaligned-load.wast",
-                    "misc_testsuite/simd/v128-equal.wast",
                     "misc_testsuite/simd/v128-select.wast",
                     "misc_testsuite/winch/issue-10331.wast",
                     "misc_testsuite/winch/issue-10357.wast",

--- a/tests/disas/winch/aarch64/v128_const/const.wat
+++ b/tests/disas/winch/aarch64/v128_const/const.wat
@@ -1,0 +1,40 @@
+;;! target = "aarch64"
+;;! test = "winch"
+
+(module
+  (memory 1)
+  (func (export "run")
+    (v128.store (i32.const 0) (v128.const i32x4 1 2 3 4))))
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
+;;       mov     x28, sp
+;;       ldur    x16, [x0, #8]
+;;       ldur    x16, [x16, #0x18]
+;;       mov     x17, #0
+;;       movk    x17, #0x10
+;;       add     x16, x16, x17
+;;       cmp     sp, x16
+;;       b.lo    #0x6c
+;;   2c: mov     x9, x0
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       ldr     q0, #0x70
+;;       mov     x0, #0
+;;       ldur    x1, [x9, #0x38]
+;;       add     x1, x1, w0, uxtw
+;;       stur    q0, [x1]
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
+;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret
+;;   6c: udf     #0xc11f
+;;   70: udf     #1
+;;   74: udf     #2
+;;   78: udf     #3
+;;   7c: udf     #4

--- a/winch/codegen/src/codegen/error.rs
+++ b/winch/codegen/src/codegen/error.rs
@@ -35,9 +35,6 @@ pub(crate) enum CodeGenError {
     /// Unsupported eager initialization of tables.
     #[error("Unsupported eager initialization of tables")]
     UnsupportedTableEagerInit,
-    /// Unsupported immediate for instruction.
-    #[error("Unsupported immediate")]
-    UnsupportedImm,
     /// An internal error.
     ///
     /// This error means that an internal invariant was not met and usually
@@ -177,10 +174,6 @@ impl CodeGenError {
 
     pub(crate) const fn invalid_local_offset() -> Self {
         Self::Internal(InternalError::InvalidLocalOffset)
-    }
-
-    pub(crate) const fn unsupported_imm() -> Self {
-        Self::UnsupportedImm
     }
 
     pub(crate) const fn invalid_two_arg_form() -> Self {

--- a/winch/codegen/src/isa/aarch64/asm.rs
+++ b/winch/codegen/src/isa/aarch64/asm.rs
@@ -313,7 +313,11 @@ impl Assembler {
                     .for_each(|i| self.emit(i));
             }
             RegClass::Float => {
-                match ASIMDFPModImm::maybe_from_u64(imm.unwrap_as_u64(), size.into()) {
+                let modimm = match imm {
+                    Imm::V128(_) => None,
+                    _ => ASIMDFPModImm::maybe_from_u64(imm.unwrap_as_u64(), size.into()),
+                };
+                match modimm {
                     Some(imm) => {
                         self.emit(Inst::FpuMoveFPImm {
                             rd: rd.map(Into::into),

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -6,7 +6,7 @@ use super::{
     regs::{self, scratch_fpr_bitset, scratch_gpr_bitset},
 };
 use crate::{
-    Context, Result,
+    Result,
     abi::{self, align_to, calculate_frame_adjustment, local::LocalSlot, vmctx},
     bail,
     codegen::{CodeGenContext, CodeGenError, Emission, FuncEnv, ptr_type_from_ptr_size},
@@ -517,14 +517,10 @@ impl Masm for MacroAssembler {
                     self.asm.mov_ir(dst, v, v.size());
                     Ok(())
                 }
-                imm @ (I::F32(_) | I::F64(_)) => {
+                imm @ (I::F32(_) | I::F64(_) | I::V128(_)) => {
                     self.asm.mov_ir(dst, imm, imm.size());
                     Ok(())
                 }
-                I::V128(_) => Err(CodeGenError::unsupported_imm()).context(
-                    "v128 immediates are not supported in winch+aarch64; the SIMD and \
-                     relaxed-SIMD proposals are unimplemented for this target",
-                ),
             },
             (RegImm::Reg(rs), rd) => match (rs.class(), rd.to_reg().class()) {
                 (RegClass::Int, RegClass::Int) => Ok(self.asm.mov_rr(rs, rd, size)),


### PR DESCRIPTION
This pr adds support for v128.const to winch for aarch64.

I'd like to tackle the [larger list](https://github.com/bytecodealliance/wasmtime/issues/9925) of missing SIMD support, and figured I should start with something small.

In `mov_ir` the v128 immediate takes the `add_constant` path rather than the emit path since that's what the x64 backend does for these [load_fp_const](https://github.com/bytecodealliance/wasmtime/blob/08aa57b569b4dfdec45d28e463b80ef19ac9a5ef/winch/codegen/src/isa/x64/asm.rs#L323-L327).

If this goes through I could go ahead and tackle the rest of v128, followed by the others.