### PR TITLE
check for and return WASIp2 UDP socket errors when receiving

### DIFF
--- a/crates/test-programs/src/bin/p2_udp_connect.rs
+++ b/crates/test-programs/src/bin/p2_udp_connect.rs
@@ -1,3 +1,5 @@
+use test_programs::wasi::clocks::monotonic_clock;
+use test_programs::wasi::io::poll;
 use test_programs::wasi::sockets::network::{
     ErrorCode, IpAddress, IpAddressFamily, IpSocketAddress, Network,
 };
@@ -154,6 +156,46 @@ fn test_udp_connect_and_send(net: &Network, family: IpAddressFamily) {
     ));
 }
 
+fn test_send_to_closed_receiver(net: &Network, family: IpAddressFamily) {
+    let unspecified_port = IpSocketAddress::new(IpAddress::new_loopback(family), 0);
+
+    let sender = UdpSocket::new(family).unwrap();
+    sender.blocking_bind(&net, unspecified_port).unwrap();
+
+    let receiver = UdpSocket::new(family).unwrap();
+    receiver.blocking_bind(&net, unspecified_port).unwrap();
+
+    let receiver_address = receiver.local_address().unwrap();
+    drop(receiver);
+    let (rx, tx) = sender.stream(Some(receiver_address)).unwrap();
+    tx.blocking_send(&[OutgoingDatagram {
+        data: b"hello".to_vec(),
+        remote_address: None,
+    }])
+    .unwrap();
+
+    let deadline = monotonic_clock::now() + 5_000_000_000;
+    loop {
+        match rx.receive(1) {
+            Ok(datagrams) if datagrams.is_empty() => {}
+            Ok(_) => panic!("expected error, got datagrams"),
+            Err(ErrorCode::ConnectionRefused | ErrorCode::ConnectionReset) => break,
+            Err(error) => panic!("unexpected error: {error:?}"),
+        }
+
+        let received = rx.subscribe();
+        let timeout = monotonic_clock::subscribe_instant(deadline);
+
+        for ready in poll::poll(&[&received, &timeout]) {
+            match ready {
+                0 => break,
+                1 => panic!("receive timed out instead of returning an error"),
+                _ => unreachable!(),
+            }
+        }
+    }
+}
+
 fn main() {
     let net = Network::default();
 
@@ -174,6 +216,9 @@ fn main() {
 
     test_udp_connect_without_bind(IpAddressFamily::Ipv4);
     test_udp_connect_without_bind(IpAddressFamily::Ipv6);
+
+    test_send_to_closed_receiver(&net, IpAddressFamily::Ipv4);
+    test_send_to_closed_receiver(&net, IpAddressFamily::Ipv6);
 
     test_udp_connect_dual_stack(&net);
 

--- a/crates/test-programs/src/bin/p2_udp_connect.rs
+++ b/crates/test-programs/src/bin/p2_udp_connect.rs
@@ -1,5 +1,3 @@
-use test_programs::wasi::clocks::monotonic_clock;
-use test_programs::wasi::io::poll;
 use test_programs::wasi::sockets::network::{
     ErrorCode, IpAddress, IpAddressFamily, IpSocketAddress, Network,
 };
@@ -156,46 +154,6 @@ fn test_udp_connect_and_send(net: &Network, family: IpAddressFamily) {
     ));
 }
 
