### PR TITLE
Avoid dangling references to exited threads

### DIFF
--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -832,6 +832,7 @@ pub(crate) enum WaitResult {
 /// lowering the result to the guest's stack and linear memory.
 pub(crate) fn poll_and_block<R: Send + Sync + 'static>(
     store: &mut dyn VMStore,
+    host_task: EnteredHostTask,
     future: impl Future<Output = Result<R>> + Send + 'static,
 ) -> Result<R> {
     let task = store.current_host_thread()?;
@@ -867,6 +868,11 @@ pub(crate) fn poll_and_block<R: Send + Sync + 'static>(
             .poll(&mut Context::from_waker(&Waker::noop()))
     });
 
+    let caller = match host_task {
+        Some(pair) => pair.1,
+        None => bail_bug!("host task wasn't created but should have been"),
+    };
+
     match poll {
         // It completed immediately; check the result and delete the task.
         Poll::Ready(result) => result?,
@@ -879,7 +885,6 @@ pub(crate) fn poll_and_block<R: Send + Sync + 'static>(
             let state = store.concurrent_state_mut()?;
             state.push_future(future);
 
-            let caller = state.get_mut(task)?.caller;
             let set = state.get_mut(caller.thread)?.sync_call_set;
             Waitable::Host(task).join(state, Some(set))?;
 
@@ -1588,8 +1593,8 @@ impl<T> StoreContextMut<'_, T> {
         Ok(core::iter::from_fn(move || {
             while let Some(t) = cur {
                 cur = state.parent(t);
-                if let Some(thread) = t.guest() {
-                    return Some(GuestTaskId(thread.task));
+                if let Some(task) = t.guest_task() {
+                    return Some(GuestTaskId(task));
                 }
             }
 
@@ -1597,6 +1602,13 @@ impl<T> StoreContextMut<'_, T> {
         }))
     }
 }
