### PR TITLE
Fix current-thread leak on concurrent lower error paths

### DIFF
--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -61,7 +61,7 @@ use crate::hash_set::HashSet;
 #[cfg(feature = "gc")]
 use crate::module::ModuleRegistry;
 use crate::prelude::*;
-use crate::store::{Store, StoreId, StoreInner, StoreOpaque, StoreToken};
+use crate::store::{AsStoreOpaque, Store, StoreId, StoreInner, StoreOpaque, StoreToken};
 #[cfg(feature = "gc")]
 use crate::vm::GcRootsList;
 use crate::vm::component::{CallContext, ComponentInstance, InstanceState};
@@ -928,33 +928,33 @@ fn handle_guest_call(store: &mut dyn VMStore, call: GuestCall) -> Result<()> {
                     call.thread,
                 );
 
-                let old_thread = store.set_thread(call.thread)?;
-                log::trace!(
-                    "GuestCallKind::DeliverEvent: replaced {old_thread:?} with {:?} as current thread",
-                    call.thread
-                );
+                let code = with_store_thread(store, call.thread, |store| {
+                    log::trace!(
+                        "GuestCallKind::DeliverEvent: set {:?} as current thread",
+                        call.thread
+                    );
 
-                store.enter_instance(runtime_instance);
+                    store.enter_instance(runtime_instance);
 
-                let Some(callback) = store
-                    .concurrent_state_mut()?
-                    .get_mut(call.thread.task)?
-                    .callback
-                    .take()
-                else {
-                    bail_bug!("guest task callback field not present")
-                };
+                    let Some(callback) = store
+                        .concurrent_state_mut()?
+                        .get_mut(call.thread.task)?
+                        .callback
+                        .take()
+                    else {
+                        bail_bug!("guest task callback field not present")
+                    };
 
-                let code = callback(store, event, handle)?;
+                    let code = callback(store, event, handle)?;
 
-                store
-                    .concurrent_state_mut()?
-                    .get_mut(call.thread.task)?
-                    .callback = Some(callback);
+                    store
+                        .concurrent_state_mut()?
+                        .get_mut(call.thread.task)?
+                        .callback = Some(callback);
 
-                store.exit_instance(runtime_instance)?;
-
-                store.set_thread(old_thread)?;
+                    store.exit_instance(runtime_instance)?;
+                    Ok(code)
+                })?;
 
                 next = instance.handle_callback_code(
                     store,
@@ -963,9 +963,7 @@ fn handle_guest_call(store: &mut dyn VMStore, call: GuestCall) -> Result<()> {
                     code,
                 )?;
 
-                log::trace!(
-                    "GuestCallKind::DeliverEvent: restored {old_thread:?} as current thread"
-                );
+                log::trace!("GuestCallKind::DeliverEvent: restored previous current thread");
             }
             GuestCallKind::StartImplicit(fun) => {
                 next = fun(store)?;
@@ -1598,6 +1596,114 @@ impl<T> StoreContextMut<'_, T> {
     }
 }
 