-fn test_send_to_closed_receiver(net: &Network, family: IpAddressFamily) {
-    let unspecified_port = IpSocketAddress::new(IpAddress::new_loopback(family), 0);
-
-    let sender = UdpSocket::new(family).unwrap();
-    sender.blocking_bind(&net, unspecified_port).unwrap();
-
-    let receiver = UdpSocket::new(family).unwrap();
-    receiver.blocking_bind(&net, unspecified_port).unwrap();
-
-    let receiver_address = receiver.local_address().unwrap();
-    drop(receiver);
-    let (rx, tx) = sender.stream(Some(receiver_address)).unwrap();
-    tx.blocking_send(&[OutgoingDatagram {
-        data: b"hello".to_vec(),
-        remote_address: None,
-    }])
-    .unwrap();
-
-    let deadline = monotonic_clock::now() + 5_000_000_000;
-    loop {
-        match rx.receive(1) {
-            Ok(datagrams) if datagrams.is_empty() => {}
-            Ok(_) => panic!("expected error, got datagrams"),
-            Err(ErrorCode::ConnectionRefused | ErrorCode::ConnectionReset) => break,
-            Err(error) => panic!("unexpected error: {error:?}"),
-        }
-
-        let received = rx.subscribe();
-        let timeout = monotonic_clock::subscribe_instant(deadline);
-
-        for ready in poll::poll(&[&received, &timeout]) {
-            match ready {
-                0 => break,
-                1 => panic!("receive timed out instead of returning an error"),
-                _ => unreachable!(),
-            }
-        }
-    }
-}
-
 fn main() {
     let net = Network::default();
 
@@ -216,9 +174,6 @@ fn main() {
 
     test_udp_connect_without_bind(IpAddressFamily::Ipv4);
     test_udp_connect_without_bind(IpAddressFamily::Ipv6);
-
-    test_send_to_closed_receiver(&net, IpAddressFamily::Ipv4);
-    test_send_to_closed_receiver(&net, IpAddressFamily::Ipv6);
 
     test_udp_connect_dual_stack(&net);
 

--- a/crates/test-programs/src/bin/p2_udp_send_to_closed_receiver.rs
+++ b/crates/test-programs/src/bin/p2_udp_send_to_closed_receiver.rs
@@ -1,0 +1,53 @@
+use test_programs::wasi::clocks::monotonic_clock;
+use test_programs::wasi::io::poll;
+use test_programs::wasi::sockets::network::{
+    ErrorCode, IpAddress, IpAddressFamily, IpSocketAddress, Network,
+};
+use test_programs::wasi::sockets::udp::{OutgoingDatagram, UdpSocket};
+
+fn test_send_to_closed_receiver(net: &Network, family: IpAddressFamily) {
+    let unspecified_port = IpSocketAddress::new(IpAddress::new_loopback(family), 0);
+
+    let sender = UdpSocket::new(family).unwrap();
+    sender.blocking_bind(&net, unspecified_port).unwrap();
+
+    let receiver = UdpSocket::new(family).unwrap();
+    receiver.blocking_bind(&net, unspecified_port).unwrap();
+
+    let receiver_address = receiver.local_address().unwrap();
+    drop(receiver);
+    let (rx, tx) = sender.stream(Some(receiver_address)).unwrap();
+    tx.blocking_send(&[OutgoingDatagram {
+        data: b"hello".to_vec(),
+        remote_address: None,
+    }])
+    .unwrap();
+
+    let deadline = monotonic_clock::now() + 5_000_000_000;
+    loop {
+        match rx.receive(1) {
+            Ok(datagrams) if datagrams.is_empty() => {}
+            Ok(_) => panic!("expected error, got datagrams"),
+            Err(ErrorCode::ConnectionRefused | ErrorCode::ConnectionReset) => break,
+            Err(error) => panic!("unexpected error: {error:?}"),
+        }
+
+        let received = rx.subscribe();
+        let timeout = monotonic_clock::subscribe_instant(deadline);
+
+        for ready in poll::poll(&[&received, &timeout]) {
+            match ready {
+                0 => break,
+                1 => panic!("receive timed out instead of returning an error"),
+                _ => unreachable!(),
+            }
+        }
+    }
+}
+
+fn main() {
+    let net = Network::default();
+
+    test_send_to_closed_receiver(&net, IpAddressFamily::Ipv4);
+    test_send_to_closed_receiver(&net, IpAddressFamily::Ipv6);
+}

--- a/crates/test-programs/src/bin/p3_sockets_udp_send.rs
+++ b/crates/test-programs/src/bin/p3_sockets_udp_send.rs
@@ -1,3 +1,6 @@
+use futures::future::{self, Either};
+use std::pin::pin;
+use test_programs::p3::wasi::clocks::monotonic_clock;
 use test_programs::p3::wasi::sockets::types::{
     ErrorCode, IpAddress, IpAddressFamily, IpSocketAddress, UdpSocket,
 };
@@ -32,6 +35,29 @@ async fn test_unspecified_remote_addr(family: IpAddressFamily) {
     assert!(matches!(result, Err(ErrorCode::InvalidArgument)));
 }
 
+async fn test_send_to_closed_receiver(family: IpAddressFamily) {
+    let unspecified_port = IpSocketAddress::new(IpAddress::new_loopback(family), 0);
+
+    let sender = UdpSocket::create(family).unwrap();
+    sender.bind(unspecified_port).unwrap();
+
+    let receiver = UdpSocket::create(family).unwrap();
+    receiver.bind(unspecified_port).unwrap();
+
+    let receiver_address = receiver.get_local_address().unwrap();
+    drop(receiver);
+    sender.connect(receiver_address).unwrap();
+    sender.send(b"hello".to_vec(), None).await.unwrap();
+
+    let received = pin!(sender.receive());
+    let timeout = pin!(monotonic_clock::wait_for(5_000_000_000));
+    match future::select(received, timeout).await {
+        Either::Left((Err(ErrorCode::ConnectionRefused | ErrorCode::ConnectionReset), _)) => {}
+        Either::Left((received, _)) => panic!("unexpected result: {received:?}"),
+        Either::Right(_) => panic!("receive timed out instead of returning an error"),
+    }
+}
+
 impl test_programs::p3::exports::wasi::cli::run::Guest for Component {
     async fn run() -> Result<(), ()> {
         test_udp_send_without_bind_or_connect(IpAddressFamily::Ipv4).await;
@@ -42,6 +68,9 @@ impl test_programs::p3::exports::wasi::cli::run::Guest for Component {
 
         test_unspecified_remote_addr(IpAddressFamily::Ipv4).await;
         test_unspecified_remote_addr(IpAddressFamily::Ipv6).await;
+
+        test_send_to_closed_receiver(IpAddressFamily::Ipv4).await;
+        test_send_to_closed_receiver(IpAddressFamily::Ipv6).await;
 
         Ok(())
     }

--- a/crates/wasi/tests/all/p2/async_.rs
+++ b/crates/wasi/tests/all/p2/async_.rs
@@ -372,6 +372,12 @@ async fn p2_udp_connect() {
     run(P2_UDP_CONNECT_COMPONENT, |_| {}).await.unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn p2_udp_send_to_closed_receiver() {
+    run(P2_UDP_SEND_TO_CLOSED_RECEIVER_COMPONENT, |_| {})
+        .await
+        .unwrap()
+}
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn p2_stream_pollable_correct() {
     run(P2_STREAM_POLLABLE_CORRECT_COMPONENT, |_| {})
         .await

--- a/crates/wasi/tests/all/p2/sync.rs
+++ b/crates/wasi/tests/all/p2/sync.rs
@@ -346,6 +346,14 @@ fn p2_udp_connect() {
     run(P2_UDP_CONNECT_COMPONENT, |_| {}).unwrap()
 }
 #[test_log::test]
+// This test is flaky on Windows.  It consistently passes when run by itself but
+// consistently fails when run in combination with the `p2::async_` variation,
+// and we've thus far been unable to determine the reason.
+#[cfg_attr(windows, ignore = "This test is flaky on Windows.")]
+fn p2_udp_send_to_closed_receiver() {
+    run(P2_UDP_SEND_TO_CLOSED_RECEIVER_COMPONENT, |_| {}).unwrap()
+}
+#[test_log::test]
 fn p2_stream_pollable_correct() {
     run(P2_STREAM_POLLABLE_CORRECT_COMPONENT, |_| {}).unwrap()
 }


### PR DESCRIPTION
This addresses [a failing Tokio
test](https://github.com/tokio-rs/tokio/blob/bc0933ccffb62e010d3ccb497abc22cec2e73f54/tokio/tests/udp.rs#L63-L87) where receiving on a connected socket whose remote has disconnected after sending should return an error immediately.

Note that I've implemented the simplest thing that could work, possibly at a cost to performance.  A more sophisticated alternative could be to update the `Pollable` impl for `IncomingDatagramStream` to check the `tokio::io::Ready` for "error" readiness and only call `tokio::net::UdpSocket::take_error` in that case.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
