### PR TITLE
[47.0.x] Backport some component-model-async fixes

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,17 @@
+## 47.0.2
+
+Released 2026-07-21.
+
+### Fixed
+
+* Fix async-delivered write-closed events for futures.
+  [#13914](https://github.com/bytecodealliance/wasmtime/pull/13914)
+
+* Fix call hooks with yields and concurrent execution.
+  [#13871](https://github.com/bytecodealliance/wasmtime/pull/13871)
+
+--------------------------------------------------------------------------------
+
 ## 47.0.1
 
 Released 2026-07-20.

--- a/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent/futures_and_streams.rs
@@ -2478,7 +2478,7 @@ impl StoreOpaque {
             .get_mut(transmit_id)
             .with_context(|| format!("error closing writer {transmit_id:?}"))?;
         log::trace!(
-            "host_drop_writer state {transmit_id:?}; write state {:?} read state {:?}",
+            "host_drop_writer state {transmit_id:?}; read state {:?} writer state {:?}",
             transmit.read,
             transmit.write
         );
@@ -3224,9 +3224,9 @@ impl Instance {
         writer: u32,
     ) -> Result<()> {
         let table = self.id().get_mut(store).table_for_transmit(ty);
-        let transmit_rep = match ty {
+        let (transmit_rep, is_done) = match ty {
             TransmitIndex::Future(ty) => table.future_remove_writable(ty, writer)?,
-            TransmitIndex::Stream(ty) => table.stream_remove_writable(ty, writer)?,
+            TransmitIndex::Stream(ty) => (table.stream_remove_writable(ty, writer)?, false),
         };
 
         let id = TableId::<TransmitHandle>::new(transmit_rep);
@@ -3235,11 +3235,15 @@ impl Instance {
             TransmitIndex::Stream(_) => store.host_drop_writer(id, None),
             TransmitIndex::Future(_) => store.host_drop_writer(
                 id,
-                Some(|| {
-                    Err(format_err!(
-                        "cannot drop future write end without first writing a value"
-                    ))
-                }),
+                if is_done {
+                    None
+                } else {
+                    Some(|| {
+                        Err(format_err!(
+                            "cannot drop future write end without first writing a value"
+                        ))
+                    })
+                },
             ),
         }
     }

--- a/crates/wasmtime/src/runtime/component/func/host.rs
+++ b/crates/wasmtime/src/runtime/component/func/host.rs
@@ -15,7 +15,7 @@ use crate::runtime::vm::component::{
 };
 use crate::runtime::vm::{VMOpaqueContext, VMStore};
 use crate::store::Asyncness;
-use crate::{AsContextMut, CallHook, StoreContextMut, ValRaw};
+use crate::{AsContextMut, StoreContextMut, ValRaw};
 use alloc::sync::Arc;
 use core::any::Any;
 use core::mem::{self, MaybeUninit};
@@ -347,12 +347,7 @@ where
                 let options = OptionsIndex::from_u32(options);
                 let storage = NonNull::slice_from_raw_parts(storage, storage_len).as_mut();
                 let data = data.cast::<Self>().as_ref();
-
-                store.0.call_hook(CallHook::CallingHost)?;
-                let res = data.entrypoint(store.as_context_mut(), instance, ty, options, storage);
-                store.0.call_hook(CallHook::ReturningFromHost)?;
-
-                res
+                data.entrypoint(store.as_context_mut(), instance, ty, options, storage)
             })
         }
     }