+/// Temporarily set `thread` as the store's current thread while running `f`,
+/// then always restore the previous thread.
+///
+/// Restoration runs even when `f` returns an error. If both `f` and the
+/// restore fail, the error from `f` is preferred.
+fn with_store_thread<S, R>(
+    store: &mut S,
+    thread: impl Into<CurrentThread>,
+    f: impl FnOnce(&mut S) -> Result<R>,
+) -> Result<R>
+where
+    S: AsStoreOpaque + ?Sized,
+{
+    let old = store.as_store_opaque().set_thread(thread)?;
+    let result = f(store);
+    store.as_store_opaque().restore_thread_after(old, result)
+}
+
+#[cfg(test)]
+mod with_store_thread_tests {
+    use super::table::TableId;
+    use super::{CurrentThread, HostTask, with_store_thread};
+    use crate::store::AsStoreOpaque;
+    use crate::{Config, Engine, Result, Store, bail};
+
+    fn concurrent_store() -> Store<()> {
+        let mut config = Config::new();
+        config.concurrency_support(true);
+        let engine = Engine::new(&config).unwrap();
+        Store::new(&engine, ())
+    }
+
+    fn current_thread(store: &mut Store<()>) -> CurrentThread {
+        store
+            .as_store_opaque()
+            .concurrent_state_mut()
+            .unwrap()
+            .unforced_current_thread
+    }
+
+    /// A non-`None` current-thread value that `set_thread` accepts without a
+    /// live table entry (host threads skip guest context slot traffic).
+    fn host_marker() -> CurrentThread {
+        CurrentThread::Host(TableId::<HostTask>::new(0xdead_beef))
+    }
+
+    #[test]
+    fn restores_on_success() {
+        let mut store = concurrent_store();
+        store.as_store_opaque().set_thread(host_marker()).unwrap();
+        assert!(matches!(current_thread(&mut store), CurrentThread::Host(_)));
+
+        with_store_thread(&mut store, CurrentThread::None, |_store| {
+            assert!(matches!(
+                // Inside the scope the temporary thread is active.
+                current_thread(_store),
+                CurrentThread::None
+            ));
+            Ok::<_, crate::Error>(42)
+        })
+        .unwrap();
+
+        assert!(matches!(current_thread(&mut store), CurrentThread::Host(_)));
+    }
+
+    #[test]
+    fn restores_on_error() {
+        let mut store = concurrent_store();
+        store.as_store_opaque().set_thread(host_marker()).unwrap();
+        assert!(matches!(current_thread(&mut store), CurrentThread::Host(_)));
+
+        let err = with_store_thread(&mut store, CurrentThread::None, |_store| -> Result<()> {
+            bail!("simulated lower failure")
+        })
+        .unwrap_err();
+        assert!(
+            format!("{err}").contains("simulated lower failure"),
+            "unexpected error: {err}"
+        );
+        assert!(
+            matches!(current_thread(&mut store), CurrentThread::Host(_)),
+            "thread context must be restored after error; got {:?}",
+            current_thread(&mut store)
+        );
+    }
+
+    #[test]
+    fn prefers_work_error_over_restore_error() {
+        // Mirrors `StoreOpaque::restore_thread_after` error preference.
+        fn prefer<R>(work: Result<R>, restore: Result<()>) -> Result<R> {
+            match (work, restore) {
+                (Ok(v), Ok(())) => Ok(v),
+                (Ok(_), Err(e)) => Err(e),
+                (Err(e), _) => Err(e),
+            }
+        }
+        let err = prefer::<()>(
+            Err(crate::format_err!("work")),
+            Err(crate::format_err!("restore")),
+        )
+        .unwrap_err();
+        assert!(format!("{err}").contains("work"));
+        assert_eq!(prefer(Ok(7), Ok(())).unwrap(), 7);
+        let err = prefer(Ok(1), Err(crate::format_err!("restore"))).unwrap_err();
+        assert!(format!("{err}").contains("restore"));
+    }
+}
+
 impl StoreOpaque {
     /// Returns the currently-running thread, promoting any deferred lazy thread
     /// into a fully-materialized `CurrentThread`.
@@ -1970,6 +2076,18 @@ impl StoreOpaque {
         };
 
         Ok(old_thread)
+    }
+
+    /// Restore `old` as the current thread after `result`.
+    ///
+    /// Prefer the original work error over a restore failure so callers still
+    /// see the failure that happened while `old` was swapped out.
+    fn restore_thread_after<R>(&mut self, old: CurrentThread, result: Result<R>) -> Result<R> {
+        match (result, self.set_thread(old)) {
+            (Ok(v), Ok(_)) => Ok(v),
+            (Ok(_), Err(e)) => Err(e),
+            (Err(e), _) => Err(e),
+        }
     }
 
     /// Set the global variable representing whether the current task may block
@@ -2650,19 +2768,21 @@ impl Instance {
                     "stackless call: replaced {old_thread:?} with {guest_thread:?} as current thread"
                 );
 
