### PR TITLE
Cranelift: skip CFG rebuild in egraph pass when no terminator changed

### DIFF
--- a/cranelift/codegen/src/egraph/mod.rs
+++ b/cranelift/codegen/src/egraph/mod.rs
@@ -756,7 +756,7 @@ impl<'a> EgraphPass<'a> {
 
     /// Run the process.
     pub fn run(&mut self) {
-        self.remove_pure_and_optimize();
+        let cfg_maybe_changed = self.remove_pure_and_optimize();
 
         trace!("egraph built:\n{}\n", self.func.display());
         if cfg!(feature = "trace-log") {
@@ -773,12 +773,15 @@ impl<'a> EgraphPass<'a> {
 
         // Branch simplification could have mutated the CFG and made some blocks
         // unreachable; recompute the CFG, find which blocks are still
-        // reachable, and remove those that aren't.
-        self.cfg.compute(self.func);
-        let reachable_blocks = self.find_reachable_blocks();
-        crate::unreachable_code::eliminate_unreachable_code(self.func, self.cfg, |block| {
-            reachable_blocks.contains(block)
-        });
+        // reachable, and remove those that aren't. But only do this if we
+        // rewrote a block terminator, because otherwise the CFG is unchanged.
+        if cfg_maybe_changed {
+            self.cfg.compute(self.func);
+            let reachable_blocks = self.find_reachable_blocks();
+            crate::unreachable_code::eliminate_unreachable_code(self.func, self.cfg, |block| {
+                reachable_blocks.contains(block)
+            });
+        }
 
         self.elaborate();
 
@@ -804,8 +807,15 @@ impl<'a> EgraphPass<'a> {
     /// because the eclass can continue to be updated and we need to
     /// only refer to its subset that exists at this stage, to
     /// maintain acyclicity.)
-    fn remove_pure_and_optimize(&mut self) {
+    ///
+    /// Returns whether we may have modified the CFG (i.e. rewrote a
+    /// terminator).
+    fn remove_pure_and_optimize(&mut self) -> bool {
         let mut cursor = FuncCursor::new(self.func);
+
+        // Set to `true` if any skeleton simplification rewrites a terminator and
+        // thus may have made some blocks unreachable. See `run`.
+        let mut cfg_maybe_changed = false;
         let mut value_to_opt_value: SecondaryMap<Value, Value> =
             SecondaryMap::with_default(Value::reserved_value());
 
@@ -957,7 +967,7 @@ impl<'a> EgraphPass<'a> {
                     cursor.remove_inst_and_step_back();
                 } else {
                     if let Some(cmd) = ctx.optimize_skeleton_inst(inst, block) {
-                        Self::execute_skeleton_inst_simplification(
+                        cfg_maybe_changed |= Self::execute_skeleton_inst_simplification(
                             cmd,
                             &mut cursor,
                             &mut value_to_opt_value,
@@ -967,6 +977,7 @@ impl<'a> EgraphPass<'a> {
                 }
             }
         }
+        cfg_maybe_changed
     }
 
     /// Find the set of blocks reachable from the entry block by
@@ -991,12 +1002,20 @@ impl<'a> EgraphPass<'a> {
 
     /// Execute a simplification of an instruction in the side-effectful
     /// skeleton.
+    ///
+    /// Returns whether this simplification may have changed the CFG's topology.
+    /// A block's set of successors can only change if its terminator changes, so
+    /// this is `true` exactly when the old instruction or an instruction we
+    /// replace it with is a terminator. (Non-terminator rewrites such as div/rem
+    /// strength reduction leave the CFG untouched.)
     fn execute_skeleton_inst_simplification(
         simplification: SkeletonInstSimplification,
         cursor: &mut FuncCursor,
         value_to_opt_value: &mut SecondaryMap<Value, Value>,
         old_inst: Inst,
-    ) {
+    ) -> bool {
+        let old_is_terminator = cursor.func.dfg.insts[old_inst].opcode().is_terminator();
+
         // Redirect uses of `old_val` to `new_val`.
         let forward_val = |cursor: &mut FuncCursor<'_>,
                            value_to_opt_value: &mut SecondaryMap<_, _>,
@@ -1044,14 +1063,22 @@ impl<'a> EgraphPass<'a> {
         let (new_inst, new_val) = match simplification {
             SkeletonInstSimplification::Remove => {
                 cursor.remove_inst_and_step_back();
-                return;
+                debug_assert!(
+                    !old_is_terminator,
+                    "cannot remove a block terminator (the block would become invalid)",
+                );
+                return false;
             }
             SkeletonInstSimplification::RemoveWithVal { val } => {
                 cursor.remove_inst_and_step_back();
                 let old_val = cursor.func.dfg.first_result(old_inst);
                 cursor.func.dfg.detach_inst_results(old_inst);
                 forward_val(cursor, value_to_opt_value, old_val, val);
-                return;
+                debug_assert!(
+                    !old_is_terminator,
+                    "cannot remove a block terminator (the block would become invalid)",
+                );
+                return false;
             }
             SkeletonInstSimplification::ReplaceBranchCond { cond } => {
                 // Swap the condition operand (argument 0) of the existing
@@ -1069,7 +1096,9 @@ impl<'a> EgraphPass<'a> {
                 // condition or it can be GVN'd.
                 self_map_operands(&cursor.func.dfg, value_to_opt_value, old_inst);
                 reprocess_from(cursor, old_inst);
-                return;
+                // The opcode and successors are unchanged, so the CFG is
+                // preserved.
+                return false;
             }
             SkeletonInstSimplification::ReplaceWithTwo { first, second } => {
                 // We don't forward result values for `ReplaceWithTwo` -- and it
@@ -1080,12 +1109,13 @@ impl<'a> EgraphPass<'a> {
                 debug_assert!(cursor.func.dfg.inst_results(first).is_empty());
                 debug_assert!(cursor.func.dfg.inst_results(second).is_empty());
 
+                debug_assert!(!cursor.func.dfg.insts[first].opcode().is_terminator());
                 // If the instruction we're replacing is a block terminator,
                 // then the trailing new instruction must also be a terminator,
                 // so the block remains well-formed.
-                debug_assert!(
-                    !cursor.func.dfg.insts[old_inst].opcode().is_terminator()
-                        || cursor.func.dfg.insts[second].opcode().is_terminator()
+                debug_assert_eq!(
+                    old_is_terminator,
+                    cursor.func.dfg.insts[second].opcode().is_terminator()
                 );
 
                 if let Some(old_srcloc) = old_srcloc {
@@ -1098,7 +1128,7 @@ impl<'a> EgraphPass<'a> {
                 self_map_operands(&cursor.func.dfg, value_to_opt_value, first);
                 self_map_operands(&cursor.func.dfg, value_to_opt_value, second);
                 reprocess_from(cursor, first);
-                return;
+                return old_is_terminator;
             }
 
             SkeletonInstSimplification::Replace { inst } => (inst, None),
@@ -1132,6 +1162,12 @@ impl<'a> EgraphPass<'a> {
 
         self_map_operands(&cursor.func.dfg, value_to_opt_value, new_inst);
         reprocess_from(cursor, new_inst);
+
+        debug_assert_eq!(
+            old_is_terminator,
+            cursor.func.dfg.insts[new_inst].opcode().is_terminator()
+        );
+        old_is_terminator
     }
 
     /// Scoped elaboration: compute a final ordering of op computation

--- a/cranelift/codegen/src/egraph/mod.rs
+++ b/cranelift/codegen/src/egraph/mod.rs
@@ -731,6 +731,35 @@ where
     }
 }
 
+impl SkeletonInstSimplification {
+    /// Does this simplification rewrite a block terminator, and thus
+    /// potentially change the CFG?
+    fn rewrites_terminator(&self, dfg: &DataFlowGraph) -> bool {
+        let is_terminator = |inst: Inst| dfg.insts[inst].opcode().is_terminator();
+        match self {
+            // Removing an instruction never rewrites a terminator: a block's
+            // terminator cannot be removed or the block would become invalid.
+            SkeletonInstSimplification::Remove
+            | SkeletonInstSimplification::RemoveWithVal { .. } => false,
+
+            // Swapping a conditional branch/trap's condition operand leaves the
+            // opcode and successors in place, so the CFG is preserved.
+            SkeletonInstSimplification::ReplaceBranchCond { .. } => false,
+
+            // A one-for-one replacement (e.g. `brif` with a constant condition
+            // into `jump`) rewrites a terminator exactly when the replacement
+            // instruction is itself a terminator.
+            SkeletonInstSimplification::Replace { inst }
+            | SkeletonInstSimplification::ReplaceWithVal { inst, .. } => is_terminator(*inst),
+
+            // Replacing one instruction with two (e.g. a branch to a
+            // trap-only block into a conditional trap plus a jump) rewrites a
+            // terminator exactly when the trailing instruction is a terminator.
+            SkeletonInstSimplification::ReplaceWithTwo { second, .. } => is_terminator(*second),
+        }
+    }
+}
+
 impl<'a> EgraphPass<'a> {
     /// Create a new EgraphPass.
     pub fn new(
@@ -967,7 +996,8 @@ impl<'a> EgraphPass<'a> {
                     cursor.remove_inst_and_step_back();
                 } else {
                     if let Some(cmd) = ctx.optimize_skeleton_inst(inst, block) {
-                        cfg_maybe_changed |= Self::execute_skeleton_inst_simplification(
+                        cfg_maybe_changed |= cmd.rewrites_terminator(&cursor.func.dfg);
+                        Self::execute_skeleton_inst_simplification(
                             cmd,
                             &mut cursor,
                             &mut value_to_opt_value,
@@ -1002,18 +1032,12 @@ impl<'a> EgraphPass<'a> {
 
     /// Execute a simplification of an instruction in the side-effectful
     /// skeleton.
-    ///
-    /// Returns whether this simplification may have changed the CFG's topology.
-    /// A block's set of successors can only change if its terminator changes, so
-    /// this is `true` exactly when the old instruction or an instruction we
-    /// replace it with is a terminator. (Non-terminator rewrites such as div/rem
-    /// strength reduction leave the CFG untouched.)
     fn execute_skeleton_inst_simplification(
         simplification: SkeletonInstSimplification,
         cursor: &mut FuncCursor,
         value_to_opt_value: &mut SecondaryMap<Value, Value>,
         old_inst: Inst,
-    ) -> bool {
+    ) {
         let old_is_terminator = cursor.func.dfg.insts[old_inst].opcode().is_terminator();
 
         // Redirect uses of `old_val` to `new_val`.
@@ -1067,7 +1091,7 @@ impl<'a> EgraphPass<'a> {
                     !old_is_terminator,
                     "cannot remove a block terminator (the block would become invalid)",
                 );
-                return false;
+                return;
             }
             SkeletonInstSimplification::RemoveWithVal { val } => {
                 cursor.remove_inst_and_step_back();
@@ -1078,7 +1102,7 @@ impl<'a> EgraphPass<'a> {
                     !old_is_terminator,
                     "cannot remove a block terminator (the block would become invalid)",
                 );
-                return false;
+                return;
             }
             SkeletonInstSimplification::ReplaceBranchCond { cond } => {
                 // Swap the condition operand (argument 0) of the existing
@@ -1098,7 +1122,7 @@ impl<'a> EgraphPass<'a> {
                 reprocess_from(cursor, old_inst);
                 // The opcode and successors are unchanged, so the CFG is
                 // preserved.
-                return false;
+                return;
             }
             SkeletonInstSimplification::ReplaceWithTwo { first, second } => {
                 // We don't forward result values for `ReplaceWithTwo` -- and it
@@ -1128,7 +1152,7 @@ impl<'a> EgraphPass<'a> {
                 self_map_operands(&cursor.func.dfg, value_to_opt_value, first);
                 self_map_operands(&cursor.func.dfg, value_to_opt_value, second);
                 reprocess_from(cursor, first);
-                return old_is_terminator;
+                return;
             }
 
             SkeletonInstSimplification::Replace { inst } => (inst, None),
@@ -1167,7 +1191,6 @@ impl<'a> EgraphPass<'a> {
             old_is_terminator,
             cursor.func.dfg.insts[new_inst].opcode().is_terminator()
         );
-        old_is_terminator
     }
 
     /// Scoped elaboration: compute a final ordering of op computation


### PR DESCRIPTION
Previously, the egraph pass unconditionally recomputed the CFG, determined reachability via a DFS traversal, and eliminated unreachable code after its optimize loop. It did this to clean up blocks that branch simplification may have made unreachable. But a block's successor set (and hence reachability) can only change when a terminator is rewritten, and that doesn't happen on many functions.

This commit adds tracking of whether any skeleton simplification rewrote a block terminator and skips the CFG rebuild, reachability computation, and dead-code elimination entirely when no block terminator was rewritten.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