--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -2373,10 +2373,6 @@ impl HostFunc {
             // this up.
             let mut store = unsafe { store.unchecked_context_mut() };
 
-            // Handle the entry call hook, with a corresponding exit call hook
-            // below.
-            store.0.call_hook(CallHook::CallingHost)?;
-
             // SAFETY: this function itself requires that the `vmctx` is
             // valid to use here.
             let state = unsafe {
@@ -2413,10 +2409,6 @@ impl HostFunc {
             };
 
             store.0.exit_gc_lifo_scope(gc_lifo_scope);
-
-            // Note that if this returns a trap then `ret` is discarded
-            // entirely.
-            store.0.call_hook(CallHook::ReturningFromHost)?;
 
             ret
         };

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -2311,6 +2311,11 @@ unsafe impl<T> VMStore for StoreInner<T> {
         &mut self.inner
     }
 
+    #[cfg(feature = "call-hook")]
+    fn call_hook(&mut self, s: CallHook) -> Result<()> {
+        StoreInner::call_hook(self, s)
+    }
+
     fn resource_limiter_and_store_opaque(
         &mut self,
     ) -> (Option<StoreResourceLimiter<'_>>, &mut StoreOpaque) {

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -213,6 +213,11 @@ pub unsafe trait VMStore: 'static {
         &mut self,
     ) -> (Option<StoreResourceLimiter<'_>>, &mut StoreOpaque);
 
+    /// Invoke this store's configured call hook, if any, to notify the
+    /// embedder of a transition between the host and WebAssembly.
+    #[cfg(feature = "call-hook")]
+    fn call_hook(&mut self, s: crate::CallHook) -> Result<()>;
+
     /// Callback invoked whenever an instance observes a new epoch
     /// number. Cannot fail; cooperative epoch-based yielding is
     /// completely semantically transparent. Returns the new deadline.

--- a/crates/wasmtime/src/runtime/vm/component/handle_table.rs
+++ b/crates/wasmtime/src/runtime/vm/component/handle_table.rs
@@ -458,25 +458,27 @@ impl HandleTable {
         Ok(ret)
     }
 
-    /// Removes the writable future handle from `idx`, returning its `rep`.
+    /// Removes the writable future handle from `idx`, returning its `rep` along
+    /// with whether the writer is "done" (i.e. it either successfully wrote a
+    /// value or was notified that the readable end was dropped).
     pub fn future_remove_writable(
         &mut self,
         expected_ty: TypeFutureTableIndex,
         idx: u32,
-    ) -> Result<u32> {
+    ) -> Result<(u32, bool)> {
         let ret = match self.get_mut(idx)? {
             Slot::Future { rep, ty, state } => {
                 if *ty != expected_ty {
                     bail!("handle is a future of a different type");
                 }
-                match state {
-                    TransmitLocalState::Write { .. } => {}
+                let is_done = match state {
+                    TransmitLocalState::Write { done } => *done,
                     TransmitLocalState::Read { .. } => {
                         bail!("passed read end to `future.drop-writable`")
                     }
                     TransmitLocalState::Busy => bail!("cannot drop busy future"),
-                }
-                *rep
+                };
+                (*rep, is_done)
             }
             _ => bail!("handle is not a future"),
         };

--- a/crates/wasmtime/src/runtime/vm/traphandlers.rs
+++ b/crates/wasmtime/src/runtime/vm/traphandlers.rs
@@ -245,7 +245,38 @@ where
         store: &mut dyn VMStore,
         f: impl FnOnce(&mut dyn VMStore) -> Result<T, E>,
     ) -> (T::Abi, Option<UnwindReason>) {
-        // First prepare the closure `f` as something that'll be invoked to
+        // First wrap `f` in call hooks if that feature is enabled. This is used
+        // as a "pretty far down in the stack" mechanism of ensuring that hooks
+        // aren't forgotten.
+        //
+        // Note that by being placed here this is handling:
+        //
+        // * libcalls
+        // * host functions
+        // * component versions of the above
+        //
+        // This specifically is NOT handling libcalls where the result can't
+        // carry a result. This should be safe as anything which doesn't return
+        // a `Result` sort of has to be simple enough to not allow recursion so
+        // it's just a brief exit from the guest to the host.
+        //
+        // Also note that this only happens with the `call-hook` feature because
+        // this otherwise imposes a dynamic dispatch on the `store` trait object
+        // which otherwise can't be optimized away.
+        #[cfg(feature = "call-hook")]
+        let f = move |store: &mut dyn VMStore| {
+            store.call_hook(crate::CallHook::CallingHost)?;
+
+            let res = f(store);
+
+            // Note that if this returns a trap then `ret` is discarded
+            // entirely.
+            store.call_hook(crate::CallHook::ReturningFromHost)?;
+
+            res.map_err(|e| e.into())
+        };
+
+        // Next prepare the closure `f` as something that'll be invoked to
         // generate the return value of this function. This is the
         // conditionally, below, passed to `catch_unwind`.
         let f = move || match f(store) {

--- a/tests/all/call_hook.rs
+++ b/tests/all/call_hook.rs
@@ -897,3 +897,38 @@ impl State {
 pub fn sync_call_hook(mut ctx: StoreContextMut<'_, State>, transition: CallHook) -> Result<()> {
     ctx.data_mut().call_hook(transition)
 }
+
+#[tokio::test]
+async fn hooks_used_at_yield_points() -> Result<(), Error> {
+    let mut config = Config::new();
+    config.consume_fuel(true);
+    let engine = Engine::new(&config)?;
+    let mut store = Store::new(&engine, State::default());
+    store.call_hook(sync_call_hook);
+    store.set_fuel(100)?;
+    store.fuel_async_yield_interval(Some(1))?;
+
+    assert_eq!(store.data().calls_into_host, 0);
+    assert_eq!(store.data().returns_from_host, 0);
+    assert_eq!(store.data().calls_into_wasm, 0);
+    assert_eq!(store.data().returns_from_wasm, 0);
+
+    let wat = r#"
+        (module
+            (func $start)
+            (start $start)
+        )
+    "#;
+    let module = Module::new(&engine, wat)?;
+
+    Linker::new(&engine)
+        .instantiate_async(&mut store, &module)
+        .await?;
+
+    assert!(store.data().calls_into_host > 0);
+    assert!(store.data().returns_from_host > 0);
+    assert_eq!(store.data().calls_into_wasm, 1);
+    assert_eq!(store.data().returns_from_wasm, 1);
+
+    Ok(())
+}

--- a/tests/all/component_model/call_hook.rs
+++ b/tests/all/component_model/call_hook.rs
@@ -618,3 +618,105 @@ async fn drop_suspended_async_hook() -> Result<()> {
         }
     }
 }
+
+#[tokio::test]
+async fn concurrent_behavior_balanced() -> Result<()> {
+    let engine = Engine::default();
+
+    let mut store = Store::new(&engine, State::default());
+    store.call_hook(sync_call_hook);
+
+    // A composition of two components where `$lowerer.run` makes an
+    // async-lowered call to the async-lifted (with callback) `$lifter.foo`.
+    // Starting `foo` forces the fiber running `run` to suspend while it waits
+    // for `foo` to start, and `foo`'s `task.return` call reenters wasm to run
+    // the fused adapter's `return_` function, both of which must be reflected
+    // in the call hooks fired in order to keep the embedder-visible
+    // transitions balanced.
+    let component = Component::new(
+        &engine,
+        r#"(component
+            (component $lifter
+                (core module $m
+                    (import "" "task.return" (func $task-return (param i32)))
+                    (func (export "callback") (param i32 i32 i32) (result i32)
+                        unreachable)
+                    (func (export "foo") (param i32) (result i32)
+                        (call $task-return (i32.add (local.get 0) (i32.const 1)))
+                        i32.const 0 (; EXIT ;)
+                    )
+                )
+                (core func $task-return (canon task.return (result u32)))
+                (core instance $i (instantiate $m
+                    (with "" (instance (export "task.return" (func $task-return))))
+                ))
+                (func (export "foo") async (param "p1" u32) (result u32)
+                    (canon lift (core func $i "foo") async (callback (func $i "callback")))
+                )
+            )
+
+            (component $lowerer
+                (import "a" (func $foo async (param "p1" u32) (result u32)))
+                (core module $libc (memory (export "memory") 1))
+                (core instance $libc (instantiate $libc))
+                (core func $foo (canon lower (func $foo) async (memory $libc "memory")))
+                (core module $m
+                    (import "libc" "memory" (memory 1))
+                    (import "" "foo" (func $foo (param i32 i32) (result i32)))
+                    (func (export "run") (result i32)
+                        ;; call `foo`, asserting that it returned immediately
+                        block
+                            (call $foo (i32.const 41) (i32.const 1204))
+                            i32.const 0xf
+                            i32.and
+                            i32.const 2 (; RETURNED ;)
+                            i32.eq
+                            br_if 0
+                            unreachable
+                        end
+                        (i32.load offset=0 (i32.const 1204))
+                    )
+                )
+                (core instance $i (instantiate $m
+                    (with "libc" (instance $libc))
+                    (with "" (instance (export "foo" (func $foo))))
+                ))
+                (func (export "run") (result u32) (canon lift (core func $i "run")))
+            )
+
+            (instance $lifter (instantiate $lifter))
+            (instance $lowerer (instantiate $lowerer (with "a" (func $lifter "foo"))))
+            (export "run" (func $lowerer "run"))
+        )"#,
+    )?;
+
+    let instance = Linker::new(&engine)
+        .instantiate_async(&mut store, &component)
+        .await?;
+    let run = instance.get_typed_func::<(), (u32,)>(&mut store, "run")?;
+    let (result,) = store
+        .run_concurrent(async |store| run.call_concurrent(store, ()).await)
+        .await??;
+    assert_eq!(result, 42);
+
+    // There are three guest exits (currently) in the above component:
+    //
+    // 1. Guest-to-guest async transitions pay an exit to prepare a task to be
+    //    run.
+    // 2. Guest-to-guest async transitions pay an exit to then run the initial
+    //    turn of the task created.
+    // 3. The `task.return` call exits the guest component.
+    assert_eq!(store.data().calls_into_host, 3);
+    assert_eq!(store.data().returns_from_host, 3);
+
+    // There are four guest entries (currently) in the above component:
+    //
+    // 1. The root invocation of `run`.
+    // 2. The synthesized adapter which translates arguments to `foo`.
+    // 3. The initial invocation of `foo` in `$lifter`.
+    // 4. The synthesized adapter which translates `task.return` values.
+    assert_eq!(store.data().calls_into_wasm, 4);
+    assert_eq!(store.data().returns_from_wasm, 4);
+
+    Ok(())
+}

--- a/tests/misc_testsuite/component-model/async/future-drop-writable-after-notified-drop.wast
+++ b/tests/misc_testsuite/component-model/async/future-drop-writable-after-notified-drop.wast
@@ -1,0 +1,160 @@
+;;! component_model_async = true
+;;! reference_types = true
+
+(component
+  ;; The writer.
+  (component $A
+    (core module $libc (memory (export "mem") 1))
+    (core instance $libc (instantiate $libc))
+
+    (type $f (future u32))
+    (core func $future.new (canon future.new $f))
+    (core func $future.write (canon future.write $f async (memory $libc "mem")))
+    (core func $future.drop-writable (canon future.drop-writable $f))
+    (core func $task.return (canon task.return))
+    (core func $waitable-set.new (canon waitable-set.new))
+    (core func $waitable-set.drop (canon waitable-set.drop))
+    (core func $waitable.join (canon waitable.join))
+
+    (core module $cm
+      (import "" "future.new" (func $future.new (result i64)))
+      (import "" "future.write" (func $future.write (param i32 i32) (result i32)))
+      (import "" "future.drop-writable" (func $future.drop-writable (param i32)))
+      (import "" "task.return" (func $task.return))
+      (import "" "waitable-set.new" (func $waitable-set.new (result i32)))
+      (import "" "waitable-set.drop" (func $waitable-set.drop (param i32)))
+      (import "" "waitable.join" (func $waitable.join (param i32 i32)))
+
+      (global $writer (mut i32) (i32.const 0))
+      (global $set (mut i32) (i32.const 0))
+
+      (func (export "get-future") (result i32)
+        (local $pair i64)
+        (local.set $pair (call $future.new))
+        (global.set $writer (i32.wrap_i64 (i64.shr_u (local.get $pair) (i64.const 32))))
+        (i32.wrap_i64 (local.get $pair))
+      )
+
+      (func (export "write-and-wait") (result i32)
+        (call $future.write (global.get $writer) (i32.const 0))
+        i32.const -1 ;; BLOCKED
+        i32.ne
+        if unreachable end
+
+        (global.set $set (call $waitable-set.new))
+        (call $waitable.join (global.get $writer) (global.get $set))
+        (i32.or
+          (i32.const 2) ;; CALLBACK_CODE_WAIT
+          (i32.shl (global.get $set) (i32.const 4)))
+      )
+
+      (func (export "write-and-wait-cb") (param $event i32) (param $waitable i32) (param $code i32) (result i32)
+        (if (i32.ne (local.get $event) (i32.const 5)) ;; EVENT_FUTURE_WRITE
+          (then unreachable))
+        (if (i32.ne (local.get $waitable) (global.get $writer))
+          (then unreachable))
+        (if (i32.ne (local.get $code) (i32.const 1)) ;; DROPPED
+          (then unreachable))
+
+        ;; Clean up everything.
+        (call $waitable.join (local.get $waitable) (i32.const 0))
+        (call $waitable-set.drop (global.get $set))
+        (call $future.drop-writable (local.get $waitable))
+        (call $task.return)
+        (i32.const 0) ;; CALLBACK_CODE_EXIT
+      )
+    )
+    (core instance $ci (instantiate $cm (with "" (instance
+      (export "future.new" (func $future.new))
+      (export "future.write" (func $future.write))
+      (export "future.drop-writable" (func $future.drop-writable))
+      (export "task.return" (func $task.return))
+      (export "waitable-set.new" (func $waitable-set.new))
+      (export "waitable-set.drop" (func $waitable-set.drop))
+      (export "waitable.join" (func $waitable.join))
+    ))))
+
+    (func (export "get-future") (result (future u32))
+      (canon lift (core func $ci "get-future")))
+    (func (export "write-and-wait") async
+      (canon lift (core func $ci "write-and-wait") async (callback (func $ci "write-and-wait-cb"))))
+  )
+
+  (component $B
+    (import "a" (instance $a
+      (export "get-future" (func (result (future u32))))
+      (export "write-and-wait" (func async))
+    ))
+
+    (core module $libc (memory (export "mem") 1))
+    (core instance $libc (instantiate $libc))
+
+    (type $f (future u32))
+    (core func $future.drop-readable (canon future.drop-readable $f))
+    (core func $get-future (canon lower (func $a "get-future")))
+    (core func $write-and-wait (canon lower (func $a "write-and-wait") async))
+    (core func $waitable-set.new (canon waitable-set.new))
+    (core func $waitable-set.drop (canon waitable-set.drop))
+    (core func $waitable.join (canon waitable.join))
+    (core func $waitable-set.wait (canon waitable-set.wait (memory $libc "mem")))
+    (core func $subtask.drop (canon subtask.drop))
+
+    (core module $dm
+      (import "" "future.drop-readable" (func $future.drop-readable (param i32)))
+      (import "" "get-future" (func $get-future (result i32)))
+      (import "" "write-and-wait" (func $write-and-wait (result i32)))
+      (import "" "waitable-set.new" (func $waitable-set.new (result i32)))
+      (import "" "waitable-set.drop" (func $waitable-set.drop (param i32)))
+      (import "" "waitable.join" (func $waitable.join (param i32 i32)))
+      (import "" "waitable-set.wait" (func $waitable-set.wait (param i32 i32) (result i32)))
+      (import "" "subtask.drop" (func $subtask.drop (param i32)))
+
+      (func (export "run")
+        (local $reader i32)
+        (local $status i32)
+        (local $subtask i32)
+        (local $ws i32)
+
+        ;; Acquire the readable end from $C.
+        (local.set $reader (call $get-future))
+
+        ;; Start $C's async writer; it blocks on the write and reports STARTED.
+        (local.set $status (call $write-and-wait))
+        (if (i32.ne (i32.and (local.get $status) (i32.const 0xf)) (i32.const 1)) ;; STARTED
+          (then unreachable))
+        (local.set $subtask (i32.shr_u (local.get $status) (i32.const 4)))
+
+        ;; Drop the readable end without reading.  This notifies $C's pending
+        ;; write that the reader is gone.
+        (call $future.drop-readable (local.get $reader))
+
+        ;; Wait for $C's subtask to finish
+        (local.set $ws (call $waitable-set.new))
+        (call $waitable.join (local.get $subtask) (local.get $ws))
+        (drop (call $waitable-set.wait (local.get $ws) (i32.const 0)))
+
+        (call $subtask.drop (local.get $subtask))
+        (call $waitable-set.drop (local.get $ws))
+      )
+    )
+    (core instance $di (instantiate $dm (with "" (instance
+      (export "future.drop-readable" (func $future.drop-readable))
+      (export "get-future" (func $get-future))
+      (export "write-and-wait" (func $write-and-wait))
+      (export "waitable-set.new" (func $waitable-set.new))
+      (export "waitable-set.drop" (func $waitable-set.drop))
+      (export "waitable.join" (func $waitable.join))
+      (export "waitable-set.wait" (func $waitable-set.wait))
+      (export "subtask.drop" (func $subtask.drop))
+    ))))
+
+    (func (export "run") async
+      (canon lift (core func $di "run")))
+  )
+
+  (instance $a (instantiate $A))
+  (instance $b (instantiate $B (with "a" (instance $a))))
+  (func (export "run") (alias export $b "run"))
+)
+
+(assert_return (invoke "run"))


### PR DESCRIPTION
This is a backport of #13871 and #13914 for issues that have blocked the update to 47.0.0 in Spin. I plan on making a 47.0.2 release after this merges.