-                store.enter_instance(callee_instance);
+                let result = (|| {
+                    store.enter_instance(callee_instance);
 
-                // SAFETY: See the documentation for `make_call` to review the
-                // contract we must uphold for `call` here.
-                //
-                // Per the contract described in the `queue_call`
-                // documentation, the `callee` pointer which `call` closes
-                // over must be valid.
-                let storage = call(store)?;
+                    // SAFETY: See the documentation for `make_call` to review the
+                    // contract we must uphold for `call` here.
+                    //
+                    // Per the contract described in the `queue_call`
+                    // documentation, the `callee` pointer which `call` closes
+                    // over must be valid.
+                    let storage = call(store)?;
 
-                store.exit_instance(callee_instance)?;
-
-                store.set_thread(old_thread)?;
+                    store.exit_instance(callee_instance)?;
+                    Ok(storage)
+                })();
+                let storage = store.restore_thread_after(old_thread, result)?;
                 let state = store.concurrent_state_mut()?;
                 if let Some(t) = old_thread.guest() {
                     state.get_mut(t.thread)?.state = GuestThreadState::Running;
@@ -2684,76 +2804,75 @@ impl Instance {
                     store,
                     callee_instance.index,
                 )?;
-                let old_thread = store.set_thread(guest_thread)?;
-                log::trace!(
-                    "sync/async-stackful call: replaced {old_thread:?} with {guest_thread:?} as current thread",
-                );
-                let flags = self.id().get(store).instance_flags(callee_instance.index);
+                with_store_thread(store, guest_thread, |store| {
+                    log::trace!("sync/async-stackful call: set {guest_thread:?} as current thread",);
+                    let flags = self.id().get(store).instance_flags(callee_instance.index);
 
-                // Unless this is a callback-less (i.e. stackful)
-                // async-lifted export, we need to record that the instance
-                // cannot be entered until the call returns.
-                if !async_ {
-                    store.enter_instance(callee_instance);
-                }
-
-                // SAFETY: See the documentation for `make_call` to review the
-                // contract we must uphold for `call` here.
-                //
-                // Per the contract described in the `queue_call`
-                // documentation, the `callee` pointer which `call` closes
-                // over must be valid.
-                let storage = call(store)?;
-
-                if !async_ {
-                    // This is a sync-lifted export, so now is when we lift the
-                    // result, optionally call the post-return function, if any,
-                    // and finally notify any current or future waiters that the
-                    // subtask has returned.
-
-                    let lift = {
-                        store.exit_instance(callee_instance)?;
-
-                        let state = store.concurrent_state_mut()?;
-                        if !state.get_mut(guest_thread.task)?.result.is_none() {
-                            bail_bug!("task has already produced a result");
-                        }
-
-                        match state.get_mut(guest_thread.task)?.lift_result.take() {
-                            Some(lift) => lift,
-                            None => bail_bug!("lift_result field is missing"),
-                        }
-                    };
-
-                    // SAFETY: `result_count` represents the number of core Wasm
-                    // results returned, per `wasmparser`.
-                    let result = (lift.lift)(store, unsafe {
-                        mem::transmute::<&[MaybeUninit<ValRaw>], &[ValRaw]>(
-                            &storage[..result_count],
-                        )
-                    })?;
-
-                    let post_return_arg = match result_count {
-                        0 => ValRaw::i32(0),
-                        // SAFETY: `result_count` represents the number of
-                        // core Wasm results returned, per `wasmparser`.
-                        1 => unsafe { storage[0].assume_init() },
-                        _ => unreachable!(),
-                    };
-
-                    unsafe {
-                        call_post_return(
-                            token.as_context_mut(store),
-                            post_return.map(|v| v.as_non_null()),
-                            post_return_arg,
-                            flags,
-                        )?;
+                    // Unless this is a callback-less (i.e. stackful)
+                    // async-lifted export, we need to record that the instance
+                    // cannot be entered until the call returns.
+                    if !async_ {
+                        store.enter_instance(callee_instance);
                     }
 
-                    self.task_complete(store, guest_thread.task, result, Status::Returned)?;
-                }
+                    // SAFETY: See the documentation for `make_call` to review the
+                    // contract we must uphold for `call` here.
+                    //
+                    // Per the contract described in the `queue_call`
+                    // documentation, the `callee` pointer which `call` closes
+                    // over must be valid.
+                    let storage = call(store)?;
 
-                store.set_thread(old_thread)?;
+                    if !async_ {
+                        // This is a sync-lifted export, so now is when we lift the
+                        // result, optionally call the post-return function, if any,
+                        // and finally notify any current or future waiters that the
+                        // subtask has returned.
+
+                        let lift = {
+                            store.exit_instance(callee_instance)?;
+
+                            let state = store.concurrent_state_mut()?;
+                            if !state.get_mut(guest_thread.task)?.result.is_none() {
+                                bail_bug!("task has already produced a result");
+                            }
+
+                            match state.get_mut(guest_thread.task)?.lift_result.take() {
+                                Some(lift) => lift,
+                                None => bail_bug!("lift_result field is missing"),
+                            }
+                        };
+
+                        // SAFETY: `result_count` represents the number of core Wasm
+                        // results returned, per `wasmparser`.
+                        let result = (lift.lift)(store, unsafe {
+                            mem::transmute::<&[MaybeUninit<ValRaw>], &[ValRaw]>(
+                                &storage[..result_count],
+                            )
+                        })?;
+
+                        let post_return_arg = match result_count {
+                            0 => ValRaw::i32(0),
+                            // SAFETY: `result_count` represents the number of
+                            // core Wasm results returned, per `wasmparser`.
+                            1 => unsafe { storage[0].assume_init() },
+                            _ => unreachable!(),
+                        };
+
+                        unsafe {
+                            call_post_return(
+                                token.as_context_mut(store),
+                                post_return.map(|v| v.as_non_null()),
+                                post_return_arg,
+                                flags,
+                            )?;
+                        }
+
+                        self.task_complete(store, guest_thread.task, result, Status::Returned)?;
+                    }
+
+                    Ok(())
+                })?;
 
                 store
                     .concurrent_state_mut()?
@@ -2929,25 +3048,22 @@ impl Instance {
                     // thread, this thread's caller, may have `realloc`
                     // callbacks invoked for example and those need the correct
                     // context set for the current thread.
-                    let prev = store.0.set_thread(old_thread)?;
-
-                    // SAFETY: `return_` is a valid `*mut VMFuncRef` from
-                    // `wasmtime-cranelift`-generated fused adapter code.  Based
-                    // on how it was constructed (see
-                    // `wasmtime_environ::fact::trampoline::Compiler::compile_async_return_adapter`
-                    // for details) we know it takes `src.len()` parameters and
-                    // returns up to 1 result.
-                    unsafe {
-                        crate::Func::call_unchecked_raw(
-                            &mut store,
-                            return_.as_non_null(),
-                            my_src.as_mut_slice().into(),
-                        )?;
-                    }
-
-                    // Restore the previous current thread after the
-                    // lifting/lowering has returned.
-                    store.0.set_thread(prev)?;
+                    with_store_thread(&mut store, old_thread, |store| {
+                        // SAFETY: `return_` is a valid `*mut VMFuncRef` from
+                        // `wasmtime-cranelift`-generated fused adapter code.  Based
+                        // on how it was constructed (see
+                        // `wasmtime_environ::fact::trampoline::Compiler::compile_async_return_adapter`
+                        // for details) we know it takes `src.len()` parameters and
+                        // returns up to 1 result.
+                        unsafe {
+                            crate::Func::call_unchecked_raw(
+                                store,
+                                return_.as_non_null(),
+                                my_src.as_mut_slice().into(),
+                            )?;
+                        }
+                        Ok(())
+                    })?;
 
                     let thread = store.0.current_guest_thread()?;
                     let state = store.0.concurrent_state_mut()?;
@@ -3262,28 +3378,26 @@ impl Instance {
                 // how to manipulate borrows and knows which scope of borrows
                 // to check.
                 let mut store = token.as_context_mut(store);
-                let old = store.0.set_thread(task)?;
+                with_store_thread(&mut store, task, |store| {
+                    let status = if result.is_some() {
+                        Status::Returned
+                    } else {
+                        Status::ReturnCancelled
+                    };
 
-                let status = if result.is_some() {
-                    Status::Returned
-                } else {
-                    Status::ReturnCancelled
-                };
+                    lower(store.as_context_mut(), result)?;
+                    let state = store.0.concurrent_state_mut()?;
+                    match &mut state.get_mut(task)?.state {
+                        // The task is already flagged as finished because it was
+                        // cancelled. No need to transition further.
+                        HostTaskState::CalleeDone { .. } => {}
 
-                lower(store.as_context_mut(), result)?;
-                let state = store.0.concurrent_state_mut()?;
-                match &mut state.get_mut(task)?.state {
-                    // The task is already flagged as finished because it was
-                    // cancelled. No need to transition further.
-                    HostTaskState::CalleeDone { .. } => {}
-
-                    // Otherwise transition this task to the done state.
-                    other => *other = HostTaskState::CalleeDone { cancelled: false },
-                }
-                Waitable::Host(task).set_event(state, Some(Event::Subtask { status }))?;
-
-                store.0.set_thread(old)?;
-                Ok(())
+                        // Otherwise transition this task to the done state.
+                        other => *other = HostTaskState::CalleeDone { cancelled: false },
+                    }
+                    Waitable::Host(task).set_event(state, Some(Event::Subtask { status }))?;
+                    Ok(())
+                })
             };
 
             // Here we schedule a task to run on a worker fiber to do the
@@ -3680,12 +3794,14 @@ impl Instance {
                 );
 
                 let mut store = token.as_context_mut(store);
-                let mut params = [ValRaw::i32(context)];
-                // Use call_unchecked rather than call or call_async, as we don't want to run the function
-                // on a separate fiber if we're running in an async store.
-                unsafe { callee.call_unchecked(store.as_context_mut(), &mut params)? };
-
-                store.0.set_thread(old_thread)?;
+                let result = (|| {
+                    let mut params = [ValRaw::i32(context)];
+                    // Use call_unchecked rather than call or call_async, as we don't want to run the function
+                    // on a separate fiber if we're running in an async store.
+                    unsafe { callee.call_unchecked(store.as_context_mut(), &mut params)? };
+                    Ok(())
+                })();
+                store.0.restore_thread_after(old_thread, result)?;
 
                 store.0.cleanup_thread(
                     guest_thread,

--- a/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
@@ -250,35 +250,42 @@ fn lower<T: func::Lower + Send + 'static, B: WriteBuffer<T>, U: 'static>(
 
     // If lowering may call realloc in the guest, then the guest may need
     // to access its thread context, so we need to set the current thread before lowering
-    // and restore the old one afterward.
-    let (lower, old_thread) = if T::MAY_REQUIRE_REALLOC {
-        let old_thread = store.0.set_thread(caller_thread)?;
-        (
-            &mut LowerContext::new(store.as_context_mut(), options, instance),
-            Some(old_thread),
-        )
-    } else {
-        (
-            &mut LowerContext::new_without_realloc(store.as_context_mut(), options, instance),
-            None,
-        )
+    // and restore the old one afterward (including on error paths).
+    let finish_lower = |lower: &mut LowerContext<'_, U>| -> Result<()> {
+        if address % usize::try_from(T::ALIGN32)? != 0 {
+            bail!("read pointer not aligned");
+        }
+        lower
+            .as_slice_mut()
+            .get_mut(address..)
+            .and_then(|b| b.get_mut(..T::SIZE32 * count))
+            .ok_or_else(|| crate::format_err!("read pointer out of bounds of memory"))?;
+
+        if let Some(payload_ty) = ty.payload(lower.types) {
+            T::linear_store_list_to_memory(
+                lower,
+                *payload_ty,
+                address,
+                &buffer.remaining()[..count],
+            )?;
+        }
+        Ok(())
     };
 
-    if address % usize::try_from(T::ALIGN32)? != 0 {
-        bail!("read pointer not aligned");
-    }
-    lower
-        .as_slice_mut()
-        .get_mut(address..)
-        .and_then(|b| b.get_mut(..T::SIZE32 * count))
-        .ok_or_else(|| crate::format_err!("read pointer out of bounds of memory"))?;
-
-    if let Some(ty) = ty.payload(lower.types) {
-        T::linear_store_list_to_memory(lower, *ty, address, &buffer.remaining()[..count])?;
-    }
-
-    if let Some(old_thread) = old_thread {
-        store.0.set_thread(old_thread)?;
+    if T::MAY_REQUIRE_REALLOC {
+        super::with_store_thread(&mut store, caller_thread, |store| {
+            finish_lower(&mut LowerContext::new(
+                store.as_context_mut(),
+                options,
+                instance,
+            ))
+        })?;
+    } else {
+        finish_lower(&mut LowerContext::new_without_realloc(
+            store.as_context_mut(),
+            options,
+            instance,
+        ))?;
     }
 
     buffer.skip(count);
@@ -3276,7 +3283,7 @@ impl Instance {
         rep: u32,
     ) -> Result<()> {
         let (write_component, store) = write_instance.component_and_store_mut(store.0);
-        let (read_component, mut store) = read_instance.component_and_store_mut(store);
+        let (read_component, store) = read_instance.component_and_store_mut(store);
         let write_types = write_component.types();
         let read_types = read_component.types();
         let count = count.as_usize();
@@ -3348,21 +3355,25 @@ impl Instance {
                 if let Some(val) = val {
                     // Serializing the value may require calling the guest's realloc function, so we
                     // set the guest's thread context in case realloc requires it, and restore the original
-                    // thread context after the copy is complete.
-                    let old_thread = store.set_thread(read_caller_thread)?;
-                    let lower =
-                        &mut LowerContext::new(store.as_context_mut(), read_options, read_instance);
-                    let ptr = func::validate_inbounds_dynamic(
-                        read_abi,
-                        lower.as_slice_mut(),
-                        &ValRaw::u32(read_address.try_into()?),
-                    )?;
-                    let ty = match read_payload_ty {
-                        Some(ty) => ty,
-                        None => bail_bug!("expected read payload type to be present"),
-                    };
-                    val.store(lower, *ty, ptr)?;
-                    store.set_thread(old_thread)?;
+                    // thread context after the copy is complete (including on error paths).
+                    super::with_store_thread(store, read_caller_thread, |mut store| {
+                        let lower = &mut LowerContext::new(
+                            store.as_context_mut(),
+                            read_options,
+                            read_instance,
+                        );
+                        let ptr = func::validate_inbounds_dynamic(
+                            read_abi,
+                            lower.as_slice_mut(),
+                            &ValRaw::u32(read_address.try_into()?),
+                        )?;
+                        let ty = match read_payload_ty {
+                            Some(ty) => ty,
+                            None => bail_bug!("expected read payload type to be present"),
+                        };
+                        val.store(lower, *ty, ptr)?;
+                        Ok(())
+                    })?;
                 }
             }
             (TransmitIndex::Stream(_), TransmitIndex::Stream(_)) => {
@@ -3434,16 +3445,20 @@ impl Instance {
 
                     // Serializing the value may require calling the guest's realloc function, so we
                     // set the guest's thread context in case realloc requires it, and restore the original
-                    // thread context after the copy is complete.
-                    let old_thread = store.set_thread(read_caller_thread)?;
-                    let lower =
-                        &mut LowerContext::new(store.as_context_mut(), read_options, read_instance);
-                    let mut ptr = read_address;
-                    for value in values {
-                        value.store(lower, *read_payload_ty, ptr)?;
-                        ptr += usize::try_from(read_abi.size32)?;
-                    }
-                    store.set_thread(old_thread)?;
+                    // thread context after the copy is complete (including on error paths).
+                    super::with_store_thread(store, read_caller_thread, |mut store| {
+                        let lower = &mut LowerContext::new(
+                            store.as_context_mut(),
+                            read_options,
+                            read_instance,
+                        );
+                        let mut ptr = read_address;
+                        for value in values {
+                            value.store(lower, *read_payload_ty, ptr)?;
+                            ptr += usize::try_from(read_abi.size32)?;
+                        }
+                        Ok(())
+                    })?;
                 }
             }
             _ => bail_bug!("mismatched transmit types in copy"),

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -2475,6 +2475,12 @@ impl<T: 'static> AsStoreOpaque for StoreInner<T> {
     }
 }
 
+impl<T: 'static> AsStoreOpaque for StoreContextMut<'_, T> {
+    fn as_store_opaque(&mut self) -> &mut StoreOpaque {
+        &mut *self.0
+    }
+}
+
 impl<T: AsStoreOpaque + ?Sized> AsStoreOpaque for &mut T {
     fn as_store_opaque(&mut self) -> &mut StoreOpaque {
         T::as_store_opaque(self)


### PR DESCRIPTION
## Summary

Temporary `set_thread` switches used during concurrent component lowering (so guest `realloc` / callbacks see the correct thread) were not restored on error paths. An early `?` / `bail!` after `set_thread` left the store's current thread pointing at the temporary thread, so later concurrent operations could run with the wrong thread context.

This adds `with_store_thread` / `restore_thread_after` that always restore the previous thread (preferring the original work error if restore also fails), and converts every temporary save/restore pair in this class.

## Why this is needed

[#12736](https://github.com/bytecodealliance/wasmtime/pull/12736) correctly established that stream/future lowering can call guest `realloc` and therefore must set the current thread first. That PR also added restore on the success path. Error paths that return before the matching restore still leave the wrong thread installed.

Concrete example in `futures_and_streams::lower` when `T::MAY_REQUIRE_REALLOC` is true:

1. `set_thread(caller_thread)` installs the caller.
2. Alignment / bounds checks or `linear_store_list_to_memory` can fail with `?`.
3. The matching `set_thread(old_thread)` never runs.

The same pattern existed for guest↔guest future/stream `copy`, event delivery callbacks, stackless/stackful guest calls, async return adapters, host-task result lowering, and explicit thread start.

## Fix

- `StoreOpaque::restore_thread_after` always restores after a work `Result`.
- Free function `with_store_thread` for the common scoped form.
- `AsStoreOpaque` for `StoreContextMut` so the helper works at those call sites.
- Converted all temporary `set_thread` pairs found by grepping `crates/wasmtime/src/runtime/component`.

Permanent thread transitions (enter/exit sync call, host task create, fiber resume bookkeeping) are unchanged.

## Testing

Unit tests in `with_store_thread_tests`:

- Restores the previous current thread on success.
- Restores the previous current thread when work returns an error (red-green: skipping restore fails the assertion with `got None` after installing a host marker thread).
- Prefer work errors over restore errors.

```
cargo test -p wasmtime --features component-model-async --lib with_store_thread
# 3 passed
```

Also ran other concurrent unit tests in the crate (`cargo test -p wasmtime --features component-model-async --lib concurrent`).

## Related

- Introduced with incomplete restore coverage in [#12736](https://github.com/bytecodealliance/wasmtime/pull/12736) (merged 2026-03-11). Review discussion there already asked about restoring the previous thread after the temporary switch.
- Related current-thread API work: [#13887](https://github.com/bytecodealliance/wasmtime/pull/13887), [#13759](https://github.com/bytecodealliance/wasmtime/pull/13759).