+
+/// Return value of [`StoreOpaque::host_task_create`].
+///
+/// This is an `Option` to handle the dynamic `store.concurrency_support()`
+/// property, and when set this returns the host task that was created in
+/// addition to the previously running guest thread.
+pub type EnteredHostTask = Option<(TableId<HostTask>, QualifiedThreadId)>;
 
 impl StoreOpaque {
     /// Returns the currently-running thread, promoting any deferred lazy thread
@@ -1628,8 +1640,8 @@ impl StoreOpaque {
         // we can get the `ComponentInstanceId` shared by the whole chain from
         // here.
         let state = self.concurrent_state_mut_without_forcing_current_thread();
-        let id = match state.unforced_current_thread.guest().copied() {
-            Some(thread) => state.get_mut(thread.task)?.instance.instance,
+        let id = match state.unforced_current_thread.guest_task() {
+            Some(task) => state.get_mut(task)?.instance.instance,
             None => bail_bug!("deferred component-model thread with non-guest base"),
         };
 
@@ -1733,8 +1745,8 @@ impl StoreOpaque {
 
         let thread = self.current_thread()?;
         let state = self.concurrent_state_mut()?;
-        let instance = if let Some(thread) = thread.guest() {
-            Some(state.get_mut(thread.task)?.instance)
+        let instance = if let Some(task) = thread.guest_task() {
+            Some(state.get_mut(task)?.instance)
         } else {
             None
         };
@@ -1812,32 +1824,17 @@ impl StoreOpaque {
     /// relatively expensive table manipulations. This would ideally be
     /// optimized to avoid the full allocation of a `HostTask` in at least some
     /// situations.
-    pub(crate) fn host_task_create(&mut self) -> Result<Option<TableId<HostTask>>> {
+    pub(crate) fn host_task_create(&mut self) -> Result<EnteredHostTask> {
         if !self.concurrency_support() {
             self.enter_call_not_concurrent()?;
             return Ok(None);
         }
         let caller = self.current_guest_thread()?;
         let state = self.concurrent_state_mut()?;
-        let task = state.push(HostTask::new(caller, HostTaskState::CalleeStarted))?;
+        let task = state.push(HostTask::new(caller.task, HostTaskState::CalleeStarted))?;
         log::trace!("new host task {task:?}");
         self.set_thread(task)?;
-        Ok(Some(task))
-    }
-
-    /// Invoked before lowering the results of a host task to the guest.
-    ///
-    /// This is used to update the current thread annotations within the store
-    /// to ensure that it reflects the guest task, not the host task, since
-    /// lowering may execute guest code.
-    pub fn host_task_reenter_caller(&mut self) -> Result<()> {
-        if !self.concurrency_support() {
-            return Ok(());
-        }
-        let task = self.current_host_thread()?;
-        let caller = self.concurrent_state_mut()?.get_mut(task)?.caller;
-        self.set_thread(caller)?;
-        Ok(())
+        Ok(Some((task, caller)))
     }
 
     /// Dual of `host_task_create` and signifies that the host has finished and
@@ -1846,9 +1843,10 @@ impl StoreOpaque {
     /// Note that this isn't invoked when the host is invoked asynchronously and
     /// the host isn't complete yet. In that situation the host task persists
     /// and will be cleaned up separately in `subtask_drop`
-    pub(crate) fn host_task_delete(&mut self, task: Option<TableId<HostTask>>) -> Result<()> {
+    pub(crate) fn host_task_delete(&mut self, task: EnteredHostTask) -> Result<()> {
         match task {
-            Some(task) => {
+            Some((task, caller)) => {
+                self.set_thread(caller)?;
                 log::trace!("delete host task {task:?}");
                 self.concurrent_state_mut()?.delete(task)?;
             }
@@ -1876,8 +1874,8 @@ impl StoreOpaque {
         let mut cur = Some(self.current_thread()?);
         let state = self.concurrent_state_mut()?;
         while let Some(t) = cur {
-            if let Some(thread) = t.guest() {
-                let task = state.get_mut(thread.task)?;
+            if let Some(task) = t.guest_task() {
+                let task = state.get_mut(task)?;
                 // Note that we only compare top-level instance IDs here.
                 // The idea is that the host is not allowed to recursively
                 // enter a top-level instance even if the specific leaf
@@ -1944,13 +1942,13 @@ impl StoreOpaque {
         // Additionally if we're switching to a new thread, set its component
         // instance's `task_may_block` according to where it left off.
         let state = self.concurrent_state_mut()?;
-        if let Some(old_thread) = old_thread.guest() {
-            let instance = state.get_mut(old_thread.task)?.instance.instance;
+        if let Some(old_task) = old_thread.guest_task() {
+            let instance = state.get_mut(old_task)?.instance.instance;
             self.component_instance_mut(instance)
                 .set_task_may_block(false)
         }
 
-        if thread.guest().is_some() {
+        if thread.guest_task().is_some() {
             self.set_task_may_block()?;
         }
 
@@ -2170,8 +2168,8 @@ impl StoreOpaque {
                     ..
                 }
             ) || old_guest_thread
-                .guest()
-                .map(|thread| self.concurrent_state_mut()?.may_block(thread.task))
+                .guest_task()
+                .map(|task| self.concurrent_state_mut()?.may_block(task))
                 .transpose()?
                 .unwrap_or(true)
         );
@@ -2347,6 +2345,7 @@ impl StoreOpaque {
         }
         let (bits, is_host) = match self.current_thread()? {
             CurrentThread::Guest(id) => (id.task.rep(), false),
+            CurrentThread::GuestTask(id) => (id.rep(), false),
             CurrentThread::Host(id) => (id.rep(), true),
             CurrentThread::None => return Ok(None),
         };
@@ -3197,9 +3196,10 @@ impl Instance {
     pub(crate) fn first_poll<T: 'static, R: Send + 'static>(
         self,
         mut store: StoreContextMut<'_, T>,
+        host_task: EnteredHostTask,
         future: impl Future<Output = Result<R>> + Send + 'static,
-        lower: impl FnOnce(StoreContextMut<T>, Option<R>) -> Result<()> + Send + 'static,
-    ) -> Result<Option<u32>> {
+        lower: impl FnOnce(StoreContextMut<T>, Option<R>, bool) -> Result<()> + Send + 'static,
+    ) -> Result<u32> {
         let token = StoreToken::new(store.as_context_mut());
         let task = store.0.current_host_thread()?;
         let state = store.0.concurrent_state_mut()?;
@@ -3229,8 +3229,8 @@ impl Instance {
             // It finished immediately; lower the result and delete the task.
             Poll::Ready(result) => {
                 let result = result.transpose()?;
-                lower(store.as_context_mut(), result)?;
-                return Ok(None);
+                lower(store.as_context_mut(), result, true)?;
+                return Ok(Status::Returned.pack(None));
             }
 
             // Future isn't ready yet, so fall through.
@@ -3262,7 +3262,7 @@ impl Instance {
                     Status::ReturnCancelled
                 };
 
-                lower(store.as_context_mut(), result)?;
+                lower(store.as_context_mut(), result, false)?;
                 let state = store.0.concurrent_state_mut()?;
                 match &mut state.get_mut(task)?.state {
                     // The task is already flagged as finished because it was
@@ -3294,9 +3294,12 @@ impl Instance {
 
         // Make this task visible to the guest and then record what it
         // was made visible as.
+        let caller = match host_task {
+            Some(pair) => pair.1,
+            None => bail_bug!("host task wasn't created but should have been"),
+        };
         let state = store.0.concurrent_state_mut()?;
         state.push_future(future);
-        let caller = state.get_mut(task)?.caller;
         let instance = state.get_mut(caller.task)?.instance;
         let handle = store
             .0
@@ -3310,7 +3313,7 @@ impl Instance {
         // caller. Note that the host task isn't deallocated as it's
         // within the store and will get deallocated later.
         store.0.set_thread(caller)?;
-        Ok(Some(handle))
+        Ok(Status::Started.pack(Some(handle)))
     }
 
     /// Implements the `task.return` intrinsic, lifting the result for the
@@ -4599,8 +4602,13 @@ type HostTaskFuture = Pin<Box<dyn Future<Output = Result<()>> + Send + 'static>>
 pub(crate) struct HostTask {
     common: WaitableCommon,
 
-    /// Guest thread which called the host.
-    caller: QualifiedThreadId,
+    /// The calling guest task of this host task. Note that this is only used
+    /// for backtrace purposes and is additionally not updated when the guest
+    /// task finishes.
+    ///
+    /// TODO: this field should probably get deleted entirely and the
+    /// backtrace-purposes here should move to an auxiliary table.
+    caller: TableId<GuestTask>,
 
     /// State of borrows/etc the host needs to track. Used when the guest passes
     /// borrows to the host, for example.
@@ -4633,7 +4641,7 @@ enum HostTaskState {
 }
 
 impl HostTask {
-    fn new(caller: QualifiedThreadId, state: HostTaskState) -> Self {
+    fn new(caller: TableId<GuestTask>, state: HostTaskState) -> Self {
         Self {
             common: WaitableCommon::default(),
             call_context: CallContext::default(),
@@ -5217,8 +5225,16 @@ impl ConcurrentInstanceState {
 
 #[derive(Debug, Copy, Clone)]
 pub(crate) enum CurrentThread {
+    /// The currently running thread is a guest, identified here with its
+    /// task/thread id combo.
     Guest(QualifiedThreadId),
+    /// The currently running thread is a host task.
     Host(TableId<HostTask>),
+    /// A bit of a kludge to get `StoreOpaque::parent` working with backtraces
+    /// and this serves as the parent node of a `Host` task. This ideally would
+    /// get removed in favor of separate backtrace storage.
+    GuestTask(TableId<GuestTask>),
+    /// There is no currently running thread.
     None,
 }
 
@@ -5226,6 +5242,14 @@ impl CurrentThread {
     fn guest(&self) -> Option<&QualifiedThreadId> {
         match self {
             Self::Guest(id) => Some(id),
+            _ => None,
+        }
+    }
+
+    fn guest_task(&self) -> Option<TableId<GuestTask>> {
+        match self {
+            Self::Guest(id) => Some(id.task),
+            Self::GuestTask(id) => Some(*id),
             _ => None,
         }
     }
@@ -5629,17 +5653,19 @@ impl ConcurrentState {
 
     /// Returns the parent thread, if any, of `cur`.
     fn parent(&mut self, cur: CurrentThread) -> Option<CurrentThread> {
-        match cur {
-            CurrentThread::Guest(thread) => {
-                let task = self.get_mut(thread.task).ok()?;
-                Some(match task.caller {
-                    Caller::Host { caller, .. } => caller,
-                    Caller::Guest { thread } => thread.into(),
-                })
+        let task = match cur {
+            CurrentThread::GuestTask(task) => task,
+            CurrentThread::Guest(thread) => thread.task,
+            CurrentThread::Host(id) => {
+                return Some(CurrentThread::GuestTask(self.get_mut(id).ok()?.caller));
             }
-            CurrentThread::Host(id) => Some(self.get_mut(id).ok()?.caller.into()),
-            CurrentThread::None => None,
-        }
+            CurrentThread::None => return None,
+        };
+        let task = self.get_mut(task).ok()?;
+        Some(match task.caller {
+            Caller::Host { caller, .. } => caller,
+            Caller::Guest { thread } => thread.into(),
+        })
     }
 }
 

--- a/crates/wasmtime/src/runtime/component/concurrent_disabled.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent_disabled.rs
@@ -166,10 +166,6 @@ impl StoreOpaque {
         self.enter_call_not_concurrent()
     }
 
-    pub(crate) fn host_task_reenter_caller(&mut self) -> Result<()> {
-        Ok(())
-    }
-
     pub(crate) fn host_task_delete(&mut self, (): ()) -> Result<()> {
         Ok(self.exit_call_not_concurrent())
     }

--- a/crates/wasmtime/src/runtime/component/func/host.rs
+++ b/crates/wasmtime/src/runtime/component/func/host.rs
@@ -1,9 +1,7 @@
 //! Implementation of calling Rust-defined functions from components.
 
 #[cfg(feature = "component-model-async")]
-use crate::component::concurrent;
-#[cfg(feature = "component-model-async")]
-use crate::component::concurrent::{Accessor, Status};
+use crate::component::concurrent::{self, Accessor, Status};
 use crate::component::func::{LiftContext, LowerContext};
 use crate::component::matching::InstanceType;
 use crate::component::storage::{slice_to_storage, slice_to_storage_mut};
@@ -377,13 +375,10 @@ where
             store.0.check_blocking()?;
         }
 
-        // Enter the host by pushing a `HostTask` into the concurrent state.
-        let host_task = store.0.host_task_create()?;
-
-        let host_task_complete = if async_ {
+        if async_ {
             #[cfg(feature = "component-model-async")]
             {
-                self.call_async_lower(store.as_context_mut(), instance, ty, options, storage)?
+                self.call_async_lower(store.as_context_mut(), instance, ty, options, storage)
             }
             #[cfg(not(feature = "component-model-async"))]
             unreachable!(
@@ -391,20 +386,8 @@ where
                  when `component-model-async` feature disabled"
             );
         } else {
-            self.call_sync_lower(store.as_context_mut(), instance, ty, options, storage)?;
-            true
-        };
-
-        // If the host task completed, then it's deallocated.
-        //
-        // Note that if the host task did not exit then the `call_async_lower`
-        // function transitively would have updated the current guest thread to
-        // the caller of this host function.
-        if host_task_complete {
-            store.0.host_task_delete(host_task)?;
+            self.call_sync_lower(store.as_context_mut(), instance, ty, options, storage)
         }
-
-        Ok(())
     }
 
     /// Implementation of the "sync" ABI.
@@ -422,13 +405,17 @@ where
         options: OptionsIndex,
         storage: &mut [MaybeUninit<ValRaw>],
     ) -> Result<()> {
+        let entered_host_task = store.0.host_task_create()?;
+
         let mut lift = LiftContext::new(store.0.store_opaque_mut(), options, instance)?;
         let (params, rest) = self.load_params(&mut lift, ty, MAX_FLAT_PARAMS, storage)?;
 
         let ret = match self.run(store.as_context_mut(), params) {
             HostResult::Done(result) => result?,
             #[cfg(feature = "component-model-async")]
-            HostResult::Future(future) => concurrent::poll_and_block(store.0, future)?,
+            HostResult::Future(future) => {
+                concurrent::poll_and_block(store.0, entered_host_task, future)?
+            }
         };
 
         let mut lower = LowerContext::new(store, options, instance);
@@ -447,7 +434,9 @@ where
                 ptr,
             )?)
         };
-        Self::lower_result_and_exit_call(&mut lower, ty, Some(ret), dst)
+        lower.validate_scope_exit()?;
+        lower.store.0.host_task_delete(entered_host_task)?;
+        Self::lower_raw(&mut lower, ty, ret, dst)
     }
 
     /// Implementation of the "async" ABI of the component model.
@@ -463,13 +452,14 @@ where
         ty: TypeFuncIndex,
         options: OptionsIndex,
         storage: &mut [MaybeUninit<ValRaw>],
-    ) -> Result<bool> {
+    ) -> Result<()> {
         use wasmtime_environ::component::MAX_FLAT_ASYNC_PARAMS;
 
         let (component, store) = instance.component_and_store_mut(store.0);
         let mut store = StoreContextMut(store);
         let types = component.types();
         let fty = &types[ty];
+        let entered_host_task = store.0.host_task_create()?;
 
         // Lift the parameters, either from flat storage or from linear
         // memory.
@@ -494,36 +484,41 @@ where
 
         let host_result = self.run(store.as_context_mut(), params);
 
-        let task = match host_result {
+        let rc = match host_result {
             HostResult::Done(result) => {
-                Self::lower_result_and_exit_call(
-                    &mut LowerContext::new(store, options, instance),
-                    ty,
-                    Some(result?),
-                    Destination::Memory(retptr),
-                )?;
-                None
+                let result = result?;
+                let mut lower = LowerContext::new(store, options, instance);
+                lower.validate_scope_exit()?;
+                lower.store.0.host_task_delete(entered_host_task)?;
+                Self::lower_raw(&mut lower, ty, result, Destination::Memory(retptr))?;
+                Status::Returned.pack(None)
             }
-            #[cfg(feature = "component-model-async")]
-            HostResult::Future(future) => {
-                instance.first_poll(store, future, move |store, ret| {
-                    Self::lower_result_and_exit_call(
-                        &mut LowerContext::new(store, options, instance),
-                        ty,
-                        ret,
-                        Destination::Memory(retptr),
-                    )
-                })?
-            }
+            HostResult::Future(future) => instance.first_poll(
+                store.as_context_mut(),
+                entered_host_task,
+                future,
+                move |store, ret, immediate| {
+                    let mut lower = LowerContext::new(store, options, instance);
+                    lower.validate_scope_exit()?;
+                    if immediate {
+                        lower.store.0.host_task_delete(entered_host_task)?;
+                    }
+                    // FIXME(WebAssembly/component-model#678) the currently
+                    // running thread for this exit lower is wrong. This happens
+                    // to pick whatever's in the store at the time of a
+                    // non-immediate exit which is not correct. There's no real
+                    // right answer here, hence the upstream issue.
+                    if let Some(result) = ret {
+                        Self::lower_raw(&mut lower, ty, result, Destination::Memory(retptr))?;
+                    }
+                    Ok(())
+                },
+            )?,
         };
 
-        storage[0].write(ValRaw::u32(if let Some(task) = task {
-            Status::Started.pack(Some(task))
-        } else {
-            Status::Returned.pack(None)
-        }));
+        storage[0].write(ValRaw::u32(rc));
 
-        Ok(task.is_none())
+        Ok(())
     }
 
     /// Loads parameters the wasm arguments `storage`.
@@ -564,33 +559,20 @@ where
         Ok((params, &storage[param_flat_count.unwrap_or(1)..]))
     }
 
-    /// Stores the result `ret` into `dst` which is calculated per the ABI.
-    fn lower_result_and_exit_call(
+    fn lower_raw(
         lower: &mut LowerContext<'_, T>,
         ty: TypeFuncIndex,
-        ret: Option<R>,
+        ret: R,
         dst: Destination<'_>,
     ) -> Result<()> {
-        // Before lowering below semantically ensure that the caller has dropped
-        // all of its borrows and such.
-        lower.validate_scope_exit()?;
-
-        // At this point we're transitioning back to the caller task which means
-        // that the current task needs to be updated. This will restore the
-        // currently running thread as the caller's thread, for example if
-        // lowering below calls `realloc` it'll use the right context.
-        lower.store.0.host_task_reenter_caller()?;
-
-        if let Some(ret) = ret {
-            let caller_instance = lower.options().instance;
-            let mut flags = lower.instance_mut().instance_flags(caller_instance);
-            unsafe {
-                flags.set_may_leave(false);
-            }
-            Self::lower_result(lower, ty, ret, dst)?;
-            unsafe {
-                flags.set_may_leave(true);
-            }
+        let caller_instance = lower.options().instance;
+        let mut flags = lower.instance_mut().instance_flags(caller_instance);
+        unsafe {
+            flags.set_may_leave(false);
+        }
+        Self::lower_result(lower, ty, ret, dst)?;
+        unsafe {
+            flags.set_may_leave(true);
         }
         Ok(())
     }

--- a/tests/misc_testsuite/component-model-threading/drop-subtask-on-separate-thread.wast
+++ b/tests/misc_testsuite/component-model-threading/drop-subtask-on-separate-thread.wast
@@ -1,0 +1,86 @@
+;;! component_model_async = true
+;;! component_model_threading = true
+
+(component
+  (import "host" (instance $host
+    (export "never-return" (func async))
+  ))
+
+  (core module $m
+    (import "" "never-return" (func $never-return (result i32)))
+    (import "" "cancel" (func $cancel (param i32) (result i32)))
+    (import "" "drop-subtask" (func $drop-subtask (param i32)))
+    (import "" "thread.new-indirect" (func $thread-new (param i32 i32) (result i32)))
+    (import "" "thread.index" (func $thread-index (result i32)))
+    (import "" "thread.suspend-then-resume" (func $thread-suspend-then-resume (param i32) (result i32)))
+    (import "" "thread.resume-later" (func $thread-resume-later (param i32)))
+    (import "" "table" (table $table 1 funcref))
+
+    (global $main-thread (mut i32) (i32.const 0))
+    (global $subtask (mut i32) (i32.const 0))
+    (global $done (mut i32) (i32.const 0))
+
+    (elem (i32.const 0) $creator)
+
+    (func (export "run")
+      (global.set $main-thread (call $thread-index))
+
+      ;; Spawn a thread to start a task.
+      (drop (call $thread-suspend-then-resume
+        (call $thread-new (i32.const 0) (i32.const 0))))
+      (if (i32.ne (global.get $done) (i32.const 1)) (then unreachable))
+
+      ;; Should be able to cancel the subtask on this thread.
+      (i32.ne
+        (call $cancel (global.get $subtask))
+        (i32.const 4)) ;; RETURN_CANCELLED
+      if unreachable end
+      (call $drop-subtask (global.get $subtask))
+    )
+
+    ;; Start an import call then exit this thread.
+    (func $creator (param i32)
+      (local $ret i32)
+      (local.set $ret (call $never-return))
+
+      (i32.ne
+        (i32.and (local.get $ret) (i32.const 0xf))
+        (i32.const 1)) ;; STARTED
+      if unreachable end
+
+      (global.set $subtask (i32.shr_u (local.get $ret) (i32.const 4)))
+      (global.set $done (i32.const 1))
+      (call $thread-resume-later (global.get $main-thread))
+    )
+  )
+
+  (core module $libc (table (export "table") 1 funcref))
+  (core instance $libc (instantiate $libc))
+  (alias core export $libc "table" (core table $table))
+  (core type $start-func-ty (func (param i32)))
+
+  (core func $never-return (canon lower (func $host "never-return") async))
+  (core func $cancel (canon subtask.cancel))
+  (core func $drop-subtask (canon subtask.drop))
+  (core func $thread.new-indirect (canon thread.new-indirect $start-func-ty (table $table)))
+  (core func $thread.index (canon thread.index))
+  (core func $thread.suspend-then-resume (canon thread.suspend-then-resume))
+  (core func $thread.resume-later (canon thread.resume-later))
+  (core instance $i (instantiate $m
+      (with "" (instance
+          (export "never-return" (func $never-return))
+          (export "cancel" (func $cancel))
+          (export "drop-subtask" (func $drop-subtask))
+          (export "thread.new-indirect" (func $thread.new-indirect))
+          (export "thread.index" (func $thread.index))
+          (export "thread.suspend-then-resume" (func $thread.suspend-then-resume))
+          (export "thread.resume-later" (func $thread.resume-later))
+          (export "table" (table $table))
+      ))
+  ))
+
+  (func (export "f") async
+      (canon lift (core func $i "run")))
+)
+
+(assert_return (invoke "f"))


### PR DESCRIPTION
This commit is a refactor of the `HostTask::caller` field to no longer refer to a `QualifiedThreadId`. This is not valid to store within a `HostTask` because threads can exit while a host task is still running. More generally a `caller` field isn't valid to store because tasks can exit without blocking on callees, but that refactoring is left for another day.

Otherwise most of this commit is juggling state and moving things around now that `caller` is no longer present. I've attempted to explicitly pass it around in a few places and notably delineate boundaries of tasks entering/exiting a bit more clearly in a few locations. This commit also surface WebAssembly/component-model#678 which is something we'll have to address in the future as well, and now it's got a `FIXME` for the primary location of where the chosen task to lower with is suspect.

Closes #13890

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
