### PR TITLE
wasi-sockets: Unify the p2 & p3 implementations

### DIFF
--- a/crates/test-programs/src/bin/p2_udp_connect.rs
+++ b/crates/test-programs/src/bin/p2_udp_connect.rs
@@ -35,6 +35,19 @@ fn test_udp_connect_disconnect_reconnect(net: &Network, family: IpAddressFamily)
     assert_eq!(client.remote_address(), Ok(remote1));
 }
 
+// `stream(None)` should keep the socket bound.
+fn test_udp_disconnect_local_address(net: &Network, family: IpAddressFamily) {
+    let unspecified_addr = IpSocketAddress::new(IpAddress::new_unspecified(family), 0);
+    let some_addr = IpSocketAddress::new(IpAddress::new_loopback(family), 4321);
+
+    let client = UdpSocket::new(family).unwrap();
+    client.blocking_bind(&net, unspecified_addr).unwrap();
+
+    _ = client.stream(Some(some_addr)).unwrap();
+    _ = client.stream(None).unwrap();
+    assert!(client.local_address().is_ok());
+}
+
 /// `0.0.0.0` / `::` is not a valid remote address in WASI.
 fn test_udp_connect_unspec(net: &Network, family: IpAddressFamily) {
     let addr = IpSocketAddress::new(IpAddress::new_unspecified(family), SOME_PORT);
@@ -146,6 +159,9 @@ fn main() {
 
     test_udp_connect_disconnect_reconnect(&net, IpAddressFamily::Ipv4);
     test_udp_connect_disconnect_reconnect(&net, IpAddressFamily::Ipv6);
+
+    test_udp_disconnect_local_address(&net, IpAddressFamily::Ipv4);
+    test_udp_disconnect_local_address(&net, IpAddressFamily::Ipv6);
 
     test_udp_connect_unspec(&net, IpAddressFamily::Ipv4);
     test_udp_connect_unspec(&net, IpAddressFamily::Ipv6);

--- a/crates/test-programs/src/bin/p2_udp_stream.rs
+++ b/crates/test-programs/src/bin/p2_udp_stream.rs
@@ -1,0 +1,112 @@
+use test_programs::wasi::sockets::network::{IpAddress, IpAddressFamily, IpSocketAddress, Network};
+use test_programs::wasi::sockets::udp::{OutgoingDatagram, UdpSocket};
+
+// Check that the implementation supports bulk sends & receives. This isn't
+// strictly required by the spec, but it is something wasmtime wants to support
+// as long as it doesn't add an unreasonable maintenance burden.
+fn test_udp_send_receive_multiple(net: &Network, family: IpAddressFamily) {
+    let bind_unspec = IpSocketAddress::new(IpAddress::new_loopback(family), 0);
+
+    let dest = UdpSocket::new(family).unwrap();
+    dest.blocking_bind(&net, bind_unspec).unwrap();
+    let dest_addr = dest.local_address().unwrap();
+
+    let src = UdpSocket::new(family).unwrap();
+    src.blocking_bind(&net, bind_unspec).unwrap();
+    let src_addr = src.local_address().unwrap();
+
+    {
+        let (_, stream) = src.stream(Some(dest_addr)).unwrap();
+
+        let permit = stream.check_send().unwrap();
+        assert!(permit >= 2);
+
+        let sent = stream
+            .send(&[
+                OutgoingDatagram {
+                    data: b"1".into(),
+                    remote_address: None,
+                },
+                OutgoingDatagram {
+                    data: b"2".into(),
+                    remote_address: None,
+                },
+            ])
+            .unwrap();
+        assert_eq!(sent, 2);
+    }
+    {
+        let (stream, _) = dest.stream(Some(src_addr)).unwrap();
+
+        stream.subscribe().block();
+
+        let datagrams = stream.receive(2).unwrap();
+
+        assert_eq!(datagrams.len(), 2);
+        assert_eq!(datagrams[0].data, b"1");
+        assert_eq!(datagrams[1].data, b"2");
+    }
+}
+
+// If `stream` is called with `Some(addr)` then the returned stream should only
+// return packets from that peer, even if packets from other peers already
+// arrived before calling `stream`.
+fn test_udp_receive_after_connect(net: &Network, family: IpAddressFamily) {
+    let bind_unspec = IpSocketAddress::new(IpAddress::new_loopback(family), 0);
+
+    let dest = UdpSocket::new(family).unwrap();
+    dest.blocking_bind(&net, bind_unspec).unwrap();
+    let dest_addr = dest.local_address().unwrap();
+
+    let src_a = UdpSocket::new(family).unwrap();
+    src_a.blocking_bind(&net, bind_unspec).unwrap();
+    let (_, src_stream_a) = src_a.stream(Some(dest_addr)).unwrap();
+    let src_a_addr = src_a.local_address().unwrap();
+
+    let src_b = UdpSocket::new(family).unwrap();
+    src_b.blocking_bind(&net, bind_unspec).unwrap();
+    let (_, src_stream_b) = src_b.stream(Some(dest_addr)).unwrap();
+    let src_b_addr = src_b.local_address().unwrap();
+
+    // First enqueue packets from multiple sources:
+    src_stream_a
+        .blocking_send(&[OutgoingDatagram {
+            data: b"A".into(),
+            remote_address: None,
+        }])
+        .unwrap();
+    src_stream_b
+        .blocking_send(&[OutgoingDatagram {
+            data: b"B".into(),
+            remote_address: None,
+        }])
+        .unwrap();
+    src_stream_a
+        .blocking_send(&[OutgoingDatagram {
+            data: b"A".into(),
+            remote_address: None,
+        }])
+        .unwrap();
+
+    // _Then_ connect the socket:
+    let (dest_stream, _) = dest.stream(Some(src_b_addr)).unwrap();
+    let dgram = dest_stream
+        .blocking_receive(1..100)
+        .unwrap()
+        .into_iter()
+        .next()
+        .unwrap();
+    assert_eq!(dgram.data, b"B");
+    assert_eq!(dgram.remote_address, src_b_addr);
+    assert_ne!(dgram.remote_address, src_a_addr);
+}
+
+fn main() {
+    let net = Network::default();
+
+    test_udp_send_receive_multiple(&net, IpAddressFamily::Ipv4);
+    test_udp_send_receive_multiple(&net, IpAddressFamily::Ipv6);
+
+    test_udp_receive_after_connect(&net, IpAddressFamily::Ipv4);
+    test_udp_receive_after_connect(&net, IpAddressFamily::Ipv6);
+}

--- a/crates/test-programs/src/bin/p3_sockets_udp_connect.rs
+++ b/crates/test-programs/src/bin/p3_sockets_udp_connect.rs
@@ -32,23 +32,33 @@ fn test_udp_connect_disconnect_reconnect(family: IpAddressFamily) {
         Err(ErrorCode::InvalidState)
     ));
 
-    _ = client.connect(remote1).unwrap();
+    client.connect(remote1).unwrap();
     assert_eq!(client.get_remote_address().unwrap(), remote1);
 
-    _ = client.connect(remote1).unwrap();
+    client.connect(remote1).unwrap();
     assert_eq!(client.get_remote_address().unwrap(), remote1);
 
-    _ = client.connect(remote2).unwrap();
+    client.connect(remote2).unwrap();
     assert_eq!(client.get_remote_address().unwrap(), remote2);
 
-    _ = client.disconnect().unwrap();
+    client.disconnect().unwrap();
     assert!(matches!(
         client.get_remote_address(),
         Err(ErrorCode::InvalidState)
     ));
 
-    _ = client.connect(remote1).unwrap();
+    client.connect(remote1).unwrap();
     assert_eq!(client.get_remote_address().unwrap(), remote1);
+}
+
+// `disconnect` should keep the socket bound.
+fn test_udp_disconnect_local_address(family: IpAddressFamily) {
+    let some_addr = IpSocketAddress::new(IpAddress::new_loopback(family), 4321);
+    let client = UdpSocket::create(family).unwrap();
+
+    client.connect(some_addr).unwrap();
+    client.disconnect().unwrap();
+    assert!(client.get_local_address().is_ok());
 }
 
 /// `0.0.0.0` / `::` is not a valid remote address in WASI.
@@ -194,6 +204,7 @@ impl test_programs::p3::exports::wasi::cli::run::Guest for Component {
         let supports_ipv6 = supports_ipv6();
 
         test_udp_connect_disconnect_reconnect(IpAddressFamily::Ipv4);
+        test_udp_disconnect_local_address(IpAddressFamily::Ipv4);
         test_udp_connect_unspec(IpAddressFamily::Ipv4);
         test_udp_connect_local_address_change(IpAddressFamily::Ipv4);
         test_udp_connect_port_0(IpAddressFamily::Ipv4);
@@ -204,6 +215,7 @@ impl test_programs::p3::exports::wasi::cli::run::Guest for Component {
 
         if supports_ipv6 {
             test_udp_connect_disconnect_reconnect(IpAddressFamily::Ipv6);
+            test_udp_disconnect_local_address(IpAddressFamily::Ipv6);
             test_udp_connect_unspec(IpAddressFamily::Ipv6);
             test_udp_connect_local_address_change(IpAddressFamily::Ipv6);
             test_udp_connect_port_0(IpAddressFamily::Ipv6);

--- a/crates/wasi/src/p2/bindings.rs
+++ b/crates/wasi/src/p2/bindings.rs
@@ -171,7 +171,7 @@ pub mod sync {
                 "wasi:sockets/tcp.tcp-socket": super::super::sockets::tcp::TcpSocket,
                 "wasi:sockets/udp.incoming-datagram-stream": super::super::sockets::udp::IncomingDatagramStream,
                 "wasi:sockets/udp.outgoing-datagram-stream": super::super::sockets::udp::OutgoingDatagramStream,
-                "wasi:sockets/udp.udp-socket": crate::sockets::UdpSocket,
+                "wasi:sockets/udp.udp-socket": crate::p2::UdpSocket,
 
                 // Error host trait from wasmtime-wasi-io is synchronous, so we can alias it
                 "wasi:io/error": wasmtime_wasi_io::bindings::wasi::io::error,
@@ -365,11 +365,12 @@ mod async_io {
             "wasi:filesystem/types.[method]descriptor.unlink-file-at": async | tracing | trappable,
             "wasi:filesystem/types.[method]descriptor.write": async | tracing | trappable,
             "wasi:filesystem/types.[method]directory-entry-stream.read-directory-entry": async | tracing | trappable,
+            "wasi:sockets/udp-create-socket.create-udp-socket": async | tracing | trappable,
             "wasi:sockets/tcp.[method]tcp-socket.start-bind": async | tracing | trappable,
-            "wasi:sockets/tcp.[method]tcp-socket.start-connect": async | tracing | trappable,
+            "wasi:sockets/tcp.[method]tcp-socket.start-listen": async | tracing | trappable,
             "wasi:sockets/udp.[method]udp-socket.start-bind": async | tracing | trappable,
             "wasi:sockets/udp.[method]udp-socket.stream": async | tracing | trappable,
-            "wasi:sockets/udp.[method]outgoing-datagram-stream.send": async | tracing | trappable,
+            "wasi:sockets/udp.[drop]outgoing-datagram-stream": async | tracing | trappable,
             default: tracing | trappable,
         },
         exports: { default: async },
@@ -389,8 +390,8 @@ mod async_io {
             // Configure all other resources to be concrete types defined in
             // this crate
             "wasi:sockets/network.network": crate::p2::network::Network,
-            "wasi:sockets/tcp.tcp-socket": crate::sockets::TcpSocket,
-            "wasi:sockets/udp.udp-socket": crate::sockets::UdpSocket,
+            "wasi:sockets/tcp.tcp-socket": crate::p2::TcpSocket,
+            "wasi:sockets/udp.udp-socket": crate::p2::UdpSocket,
             "wasi:sockets/udp.incoming-datagram-stream": crate::p2::udp::IncomingDatagramStream,
             "wasi:sockets/udp.outgoing-datagram-stream": crate::p2::udp::OutgoingDatagramStream,
             "wasi:sockets/ip-name-lookup.resolve-address-stream": crate::p2::ip_name_lookup::ResolveAddressStream,

--- a/crates/wasi/src/p2/host/instance_network.rs
+++ b/crates/wasi/src/p2/host/instance_network.rs
@@ -5,10 +5,7 @@ use wasmtime::component::Resource;
 
 impl instance_network::Host for WasiSocketsCtxView<'_> {
     fn instance_network(&mut self) -> Result<Resource<Network>, wasmtime::Error> {
-        let network = Network {
-            socket_addr_check: self.ctx.socket_addr_check.clone(),
-            allow_ip_name_lookup: self.ctx.allowed_network_uses.ip_name_lookup,
-        };
+        let network = Network { _priv: () };
         let network = self.table.push(network)?;
         Ok(network)
     }

--- a/crates/wasi/src/p2/host/tcp.rs
+++ b/crates/wasi/src/p2/host/tcp.rs
@@ -1,10 +1,14 @@
-use crate::p2::bindings::{
-    sockets::network::{ErrorCode, IpAddressFamily, IpSocketAddress, Network},
-    sockets::tcp::{self, ShutdownType},
+use crate::p2::{Pollable, SocketResult, tcp::TcpSocket};
+use crate::p2::{
+    bindings::sockets::{
+        network::{ErrorCode, IpAddressFamily, IpSocketAddress, Network},
+        tcp::{self, ShutdownType},
+    },
+    tcp::AsyncOperation,
 };
-use crate::p2::{Pollable, SocketResult};
-use crate::sockets::{SocketAddrUse, TcpSocket, WasiSocketsCtxView};
+use crate::sockets::{WasiSocketsCtxView, noop_cx};
 use std::net::SocketAddr;
+use std::task::Poll;
 use wasmtime::component::Resource;
 use wasmtime_wasi_io::{
     poll::DynPollable,
@@ -20,47 +24,50 @@ impl crate::p2::host::tcp::tcp::HostTcpSocket for WasiSocketsCtxView<'_> {
         network: Resource<Network>,
         local_address: IpSocketAddress,
     ) -> SocketResult<()> {
-        let network = self.table.get(&network)?;
+        // The network resource itself represents the capability to use this
+        // method, so we need to check its validity. Other than that, we have no
+        // use for it.
+        _ = self.table.get(&network)?;
+
         let local_address: SocketAddr = local_address.into();
+        let socket = self.table.get_mut(&this)?;
+        if socket.in_progress_operation.is_some() {
+            return Err(ErrorCode::ConcurrencyConflict.into());
+        }
 
-        // Ensure that we're allowed to connect to this address.
-        network
-            .check_socket_addr(local_address, SocketAddrUse::TcpBind)
-            .await?;
-
-        // Bind to the address.
-        self.table.get_mut(&this)?.start_bind(local_address)?;
-
+        socket.inner.bind(local_address).await?;
+        socket.in_progress_operation = Some(AsyncOperation::Bind);
         Ok(())
     }
 
     fn finish_bind(&mut self, this: Resource<TcpSocket>) -> SocketResult<()> {
         let socket = self.table.get_mut(&this)?;
-        socket.finish_bind()?;
+        if socket.in_progress_operation != Some(AsyncOperation::Bind) {
+            return Err(ErrorCode::NotInProgress.into());
+        };
+        socket.in_progress_operation = None;
         Ok(())
     }
 
-    async fn start_connect(
+    fn start_connect(
         &mut self,
         this: Resource<TcpSocket>,
         network: Resource<Network>,
         remote_address: IpSocketAddress,
     ) -> SocketResult<()> {
-        let network = self.table.get(&network)?;
+        // The network resource itself represents the capability to use this
+        // method, so we need to check its validity. Other than that, we have no
+        // use for it.
+        _ = self.table.get(&network)?;
+
         let remote_address: SocketAddr = remote_address.into();
-
-        // Ensure that we're allowed to connect to this address.
-        network
-            .check_socket_addr(remote_address, SocketAddrUse::TcpConnect)
-            .await?;
-
-        // Start connection
         let socket = self.table.get_mut(&this)?;
-        let future = socket
-            .start_connect(&remote_address)?
-            .connect(remote_address);
-        socket.set_pending_connect(future)?;
+        if socket.in_progress_operation.is_some() {
+            return Err(ErrorCode::ConcurrencyConflict.into());
+        }
 
+        socket.inner.start_connect(remote_address)?;
+        socket.in_progress_operation = Some(AsyncOperation::Connect);
         Ok(())
     }
 
@@ -69,27 +76,48 @@ impl crate::p2::host::tcp::tcp::HostTcpSocket for WasiSocketsCtxView<'_> {
         this: Resource<TcpSocket>,
     ) -> SocketResult<(Resource<DynInputStream>, Resource<DynOutputStream>)> {
         let socket = self.table.get_mut(&this)?;
+        if socket.in_progress_operation != Some(AsyncOperation::Connect) {
+            return Err(ErrorCode::NotInProgress.into());
+        };
 
-        let result = socket
-            .take_pending_connect()?
-            .ok_or(ErrorCode::WouldBlock)?;
-        socket.finish_connect(result)?;
-        let (input, output) = socket.p2_streams()?;
+        let Poll::Ready(result) = socket.inner.poll_finish_connect(&mut noop_cx()) else {
+            return Err(ErrorCode::WouldBlock.into());
+        };
+        socket.in_progress_operation = None;
+
+        if let Err(e) = result {
+            return Err(e.into());
+        }
+
+        let (input, output) = socket.take_streams()?;
         let input = self.table.push_child(input, &this)?;
         let output = self.table.push_child(output, &this)?;
         Ok((input, output))
     }
 
-    fn start_listen(&mut self, this: Resource<TcpSocket>) -> SocketResult<()> {
+    async fn start_listen(&mut self, this: Resource<TcpSocket>) -> SocketResult<()> {
         let socket = self.table.get_mut(&this)?;
+        if socket.in_progress_operation.is_some() {
+            return Err(ErrorCode::ConcurrencyConflict.into());
+        }
 
-        socket.start_listen()?;
+        if !socket.inner.is_bound() {
+            // In WASI 0.2, sockets had to be explicitly bound before listening.
+            return Err(ErrorCode::InvalidState.into());
+        }
+
+        let listener = socket.inner.listen().await?;
+        socket.in_progress_operation = Some(AsyncOperation::Listen);
+        socket.listener = Some(listener);
         Ok(())
     }
 
     fn finish_listen(&mut self, this: Resource<TcpSocket>) -> SocketResult<()> {
         let socket = self.table.get_mut(&this)?;
-        socket.finish_listen()?;
+        if socket.in_progress_operation != Some(AsyncOperation::Listen) {
+            return Err(ErrorCode::NotInProgress.into());
+        };
+        socket.in_progress_operation = None;
         Ok(())
     }
 
@@ -102,9 +130,16 @@ impl crate::p2::host::tcp::tcp::HostTcpSocket for WasiSocketsCtxView<'_> {
         Resource<DynOutputStream>,
     )> {
         let socket = self.table.get_mut(&this)?;
+        let Some(listener) = &mut socket.listener else {
+            return Err(ErrorCode::InvalidState.into());
+        };
 
-        let mut tcp_socket = socket.accept()?.ok_or(ErrorCode::WouldBlock)?;
-        let (input, output) = tcp_socket.p2_streams()?;
+        let accepted = match listener.poll_accept(&mut noop_cx()) {
+            Poll::Pending => return Err(ErrorCode::WouldBlock.into()),
+            Poll::Ready(accepted) => accepted,
+        };
+        let mut tcp_socket = TcpSocket::new(accepted);
+        let (input, output) = tcp_socket.take_streams()?;
 
         let tcp_socket = self.table.push(tcp_socket)?;
         let input_stream = self.table.push_child(input, &tcp_socket)?;
@@ -114,19 +149,18 @@ impl crate::p2::host::tcp::tcp::HostTcpSocket for WasiSocketsCtxView<'_> {
     }
 
     fn local_address(&mut self, this: Resource<TcpSocket>) -> SocketResult<IpSocketAddress> {
-        let socket = self.table.get(&this)?;
-        Ok(socket.local_address()?.into())
+        let socket = self.table.get_mut(&this)?;
+        Ok(socket.inner.local_address()?.into())
     }
 
     fn remote_address(&mut self, this: Resource<TcpSocket>) -> SocketResult<IpSocketAddress> {
         let socket = self.table.get(&this)?;
-        Ok(socket.remote_address()?.into())
+        Ok(socket.inner.remote_address()?.into())
     }
 
     fn is_listening(&mut self, this: Resource<TcpSocket>) -> Result<bool, wasmtime::Error> {
         let socket = self.table.get(&this)?;
-
-        Ok(socket.is_listening())
+        Ok(socket.inner.is_listening())
     }
 
     fn address_family(
@@ -134,7 +168,7 @@ impl crate::p2::host::tcp::tcp::HostTcpSocket for WasiSocketsCtxView<'_> {
         this: Resource<TcpSocket>,
     ) -> Result<IpAddressFamily, wasmtime::Error> {
         let socket = self.table.get(&this)?;
-        Ok(socket.address_family().into())
+        Ok(socket.inner.address_family().into())
     }
 
     fn set_listen_backlog_size(
@@ -143,13 +177,13 @@ impl crate::p2::host::tcp::tcp::HostTcpSocket for WasiSocketsCtxView<'_> {
         value: u64,
     ) -> SocketResult<()> {
         let socket = self.table.get_mut(&this)?;
-        socket.set_listen_backlog_size(value)?;
+        socket.inner.set_listen_backlog_size(value)?;
         Ok(())
     }
 
     fn keep_alive_enabled(&mut self, this: Resource<TcpSocket>) -> SocketResult<bool> {
         let socket = self.table.get(&this)?;
-        Ok(socket.keep_alive_enabled()?)
+        Ok(socket.inner.keep_alive_enabled()?)
     }
 
     fn set_keep_alive_enabled(
@@ -158,13 +192,13 @@ impl crate::p2::host::tcp::tcp::HostTcpSocket for WasiSocketsCtxView<'_> {
         value: bool,
     ) -> SocketResult<()> {
         let socket = self.table.get(&this)?;
-        socket.set_keep_alive_enabled(value)?;
+        socket.inner.set_keep_alive_enabled(value)?;
         Ok(())
     }
 
     fn keep_alive_idle_time(&mut self, this: Resource<TcpSocket>) -> SocketResult<u64> {
         let socket = self.table.get(&this)?;
-        Ok(socket.keep_alive_idle_time()?)
+        Ok(socket.inner.keep_alive_idle_time()?)
     }
 
     fn set_keep_alive_idle_time(
@@ -173,13 +207,13 @@ impl crate::p2::host::tcp::tcp::HostTcpSocket for WasiSocketsCtxView<'_> {
         value: u64,
     ) -> SocketResult<()> {
         let socket = self.table.get_mut(&this)?;
-        socket.set_keep_alive_idle_time(value)?;
+        socket.inner.set_keep_alive_idle_time(value)?;
         Ok(())
     }
 
     fn keep_alive_interval(&mut self, this: Resource<TcpSocket>) -> SocketResult<u64> {
         let socket = self.table.get(&this)?;
-        Ok(socket.keep_alive_interval()?)
+        Ok(socket.inner.keep_alive_interval()?)
     }
 
     fn set_keep_alive_interval(
@@ -188,35 +222,35 @@ impl crate::p2::host::tcp::tcp::HostTcpSocket for WasiSocketsCtxView<'_> {
         value: u64,
     ) -> SocketResult<()> {
         let socket = self.table.get(&this)?;
-        socket.set_keep_alive_interval(value)?;
+        socket.inner.set_keep_alive_interval(value)?;
         Ok(())
     }
 
     fn keep_alive_count(&mut self, this: Resource<TcpSocket>) -> SocketResult<u32> {
         let socket = self.table.get(&this)?;
-        Ok(socket.keep_alive_count()?)
+        Ok(socket.inner.keep_alive_count()?)
     }
 
     fn set_keep_alive_count(&mut self, this: Resource<TcpSocket>, value: u32) -> SocketResult<()> {
         let socket = self.table.get(&this)?;
-        socket.set_keep_alive_count(value)?;
+        socket.inner.set_keep_alive_count(value)?;
         Ok(())
     }
 
     fn hop_limit(&mut self, this: Resource<TcpSocket>) -> SocketResult<u8> {
         let socket = self.table.get(&this)?;
-        Ok(socket.hop_limit()?)
+        Ok(socket.inner.hop_limit()?)
     }
 
     fn set_hop_limit(&mut self, this: Resource<TcpSocket>, value: u8) -> SocketResult<()> {
         let socket = self.table.get_mut(&this)?;
-        socket.set_hop_limit(value)?;
+        socket.inner.set_hop_limit(value)?;
         Ok(())
     }
 
     fn receive_buffer_size(&mut self, this: Resource<TcpSocket>) -> SocketResult<u64> {
         let socket = self.table.get(&this)?;
-        Ok(socket.receive_buffer_size()?)
+        Ok(socket.inner.receive_buffer_size()?)
     }
 
     fn set_receive_buffer_size(
@@ -225,18 +259,18 @@ impl crate::p2::host::tcp::tcp::HostTcpSocket for WasiSocketsCtxView<'_> {
         value: u64,
     ) -> SocketResult<()> {
         let socket = self.table.get_mut(&this)?;
-        socket.set_receive_buffer_size(value)?;
+        socket.inner.set_receive_buffer_size(value)?;
         Ok(())
     }
 
     fn send_buffer_size(&mut self, this: Resource<TcpSocket>) -> SocketResult<u64> {
         let socket = self.table.get(&this)?;
-        Ok(socket.send_buffer_size()?)
+        Ok(socket.inner.send_buffer_size()?)
     }
 
     fn set_send_buffer_size(&mut self, this: Resource<TcpSocket>, value: u64) -> SocketResult<()> {
         let socket = self.table.get_mut(&this)?;
-        socket.set_send_buffer_size(value)?;
+        socket.inner.set_send_buffer_size(value)?;
         Ok(())
     }
 
@@ -249,16 +283,8 @@ impl crate::p2::host::tcp::tcp::HostTcpSocket for WasiSocketsCtxView<'_> {
         this: Resource<TcpSocket>,
         shutdown_type: ShutdownType,
     ) -> SocketResult<()> {
-        let socket = self.table.get(&this)?;
-
-        let how = match shutdown_type {
-            ShutdownType::Receive => std::net::Shutdown::Read,
-            ShutdownType::Send => std::net::Shutdown::Write,
-            ShutdownType::Both => std::net::Shutdown::Both,
-        };
-
-        let state = socket.p2_streaming_state()?;
-        state.shutdown(how)?;
+        let socket = self.table.get_mut(&this)?;
+        socket.shutdown(shutdown_type.into())?;
         Ok(())
     }
 
@@ -275,7 +301,15 @@ impl crate::p2::host::tcp::tcp::HostTcpSocket for WasiSocketsCtxView<'_> {
 #[async_trait::async_trait]
 impl Pollable for TcpSocket {
     async fn ready(&mut self) {
-        <TcpSocket>::ready(self).await;
+        match &self.in_progress_operation {
+            Some(AsyncOperation::Connect) => {
+                _ = std::future::poll_fn(|cx| self.inner.poll_finish_connect(cx)).await;
+            }
+            None if let Some(listener) = &mut self.listener => {
+                std::future::poll_fn(|cx| listener.poll_ready(cx)).await;
+            }
+            _ => {}
+        }
     }
 }
 
@@ -321,9 +355,7 @@ pub mod sync {
             network: Resource<Network>,
             remote_address: IpSocketAddress,
         ) -> Result<(), SocketError> {
-            in_tokio(async {
-                AsyncHostTcpSocket::start_connect(self, self_, network, remote_address).await
-            })
+            AsyncHostTcpSocket::start_connect(self, self_, network, remote_address)
         }
 
         fn finish_connect(
@@ -334,7 +366,7 @@ pub mod sync {
         }
 
         fn start_listen(&mut self, self_: Resource<TcpSocket>) -> Result<(), SocketError> {
-            AsyncHostTcpSocket::start_listen(self, self_)
+            in_tokio(async { AsyncHostTcpSocket::start_listen(self, self_).await })
         }
 
         fn finish_listen(&mut self, self_: Resource<TcpSocket>) -> Result<(), SocketError> {

--- a/crates/wasi/src/p2/host/tcp_create_socket.rs
+++ b/crates/wasi/src/p2/host/tcp_create_socket.rs
@@ -1,6 +1,6 @@
-use crate::p2::SocketResult;
 use crate::p2::bindings::{sockets::network::IpAddressFamily, sockets::tcp_create_socket};
-use crate::sockets::{SocketAddressFamily, TcpSocket, WasiSocketsCtxView};
+use crate::p2::{SocketResult, TcpSocket};
+use crate::sockets::{SocketAddressFamily, TcpSocket as P3Socket, WasiSocketsCtxView};
 use wasmtime::component::Resource;
 
 impl tcp_create_socket::Host for WasiSocketsCtxView<'_> {
@@ -8,8 +8,8 @@ impl tcp_create_socket::Host for WasiSocketsCtxView<'_> {
         &mut self,
         address_family: IpAddressFamily,
     ) -> SocketResult<Resource<TcpSocket>> {
-        let socket = TcpSocket::new(self.ctx, address_family.into())?;
-        let socket = self.table.push(socket)?;
+        let socket = P3Socket::new(self.ctx, address_family.into())?;
+        let socket = self.table.push(TcpSocket::new(socket))?;
         Ok(socket)
     }
 }

--- a/crates/wasi/src/p2/host/udp.rs
+++ b/crates/wasi/src/p2/host/udp.rs
@@ -1,48 +1,60 @@
 use crate::p2::bindings::sockets::network::{ErrorCode, IpAddressFamily, IpSocketAddress, Network};
 use crate::p2::bindings::sockets::udp;
-use crate::p2::udp::{IncomingDatagramStream, OutgoingDatagramStream};
-use crate::p2::{Pollable, SocketError, SocketResult};
-use crate::sockets::util::{is_valid_address_family, is_valid_remote_address};
-use crate::sockets::{
-    MAX_UDP_DATAGRAM_SIZE, SocketAddrUse, SocketAddressFamily, UdpSocket, WasiSocketsCtxView,
-};
+use crate::p2::udp::{AsyncOperation, IncomingDatagramStream, OutgoingDatagramStream};
+use crate::p2::{Pollable, SocketError, SocketResult, UdpSocket};
+use crate::sockets::{SocketAddressFamily, WasiSocketsCtxView};
 use async_trait::async_trait;
+use std::future::poll_fn;
 use std::net::SocketAddr;
-use std::pin::pin;
 use std::task::{Context, Poll, Waker};
-use tokio::io::Interest;
 use wasmtime::component::Resource;
 use wasmtime::format_err;
 use wasmtime_wasi_io::poll::DynPollable;
+
+const MAX_DATAGRAMS: usize = 16;
 
 impl udp::Host for WasiSocketsCtxView<'_> {}
 
 impl udp::HostUdpSocket for WasiSocketsCtxView<'_> {
     async fn start_bind(
         &mut self,
-        this: Resource<udp::UdpSocket>,
+        this: Resource<UdpSocket>,
         network: Resource<Network>,
         local_address: IpSocketAddress,
     ) -> SocketResult<()> {
+        // The network resource itself represents the capability to use this
+        // method, so we need to check its validity. Other than that, we have no
+        // use for it.
+        _ = self.table.get(&network)?;
+
         let local_address = SocketAddr::from(local_address);
-        let check = self.table.get(&network)?.socket_addr_check.clone();
-        check.check(local_address, SocketAddrUse::UdpBind).await?;
-
         let socket = self.table.get_mut(&this)?;
-        socket.bind(local_address)?;
-        socket.set_socket_addr_check(Some(check));
+        if socket.in_progress_operation.is_some() {
+            return Err(ErrorCode::ConcurrencyConflict.into());
+        }
 
+        socket
+            .get_mut()
+            .ok_or(ErrorCode::InvalidState)?
+            .bind(local_address)
+            .await?;
+
+        socket.in_progress_operation = Some(AsyncOperation::Bind);
         Ok(())
     }
 
-    fn finish_bind(&mut self, this: Resource<udp::UdpSocket>) -> SocketResult<()> {
-        self.table.get_mut(&this)?.finish_bind()?;
+    fn finish_bind(&mut self, this: Resource<UdpSocket>) -> SocketResult<()> {
+        let socket = self.table.get_mut(&this)?;
+        if socket.in_progress_operation != Some(AsyncOperation::Bind) {
+            return Err(ErrorCode::NotInProgress.into());
+        };
+        socket.in_progress_operation = None;
         Ok(())
     }
 
     async fn stream(
         &mut self,
-        this: Resource<udp::UdpSocket>,
+        this: Resource<UdpSocket>,
         remote_address: Option<IpSocketAddress>,
     ) -> SocketResult<(
         Resource<udp::IncomingDatagramStream>,
@@ -60,95 +72,81 @@ impl udp::HostUdpSocket for WasiSocketsCtxView<'_> {
         }
 
         let socket = self.table.get_mut(&this)?;
-        let remote_address = remote_address.map(SocketAddr::from);
+        let inner = socket
+            .get_mut()
+            .ok_or(SocketError::trap(wasmtime::error::format_err!(
+                "`connect` needs exclusive access"
+            )))?;
 
-        if !socket.is_bound() {
+        if !inner.is_bound() {
+            // In WASI 0.2, sockets had to be explicitly bound before connecting.
             return Err(ErrorCode::InvalidState.into());
         }
 
         if let Some(connect_addr) = remote_address {
-            let Some(check) = socket.socket_addr_check() else {
-                return Err(ErrorCode::InvalidState.into());
-            };
-            check.check(connect_addr, SocketAddrUse::UdpConnect).await?;
-            socket.connect_p2(connect_addr)?;
-        } else if socket.is_connected() {
-            socket.disconnect()?;
+            inner.connect(connect_addr.into()).await?;
+        } else if inner.is_connected() {
+            inner.disconnect()?;
         }
-
-        let incoming_stream = IncomingDatagramStream {
-            inner: socket.socket().clone(),
-            remote_address,
-        };
-        let outgoing_stream = OutgoingDatagramStream {
-            inner: socket.socket().clone(),
-            remote_address,
-            family: socket.address_family(),
-            socket_addr_check: socket.socket_addr_check().cloned(),
-            check_send_permit_count: 0,
-        };
-
+        let incoming_stream = IncomingDatagramStream::new(socket.inner.clone());
+        let outgoing_stream = OutgoingDatagramStream::new(socket.inner.clone());
         Ok((
             self.table.push_child(incoming_stream, &this)?,
             self.table.push_child(outgoing_stream, &this)?,
         ))
     }
 
-    fn local_address(&mut self, this: Resource<udp::UdpSocket>) -> SocketResult<IpSocketAddress> {
-        let socket = self.table.get(&this)?;
+    fn local_address(&mut self, this: Resource<UdpSocket>) -> SocketResult<IpSocketAddress> {
+        let mut socket = self.table.get(&this)?.lock();
         Ok(socket.local_address()?.into())
     }
 
-    fn remote_address(&mut self, this: Resource<udp::UdpSocket>) -> SocketResult<IpSocketAddress> {
-        let socket = self.table.get(&this)?;
+    fn remote_address(&mut self, this: Resource<UdpSocket>) -> SocketResult<IpSocketAddress> {
+        let mut socket = self.table.get(&this)?.lock();
         Ok(socket.remote_address()?.into())
     }
 
     fn address_family(
         &mut self,
-        this: Resource<udp::UdpSocket>,
+        this: Resource<UdpSocket>,
     ) -> Result<IpAddressFamily, wasmtime::Error> {
-        let socket = self.table.get(&this)?;
+        let socket = self.table.get(&this)?.lock();
         Ok(socket.address_family().into())
     }
 
-    fn unicast_hop_limit(&mut self, this: Resource<udp::UdpSocket>) -> SocketResult<u8> {
-        let socket = self.table.get(&this)?;
+    fn unicast_hop_limit(&mut self, this: Resource<UdpSocket>) -> SocketResult<u8> {
+        let socket = self.table.get(&this)?.lock();
         Ok(socket.unicast_hop_limit()?)
     }
 
-    fn set_unicast_hop_limit(
-        &mut self,
-        this: Resource<udp::UdpSocket>,
-        value: u8,
-    ) -> SocketResult<()> {
-        let socket = self.table.get(&this)?;
+    fn set_unicast_hop_limit(&mut self, this: Resource<UdpSocket>, value: u8) -> SocketResult<()> {
+        let socket = self.table.get(&this)?.lock();
         socket.set_unicast_hop_limit(value)?;
         Ok(())
     }
 
-    fn receive_buffer_size(&mut self, this: Resource<udp::UdpSocket>) -> SocketResult<u64> {
-        let socket = self.table.get(&this)?;
+    fn receive_buffer_size(&mut self, this: Resource<UdpSocket>) -> SocketResult<u64> {
+        let socket = self.table.get(&this)?.lock();
         Ok(socket.receive_buffer_size()?)
     }
 
     fn set_receive_buffer_size(
         &mut self,
-        this: Resource<udp::UdpSocket>,
+        this: Resource<UdpSocket>,
         value: u64,
     ) -> SocketResult<()> {
-        let socket = self.table.get(&this)?;
+        let socket = self.table.get(&this)?.lock();
         socket.set_receive_buffer_size(value)?;
         Ok(())
     }
 
-    fn send_buffer_size(&mut self, this: Resource<udp::UdpSocket>) -> SocketResult<u64> {
-        let socket = self.table.get(&this)?;
+    fn send_buffer_size(&mut self, this: Resource<UdpSocket>) -> SocketResult<u64> {
+        let socket = self.table.get(&this)?.lock();
         Ok(socket.send_buffer_size()?)
     }
 
     fn set_send_buffer_size(&mut self, this: Resource<UdpSocket>, value: u64) -> SocketResult<()> {
-        let socket = self.table.get(&this)?;
+        let socket = self.table.get(&this)?.lock();
         socket.set_send_buffer_size(value)?;
         Ok(())
     }
@@ -157,7 +155,7 @@ impl udp::HostUdpSocket for WasiSocketsCtxView<'_> {
         wasmtime_wasi_io::poll::subscribe(self.table, this)
     }
 
-    fn drop(&mut self, this: Resource<udp::UdpSocket>) -> Result<(), wasmtime::Error> {
+    fn drop(&mut self, this: Resource<UdpSocket>) -> Result<(), wasmtime::Error> {
         // As in the filesystem implementation, we assume closing a socket
         // doesn't block.
         let dropped = self.table.delete(this)?;
@@ -180,31 +178,11 @@ impl udp::HostIncomingDatagramStream for WasiSocketsCtxView<'_> {
         this: Resource<udp::IncomingDatagramStream>,
         max_results: u64,
     ) -> SocketResult<Vec<udp::IncomingDatagram>> {
-        // Returns Ok(None) when the message was dropped.
-        fn recv_one(
-            stream: &IncomingDatagramStream,
-        ) -> SocketResult<Option<udp::IncomingDatagram>> {
-            let mut buf = [0; MAX_UDP_DATAGRAM_SIZE];
-            let (size, received_addr) = stream.inner.try_recv_from(&mut buf)?;
-            debug_assert!(size <= buf.len());
-
-            match stream.remote_address {
-                Some(connected_addr) if connected_addr != received_addr => {
-                    // Normally, this should have already been checked for us by the OS.
-                    return Ok(None);
-                }
-                _ => {}
-            }
-
-            Ok(Some(udp::IncomingDatagram {
-                data: buf[..size].into(),
-                remote_address: received_addr.into(),
-            }))
-        }
-
-        let stream = self.table.get(&this)?;
-        let max_results: usize = max_results.try_into().unwrap_or(usize::MAX);
-
+        let stream = self.table.get_mut(&this)?;
+        let max_results: usize = max_results
+            .try_into()
+            .unwrap_or(usize::MAX)
+            .min(MAX_DATAGRAMS);
         if max_results == 0 {
             return Ok(vec![]);
         }
@@ -213,22 +191,18 @@ impl udp::HostIncomingDatagramStream for WasiSocketsCtxView<'_> {
         let mut sum = 0;
 
         while datagrams.len() < max_results && sum < crate::MAX_READ_SIZE_ALLOC {
-            match recv_one(stream) {
-                Ok(Some(datagram)) => {
-                    sum += 1 + datagram.data.len();
-                    datagrams.push(datagram);
+            match stream.try_recv() {
+                Err(ErrorCode::WouldBlock) => break,
+                Ok((data, remote_addr)) => {
+                    sum += 1 + data.len();
+                    datagrams.push(udp::IncomingDatagram {
+                        data,
+                        remote_address: remote_addr.into(),
+                    });
                 }
-                Ok(None) => {
-                    // Message was dropped
-                }
-                Err(_) if datagrams.len() > 0 => {
-                    return Ok(datagrams);
-                }
-                Err(e) if matches!(e.downcast_ref(), Some(ErrorCode::WouldBlock)) => {
-                    return Ok(datagrams);
-                }
+                Err(_) if datagrams.len() > 0 => break,
                 Err(e) => {
-                    return Err(e);
+                    return Err(e.into());
                 }
             }
         }
@@ -256,10 +230,7 @@ impl udp::HostIncomingDatagramStream for WasiSocketsCtxView<'_> {
 #[async_trait]
 impl Pollable for IncomingDatagramStream {
     async fn ready(&mut self) {
-        self.inner
-            .ready(Interest::READABLE.add(Interest::ERROR))
-            .await
-            .expect("failed to await UDP socket readiness");
+        poll_fn(|cx| self.poll_recv_ready(cx)).await
     }
 }
 
@@ -267,15 +238,14 @@ impl udp::HostOutgoingDatagramStream for WasiSocketsCtxView<'_> {
     fn check_send(&mut self, this: Resource<udp::OutgoingDatagramStream>) -> SocketResult<u64> {
         let stream = self.table.get_mut(&this)?;
 
-        let count = if let Poll::Ready(_) =
-            pin!(stream.inner.ready(Interest::WRITABLE.add(Interest::ERROR)))
-                .poll(&mut Context::from_waker(Waker::noop()))
+        let count = if let Poll::Ready(()) =
+            stream.poll_send_ready(&mut Context::from_waker(Waker::noop()))
         {
             // We don't know how many Tokio will accept, so we make up a
             // reasonable number here.  If we're wrong and `send` returns
             // `Ok(0)`, the guest will just have to deal with that, e.g. by
             // looping or returning `EWOULDBLOCK`.
-            16
+            MAX_DATAGRAMS
         } else {
             0
         };
@@ -285,51 +255,11 @@ impl udp::HostOutgoingDatagramStream for WasiSocketsCtxView<'_> {
         Ok(count.try_into().unwrap())
     }
 
-    async fn send(
+    fn send(
         &mut self,
         this: Resource<udp::OutgoingDatagramStream>,
         datagrams: Vec<udp::OutgoingDatagram>,
     ) -> SocketResult<u64> {
-        async fn send_one(
-            stream: &OutgoingDatagramStream,
-            datagram: &udp::OutgoingDatagram,
-        ) -> SocketResult<()> {
-            if datagram.data.len() > MAX_UDP_DATAGRAM_SIZE {
-                return Err(ErrorCode::DatagramTooLarge.into());
-            }
-
-            let provided_addr = datagram.remote_address.map(SocketAddr::from);
-            let addr = match (stream.remote_address, provided_addr) {
-                (None, Some(addr)) => {
-                    let Some(check) = stream.socket_addr_check.as_ref() else {
-                        return Err(ErrorCode::InvalidState.into());
-                    };
-                    check
-                        .check(addr, SocketAddrUse::UdpOutgoingDatagram)
-                        .await?;
-                    addr
-                }
-                (Some(addr), None) => addr,
-                (Some(connected_addr), Some(provided_addr)) if connected_addr == provided_addr => {
-                    connected_addr
-                }
-                _ => return Err(ErrorCode::InvalidArgument.into()),
-            };
-
-            if !is_valid_remote_address(addr) || !is_valid_address_family(addr.ip(), stream.family)
-            {
-                return Err(ErrorCode::InvalidArgument.into());
-            }
-
-            if stream.remote_address == Some(addr) {
-                stream.inner.try_send(&datagram.data)?;
-            } else {
-                stream.inner.try_send_to(&datagram.data, addr)?;
-            }
-
-            Ok(())
-        }
-
         let stream = self.table.get_mut(&this)?;
 
         if datagrams.is_empty() {
@@ -342,23 +272,22 @@ impl udp::HostOutgoingDatagramStream for WasiSocketsCtxView<'_> {
             )));
         }
 
-        stream.check_send_permit_count -= datagrams.len();
+        // Reset permit. From the WIT spec:
+        // > Each call to `send` must be permitted by a preceding `check-send`.
+        stream.check_send_permit_count = 0;
 
         let mut count = 0;
 
         for datagram in datagrams {
-            match send_one(stream, &datagram).await {
-                Ok(_) => count += 1,
+            match stream.try_send(datagram.data, datagram.remote_address.map(SocketAddr::from)) {
+                Err(ErrorCode::WouldBlock) => break,
+                Ok(()) => count += 1,
                 Err(_) if count > 0 => {
                     // WIT: "If at least one datagram has been sent successfully, this function never returns an error."
-                    return Ok(count);
-                }
-                Err(e) if matches!(e.downcast_ref(), Some(ErrorCode::WouldBlock)) => {
-                    debug_assert!(count == 0);
-                    return Ok(0);
+                    break;
                 }
                 Err(e) => {
-                    return Err(e);
+                    return Err(e.into());
                 }
             }
         }
@@ -373,12 +302,17 @@ impl udp::HostOutgoingDatagramStream for WasiSocketsCtxView<'_> {
         wasmtime_wasi_io::poll::subscribe(self.table, this)
     }
 
-    fn drop(&mut self, this: Resource<udp::OutgoingDatagramStream>) -> Result<(), wasmtime::Error> {
-        // As in the filesystem implementation, we assume closing a socket
-        // doesn't block.
-        let dropped = self.table.delete(this)?;
-        drop(dropped);
-
+    async fn drop(
+        &mut self,
+        this: Resource<udp::OutgoingDatagramStream>,
+    ) -> Result<(), wasmtime::Error> {
+        let mut stream = self.table.delete(this)?;
+        // Prevent silently dropping already-acknowledged sends by waiting for
+        // any in-progress background send to complete. This may block
+        // the guest, but that's the price we pay for implementing the
+        // readiness-based P2 API in terms of the completion-based P3 API.
+        std::future::poll_fn(|cx| stream.poll_send_ready(cx)).await;
+        drop(stream);
         Ok(())
     }
 }
@@ -386,10 +320,7 @@ impl udp::HostOutgoingDatagramStream for WasiSocketsCtxView<'_> {
 #[async_trait]
 impl Pollable for OutgoingDatagramStream {
     async fn ready(&mut self) {
-        self.inner
-            .ready(Interest::WRITABLE.add(Interest::ERROR))
-            .await
-            .expect("failed to await UDP socket readiness");
+        poll_fn(|cx| self.poll_send_ready(cx)).await
     }
 }
 
@@ -406,7 +337,7 @@ pub mod sync {
     use wasmtime::component::Resource;
 
     use crate::p2::{
-        SocketError,
+        SocketError, UdpSocket,
         bindings::{
             sockets::{
                 network::Network,
@@ -421,7 +352,6 @@ pub mod sync {
             sync::sockets::udp::{
                 self, HostIncomingDatagramStream, HostOutgoingDatagramStream, HostUdpSocket,
                 IncomingDatagram, IpAddressFamily, IpSocketAddress, OutgoingDatagram, Pollable,
-                UdpSocket,
             },
         },
     };
@@ -582,7 +512,7 @@ pub mod sync {
             datagrams: Vec<OutgoingDatagram>,
         ) -> Result<u64, SocketError> {
             let datagrams = datagrams.into_iter().map(Into::into).collect();
-            in_tokio(async { AsyncHostOutgoingDatagramStream::send(self, self_, datagrams).await })
+            AsyncHostOutgoingDatagramStream::send(self, self_, datagrams)
         }
 
         fn subscribe(
@@ -593,7 +523,7 @@ pub mod sync {
         }
 
         fn drop(&mut self, rep: Resource<OutgoingDatagramStream>) -> wasmtime::Result<()> {
-            AsyncHostOutgoingDatagramStream::drop(self, rep)
+            in_tokio(async { AsyncHostOutgoingDatagramStream::drop(self, rep).await })
         }
     }
 

--- a/crates/wasi/src/p2/host/udp_create_socket.rs
+++ b/crates/wasi/src/p2/host/udp_create_socket.rs
@@ -1,16 +1,37 @@
-use crate::p2::SocketResult;
 use crate::p2::bindings::{sockets::network::IpAddressFamily, sockets::udp_create_socket};
-use crate::sockets::UdpSocket;
+use crate::p2::{SocketResult, UdpSocket};
+use crate::sockets::UdpSocket as P3Socket;
 use crate::sockets::WasiSocketsCtxView;
 use wasmtime::component::Resource;
 
 impl udp_create_socket::Host for WasiSocketsCtxView<'_> {
-    fn create_udp_socket(
+    async fn create_udp_socket(
         &mut self,
         address_family: IpAddressFamily,
     ) -> SocketResult<Resource<UdpSocket>> {
-        let socket = UdpSocket::new(self.ctx, address_family.into())?;
-        let socket = self.table.push(socket)?;
+        let inner = P3Socket::new(self.ctx, address_family.into()).await?;
+        let socket = self.table.push(UdpSocket::new(inner))?;
         Ok(socket)
+    }
+}
+
+pub mod sync {
+    use wasmtime::component::Resource;
+
+    use crate::p2::{
+        SocketResult, UdpSocket,
+        bindings::sockets::udp_create_socket::Host as AsyncHost,
+        bindings::sync::sockets::{udp::IpAddressFamily, udp_create_socket},
+    };
+    use crate::runtime::in_tokio;
+    use crate::sockets::WasiSocketsCtxView;
+
+    impl udp_create_socket::Host for WasiSocketsCtxView<'_> {
+        fn create_udp_socket(
+            &mut self,
+            address_family: IpAddressFamily,
+        ) -> SocketResult<Resource<UdpSocket>> {
+            in_tokio(async { AsyncHost::create_udp_socket(self, address_family).await })
+        }
     }
 }

--- a/crates/wasi/src/p2/ip_name_lookup.rs
+++ b/crates/wasi/src/p2/ip_name_lookup.rs
@@ -24,11 +24,14 @@ impl Host for WasiSocketsCtxView<'_> {
         network: Resource<Network>,
         name: String,
     ) -> Result<Resource<ResolveAddressStream>, SocketError> {
-        let network = self.table.get(&network)?;
+        // The network resource itself represents the capability to use this
+        // method, so we need to check its validity. Other than that, we have no
+        // use for it.
+        _ = self.table.get(&network)?;
 
         let host = parse_host(&name)?;
 
-        if !network.allow_ip_name_lookup {
+        if !self.ctx.allowed_network_uses.ip_name_lookup {
             return Err(ErrorCode::PermanentResolverFailure.into());
         }
 

--- a/crates/wasi/src/p2/mod.rs
+++ b/crates/wasi/src/p2/mod.rs
@@ -248,7 +248,8 @@ mod write_stream;
 pub use self::filesystem::{FsError, FsResult, ReaddirIterator};
 pub use self::network::{Network, SocketError, SocketResult};
 pub use self::stdio::IsATTY;
-pub(crate) use tcp::P2TcpStreamingState;
+pub use tcp::TcpSocket;
+pub use udp::UdpSocket;
 // These contents of wasmtime-wasi-io are re-exported by this module for compatibility:
 // they were originally defined in this module before being factored out, and many
 // users of this module depend on them at these names.
@@ -327,6 +328,7 @@ pub fn add_to_linker_with_options_async<T: WasiView>(
     bindings::filesystem::types::add_to_linker::<T, WasiFilesystem>(l, T::filesystem)?;
     bindings::sockets::tcp::add_to_linker::<T, WasiSockets>(l, T::sockets)?;
     bindings::sockets::udp::add_to_linker::<T, WasiSockets>(l, T::sockets)?;
+    bindings::sockets::udp_create_socket::add_to_linker::<T, WasiSockets>(l, T::sockets)?;
     Ok(())
 }
 
@@ -358,7 +360,6 @@ where
     cli::terminal_stdout::add_to_linker::<T, WasiCli>(l, T::cli)?;
     cli::terminal_stderr::add_to_linker::<T, WasiCli>(l, T::cli)?;
     sockets::tcp_create_socket::add_to_linker::<T, WasiSockets>(l, T::sockets)?;
-    sockets::udp_create_socket::add_to_linker::<T, WasiSockets>(l, T::sockets)?;
     sockets::instance_network::add_to_linker::<T, WasiSockets>(l, T::sockets)?;
     sockets::network::add_to_linker::<T, WasiSockets>(l, &options.into(), T::sockets)?;
     sockets::ip_name_lookup::add_to_linker::<T, WasiSockets>(l, T::sockets)?;
@@ -467,6 +468,7 @@ pub fn add_to_linker_with_options_sync<T: WasiView>(
     bindings::sync::filesystem::types::add_to_linker::<T, WasiFilesystem>(l, T::filesystem)?;
     bindings::sync::sockets::tcp::add_to_linker::<T, WasiSockets>(l, T::sockets)?;
     bindings::sync::sockets::udp::add_to_linker::<T, WasiSockets>(l, T::sockets)?;
+    bindings::sync::sockets::udp_create_socket::add_to_linker::<T, WasiSockets>(l, T::sockets)?;
     Ok(())
 }
 

--- a/crates/wasi/src/p2/network.rs
+++ b/crates/wasi/src/p2/network.rs
@@ -1,7 +1,6 @@
 use crate::TrappableError;
 use crate::p2::bindings::sockets::network::ErrorCode;
-use crate::sockets::{SocketAddrCheck, SocketAddrUse};
-use std::net::SocketAddr;
+use crate::p2::bindings::sockets::tcp::ShutdownType;
 
 pub type SocketResult<T> = Result<T, SocketError>;
 
@@ -34,7 +33,7 @@ impl From<crate::sockets::util::ErrorCode> for SocketError {
 impl From<crate::sockets::util::ErrorCode> for ErrorCode {
     fn from(error: crate::sockets::util::ErrorCode) -> Self {
         match error {
-            crate::sockets::util::ErrorCode::Unknown => Self::Unknown,
+            crate::sockets::util::ErrorCode::Other => Self::Unknown,
             crate::sockets::util::ErrorCode::AccessDenied => Self::AccessDenied,
             crate::sockets::util::ErrorCode::NotSupported => Self::NotSupported,
             crate::sockets::util::ErrorCode::InvalidArgument => Self::InvalidArgument,
@@ -45,26 +44,31 @@ impl From<crate::sockets::util::ErrorCode> for ErrorCode {
             crate::sockets::util::ErrorCode::AddressInUse => Self::AddressInUse,
             crate::sockets::util::ErrorCode::RemoteUnreachable => Self::RemoteUnreachable,
             crate::sockets::util::ErrorCode::ConnectionRefused => Self::ConnectionRefused,
+            crate::sockets::util::ErrorCode::ConnectionBroken => Self::Unknown,
             crate::sockets::util::ErrorCode::ConnectionReset => Self::ConnectionReset,
             crate::sockets::util::ErrorCode::ConnectionAborted => Self::ConnectionAborted,
             crate::sockets::util::ErrorCode::DatagramTooLarge => Self::DatagramTooLarge,
-            crate::sockets::util::ErrorCode::NotInProgress => Self::NotInProgress,
-            crate::sockets::util::ErrorCode::ConcurrencyConflict => Self::ConcurrencyConflict,
         }
     }
 }
 
-pub struct Network {
-    pub(crate) socket_addr_check: SocketAddrCheck,
-    pub(crate) allow_ip_name_lookup: bool,
+impl From<ShutdownType> for std::net::Shutdown {
+    fn from(value: ShutdownType) -> Self {
+        match value {
+            ShutdownType::Receive => Self::Read,
+            ShutdownType::Send => Self::Write,
+            ShutdownType::Both => Self::Both,
+        }
+    }
 }
 
-impl Network {
-    pub async fn check_socket_addr(
-        &self,
-        addr: SocketAddr,
-        reason: SocketAddrUse,
-    ) -> std::io::Result<()> {
-        self.socket_addr_check.check(addr, reason).await
-    }
+/// A network resource representing the capability to use the networking
+/// APIs in WASI 0.2. The concept of network handles has been removed in
+/// WASI 0.3.
+///
+/// Note that in Wasmtime all permissions are checked through the `WasiCtx` and
+/// not through the `Network` resource itself. The `Network` resource is just a
+/// placeholder capability handle.
+pub struct Network {
+    pub(crate) _priv: (),
 }

--- a/crates/wasi/src/p2/tcp.rs
+++ b/crates/wasi/src/p2/tcp.rs
@@ -1,85 +1,93 @@
+use crate::MAX_READ_SIZE_ALLOC;
+use crate::p2::bindings::sockets::network::ErrorCode;
 use crate::p2::{
-    DynInputStream, DynOutputStream, InputStream, OutputStream, Pollable, SocketError,
-    SocketResult, StreamError,
+    DynInputStream, DynOutputStream, InputStream, OutputStream, Pollable, SocketResult, StreamError,
 };
-use crate::runtime::AbortOnDropJoinHandle;
-use crate::sockets::TcpSocket;
-use rustix::io::Errno;
-use std::io;
+use crate::sockets::{
+    MaybeReady, TcpListenStream, TcpReceiveStream, TcpSendStream, TcpSocket as P3Socket, noop_cx,
+};
+use std::future::poll_fn;
 use std::mem;
 use std::net::Shutdown;
 use std::sync::Arc;
-use tokio::sync::Mutex;
+use std::sync::Mutex;
+use std::task::{Poll, ready};
 use wasmtime::Result;
+use wasmtime_wasi_io::streams::StreamResult;
+
+/// A TCP socket + associated p2 bookkeeping.
+pub struct TcpSocket {
+    pub(crate) inner: P3Socket,
+    pub(crate) in_progress_operation: Option<AsyncOperation>,
+    pub(crate) listener: Option<TcpListenStream>,
+    reader: Option<TcpReader>,
+    writer: Option<TcpWriter>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum AsyncOperation {
+    Bind,
+    Connect,
+    Listen,
+}
 
 impl TcpSocket {
-    pub(crate) fn p2_streams(&mut self) -> SocketResult<(DynInputStream, DynOutputStream)> {
-        let reader = Arc::new(Mutex::new(TcpReader::new(self.take_receive_stream()?)));
-        let writer = Arc::new(Mutex::new(TcpWriter::new(self.take_send_stream()?)));
-        self.set_p2_streaming_state(P2TcpStreamingState {
-            reader: reader.clone(),
-            writer: writer.clone(),
-        })?;
-        let input: DynInputStream = Box::new(TcpReadStream(reader));
-        let output: DynOutputStream = Box::new(TcpWriteStream(writer));
+    pub(crate) fn new(inner: P3Socket) -> Self {
+        Self {
+            inner,
+            in_progress_operation: None,
+            listener: None,
+            reader: None,
+            writer: None,
+        }
+    }
+    pub(crate) fn take_streams(&mut self) -> SocketResult<(DynInputStream, DynOutputStream)> {
+        let reader = TcpReader::new(self.inner.take_receive_stream()?);
+        let writer = TcpWriter::new(self.inner.take_send_stream()?);
+        self.reader = Some(reader.clone());
+        self.writer = Some(writer.clone());
+        let input: DynInputStream = Box::new(reader);
+        let output: DynOutputStream = Box::new(writer);
         Ok((input, output))
     }
-}
+    pub(crate) fn shutdown(&mut self, how: Shutdown) -> SocketResult<()> {
+        let reader = self.reader.as_mut().ok_or(ErrorCode::InvalidState)?;
+        let writer = self.writer.as_mut().ok_or(ErrorCode::InvalidState)?;
 
-pub(crate) struct P2TcpStreamingState {
-    reader: Arc<Mutex<TcpReader>>,
-    writer: Arc<Mutex<TcpWriter>>,
-}
-
-impl P2TcpStreamingState {
-    pub(crate) fn shutdown(&self, how: Shutdown) -> SocketResult<()> {
         if let Shutdown::Both | Shutdown::Read = how {
-            try_lock_for_socket(&self.reader)?.shutdown();
+            reader.0.lock().unwrap().shutdown();
         }
 
         if let Shutdown::Both | Shutdown::Write = how {
-            try_lock_for_socket(&self.writer)?.shutdown();
+            writer.0.lock().unwrap().shutdown();
         }
 
         Ok(())
     }
 }
 
-struct TcpReader {
-    stream: Arc<tokio::net::TcpStream>,
-    closed: bool,
+enum ReadState {
+    Open(TcpReceiveStream),
+    Closed,
 }
-
-impl TcpReader {
-    fn new(stream: Arc<tokio::net::TcpStream>) -> Self {
-        Self {
-            stream,
-            closed: false,
-        }
-    }
-    fn read(&mut self, size: usize) -> Result<bytes::Bytes, StreamError> {
-        if self.closed {
+impl ReadState {
+    fn read(&mut self, size: usize) -> StreamResult<bytes::Bytes> {
+        let Self::Open(stream) = self else {
             return Err(StreamError::Closed);
-        }
+        };
         if size == 0 {
             return Ok(bytes::Bytes::new());
         }
-
-        let mut buf = bytes::BytesMut::with_capacity(size.min(crate::MAX_READ_SIZE_ALLOC));
-        let n = match self.stream.try_read_buf(&mut buf) {
-            // A 0-byte read indicates that the stream has closed.
-            Ok(0) => {
-                self.closed = true;
+        let mut buf = bytes::BytesMut::zeroed(size.min(crate::MAX_READ_SIZE_ALLOC));
+        let n = match stream.poll_read(&mut noop_cx(), &mut buf) {
+            Poll::Pending => 0,
+            Poll::Ready(Ok(0)) => {
+                *self = ReadState::Closed;
                 return Err(StreamError::Closed);
             }
-            Ok(n) => n,
-
-            // Failing with `EWOULDBLOCK` is how we differentiate between a closed channel and no
-            // data to read right now.
-            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => 0,
-
-            Err(e) => {
-                self.closed = true;
+            Poll::Ready(Ok(n)) => n,
+            Poll::Ready(Err(e)) => {
+                *self = ReadState::Closed;
                 return Err(StreamError::LastOperationFailed(e.into()));
             }
         };
@@ -89,188 +97,145 @@ impl TcpReader {
     }
 
     fn shutdown(&mut self) {
-        native_shutdown(&self.stream, Shutdown::Read);
-        self.closed = true;
+        *self = ReadState::Closed;
     }
 
-    async fn ready(&mut self) {
-        if self.closed {
-            return;
+    fn poll_ready(&mut self, cx: &mut std::task::Context<'_>) -> Poll<()> {
+        match self {
+            Self::Open(stream) => stream.poll_ready(cx),
+            Self::Closed => Poll::Ready(()),
         }
-
-        self.stream.readable().await.unwrap();
     }
 }
 
-struct TcpReadStream(Arc<Mutex<TcpReader>>);
-
-#[async_trait::async_trait]
-impl InputStream for TcpReadStream {
-    fn read(&mut self, size: usize) -> Result<bytes::Bytes, StreamError> {
-        try_lock_for_stream(&self.0)?.read(size)
+#[derive(Clone)]
+struct TcpReader(Arc<Mutex<ReadState>>);
+impl TcpReader {
+    fn new(stream: TcpReceiveStream) -> Self {
+        Self(Arc::new(Mutex::new(ReadState::Open(stream))))
     }
 }
 
 #[async_trait::async_trait]
-impl Pollable for TcpReadStream {
+impl InputStream for TcpReader {
+    fn read(&mut self, size: usize) -> StreamResult<bytes::Bytes> {
+        self.0.lock().unwrap().read(size)
+    }
+}
+
+#[async_trait::async_trait]
+impl Pollable for TcpReader {
     async fn ready(&mut self) {
-        self.0.lock().await.ready().await
+        std::future::poll_fn(|cx| self.0.lock().unwrap().poll_ready(cx)).await
     }
 }
 
-const SOCKET_READY_SIZE: usize = 1024 * 1024 * 1024;
-
-struct TcpWriter {
-    stream: Arc<tokio::net::TcpStream>,
-    state: WriteState,
+/// A cloneable subset of StreamError
+#[derive(Debug, Clone)]
+enum WriteError {
+    Closed,
+    LastOperationFailed(ErrorCode),
+}
+impl From<WriteError> for StreamError {
+    fn from(err: WriteError) -> Self {
+        match err {
+            WriteError::Closed => StreamError::Closed,
+            WriteError::LastOperationFailed(e) => StreamError::LastOperationFailed(e.into()),
+        }
+    }
 }
 
 enum WriteState {
-    Ready,
-    Writing(AbortOnDropJoinHandle<io::Result<()>>),
-    Closing(AbortOnDropJoinHandle<io::Result<()>>),
-    Closed,
-    Error(io::Error),
+    Ready(TcpSendStream, usize),
+    Writing(MaybeReady<Result<TcpSendStream, WriteError>>),
+    Closing(MaybeReady<Result<(), WriteError>>),
+    Closed(WriteError),
 }
 
-impl TcpWriter {
-    fn new(stream: Arc<tokio::net::TcpStream>) -> Self {
-        Self {
-            stream,
-            state: WriteState::Ready,
+impl WriteState {
+    fn take(&mut self) -> WriteState {
+        mem::replace(self, WriteState::Closed(WriteError::Closed))
+    }
+
+    fn check_write(&mut self) -> StreamResult<usize> {
+        match self.poll_ready(&mut noop_cx()) {
+            Poll::Pending => Ok(0),
+            Poll::Ready(Ok((_, permit))) => {
+                *permit = MAX_READ_SIZE_ALLOC;
+                Ok(*permit)
+            }
+            Poll::Ready(Err(e)) => Err(e),
         }
     }
 
-    fn try_write_portable(stream: &tokio::net::TcpStream, buf: &[u8]) -> io::Result<usize> {
-        stream.try_write(buf).map_err(|error| {
-            match Errno::from_io_error(&error) {
-                // Windows returns `WSAESHUTDOWN` when writing to a shut down socket.
-                // We normalize this to EPIPE, because that is what the other platforms return.
-                // See: https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-send#:~:text=WSAESHUTDOWN
-                #[cfg(windows)]
-                Some(Errno::SHUTDOWN) => io::Error::new(io::ErrorKind::BrokenPipe, error),
-
-                _ => error,
-            }
-        })
-    }
-
-    /// Write `bytes` in a background task, remembering the task handle for use in a future call to
-    /// `write_ready`
-    fn background_write(&mut self, mut bytes: bytes::Bytes) {
-        assert!(matches!(self.state, WriteState::Ready));
-
-        let stream = self.stream.clone();
-        self.state = WriteState::Writing(crate::runtime::spawn(async move {
-            // Note: we are not using the AsyncWrite impl here, and instead using the TcpStream
-            // primitive try_write, which goes directly to attempt a write with mio. This has
-            // two advantages: 1. this operation takes a &TcpStream instead of a &mut TcpStream
-            // required to AsyncWrite, and 2. it eliminates any buffering in tokio we may need
-            // to flush.
-            while !bytes.is_empty() {
-                stream.writable().await?;
-                match Self::try_write_portable(&stream, &bytes) {
-                    Ok(n) => {
-                        let _ = bytes.split_to(n);
-                    }
-                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => continue,
-                    Err(e) => return Err(e),
-                }
-            }
-
-            Ok(())
-        }));
-    }
-
-    fn write(&mut self, mut bytes: bytes::Bytes) -> Result<(), StreamError> {
-        match self.state {
-            WriteState::Ready => {}
-            WriteState::Closed => return Err(StreamError::Closed),
-            WriteState::Writing(_) | WriteState::Closing(_) | WriteState::Error(_) => {
-                return Err(StreamError::Trap(wasmtime::format_err!(
-                    "unpermitted: must call check_write first"
-                )));
-            }
-        }
-        while !bytes.is_empty() {
-            match Self::try_write_portable(&self.stream, &bytes) {
-                Ok(n) => {
-                    let _ = bytes.split_to(n);
-                }
-
-                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                    // As `try_write` indicated that it would have blocked, we'll perform the write
-                    // in the background to allow us to return immediately.
-                    self.background_write(bytes);
-
+    fn write(&mut self, mut bytes: bytes::Bytes) -> StreamResult<()> {
+        let mut stream = match self {
+            WriteState::Ready(_, permit) if bytes.len() <= *permit => {
+                if bytes.is_empty() {
                     return Ok(());
                 }
 
-                Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => {
-                    self.state = WriteState::Closed;
-                    return Err(StreamError::Closed);
+                let WriteState::Ready(stream, _) = self.take() else {
+                    unreachable!()
+                };
+                stream
+            }
+            WriteState::Closed(e) => {
+                return Err(e.clone().into());
+            }
+            _ => {
+                return Err(StreamError::Trap(wasmtime::format_err!(
+                    "not permitted to write {} bytes",
+                    bytes.len()
+                )));
+            }
+        };
+
+        *self = WriteState::Writing(MaybeReady::poll_or_spawn(async move {
+            while !bytes.is_empty() {
+                match stream.write(&bytes).await {
+                    Ok(n) => {
+                        let _ = bytes.split_to(n);
+                    }
+                    Err(crate::sockets::util::ErrorCode::ConnectionBroken) => {
+                        return Err(WriteError::Closed);
+                    }
+                    Err(e) => {
+                        return Err(WriteError::LastOperationFailed(e.into()));
+                    }
                 }
-
-                Err(e) => return Err(StreamError::LastOperationFailed(e.into())),
             }
-        }
 
-        Ok(())
-    }
+            Ok(stream)
+        }));
 
-    fn flush(&mut self) -> Result<(), StreamError> {
-        // `flush` is a no-op here, as we're not managing any internal buffer. Additionally,
-        // `write_ready` will join the background write task if it's active, so following `flush`
-        // with `write_ready` will have the desired effect.
-        match self.state {
-            WriteState::Ready
-            | WriteState::Writing(_)
-            | WriteState::Closing(_)
-            | WriteState::Error(_) => Ok(()),
-            WriteState::Closed => Err(StreamError::Closed),
+        // Attempt to finish the write, surfacing potential errors immediately:
+        match self.poll_ready(&mut noop_cx()) {
+            Poll::Pending | Poll::Ready(Ok(_)) => Ok(()),
+            Poll::Ready(Err(e)) => Err(e),
         }
     }
 
-    fn check_write(&mut self) -> Result<usize, StreamError> {
-        match mem::replace(&mut self.state, WriteState::Closed) {
-            WriteState::Writing(task) => {
-                self.state = WriteState::Writing(task);
-                return Ok(0);
-            }
-            WriteState::Closing(task) => {
-                self.state = WriteState::Closing(task);
-                return Ok(0);
-            }
-            WriteState::Ready => {
-                self.state = WriteState::Ready;
-            }
-            WriteState::Closed => return Err(StreamError::Closed),
-            WriteState::Error(e) => return Err(StreamError::LastOperationFailed(e.into())),
+    fn flush(&mut self) -> StreamResult<()> {
+        // `flush` is a no-op here. Writes happen on background tasks and will
+        // always be delivered to the OS as soon as possible. There's nothing
+        // for `flush` to do here that will speed up that process.
+        match self {
+            WriteState::Ready(..) | WriteState::Writing(_) | WriteState::Closing(_) => Ok(()),
+            WriteState::Closed(e) => Err(e.clone().into()),
         }
-
-        let writable = self.stream.writable();
-        futures::pin_mut!(writable);
-        if crate::runtime::poll_noop(writable).is_none() {
-            return Ok(0);
-        }
-        Ok(SOCKET_READY_SIZE)
     }
 
-    fn shutdown(&mut self) {
-        self.state = match mem::replace(&mut self.state, WriteState::Closed) {
-            // No write in progress, immediately shut down:
-            WriteState::Ready => {
-                native_shutdown(&self.stream, Shutdown::Write);
-                WriteState::Closed
-            }
+    pub(crate) fn shutdown(&mut self) {
+        *self = match self.take() {
+            // No write in progress, immediately drop the inner stream:
+            WriteState::Ready(..) => WriteState::Closed(WriteError::Closed),
 
             // Schedule the shutdown after the current write has finished:
             WriteState::Writing(write) => {
-                let stream = self.stream.clone();
-                WriteState::Closing(crate::runtime::spawn(async move {
-                    let result = write.await;
-                    native_shutdown(&stream, Shutdown::Write);
-                    result
+                WriteState::Closing(MaybeReady::poll_or_spawn(async move {
+                    _ = write.into_future().await?;
+                    Ok(())
                 }))
             }
 
@@ -278,78 +243,77 @@ impl TcpWriter {
         };
     }
 
-    async fn cancel(&mut self) {
-        match mem::replace(&mut self.state, WriteState::Closed) {
-            WriteState::Writing(task) | WriteState::Closing(task) => _ = task.cancel().await,
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<StreamResult<(&mut TcpSendStream, &mut usize)>> {
+        match self {
+            WriteState::Writing(write) => {
+                ready!(write.poll_ready(cx));
+                let WriteState::Writing(write) = self.take() else {
+                    unreachable!()
+                };
+                *self = match write.unwrap_ready() {
+                    Ok(stream) => WriteState::Ready(stream, 0),
+                    Err(err) => WriteState::Closed(err),
+                };
+            }
+            WriteState::Closing(close) => {
+                ready!(close.poll_ready(cx));
+                let WriteState::Closing(close) = self.take() else {
+                    unreachable!()
+                };
+                *self = match close.unwrap_ready() {
+                    Ok(()) => WriteState::Closed(WriteError::Closed),
+                    Err(err) => WriteState::Closed(err),
+                };
+            }
             _ => {}
         }
-    }
 
-    async fn ready(&mut self) {
-        match &mut self.state {
-            WriteState::Writing(task) => {
-                self.state = match task.await {
-                    Ok(()) => WriteState::Ready,
-                    Err(e) => WriteState::Error(e),
-                }
-            }
-            WriteState::Closing(task) => {
-                self.state = match task.await {
-                    Ok(()) => WriteState::Closed,
-                    Err(e) => WriteState::Error(e),
-                }
-            }
-            _ => {}
-        }
-
-        if let WriteState::Ready = self.state {
-            self.stream.writable().await.unwrap();
+        match self {
+            WriteState::Ready(stream, permit) => match stream.poll_ready(cx) {
+                Poll::Ready(()) => Poll::Ready(Ok((stream, permit))),
+                Poll::Pending => Poll::Pending,
+            },
+            WriteState::Writing(..) | WriteState::Closing(..) => Poll::Pending,
+            WriteState::Closed(e) => Poll::Ready(Err(e.clone().into())),
         }
     }
 }
 
-struct TcpWriteStream(Arc<Mutex<TcpWriter>>);
-
-#[async_trait::async_trait]
-impl OutputStream for TcpWriteStream {
-    fn write(&mut self, bytes: bytes::Bytes) -> Result<(), StreamError> {
-        try_lock_for_stream(&self.0)?.write(bytes)
-    }
-
-    fn flush(&mut self) -> Result<(), StreamError> {
-        try_lock_for_stream(&self.0)?.flush()
-    }
-
-    fn check_write(&mut self) -> Result<usize, StreamError> {
-        try_lock_for_stream(&self.0)?.check_write()
-    }
-
-    async fn cancel(&mut self) {
-        self.0.lock().await.cancel().await
+#[derive(Clone)]
+struct TcpWriter(Arc<Mutex<WriteState>>);
+impl TcpWriter {
+    fn new(stream: TcpSendStream) -> Self {
+        Self(Arc::new(Mutex::new(WriteState::Ready(stream, 0))))
     }
 }
 
 #[async_trait::async_trait]
-impl Pollable for TcpWriteStream {
-    async fn ready(&mut self) {
-        self.0.lock().await.ready().await
+impl OutputStream for TcpWriter {
+    fn write(&mut self, bytes: bytes::Bytes) -> StreamResult<()> {
+        self.0.lock().unwrap().write(bytes)
+    }
+
+    fn flush(&mut self) -> StreamResult<()> {
+        self.0.lock().unwrap().flush()
+    }
+
+    fn check_write(&mut self) -> StreamResult<usize> {
+        self.0.lock().unwrap().check_write()
+    }
+
+    async fn cancel(&mut self) {
+        // Wait for background writes to finish in order to prevent silently
+        // dropping data that (from the guest's perspective) was already written.
+        self.ready().await
     }
 }
 
-fn native_shutdown(stream: &tokio::net::TcpStream, how: Shutdown) {
-    _ = crate::sockets::util::shutdown(stream, how);
-}
-
-fn try_lock_for_stream<T>(mutex: &Mutex<T>) -> Result<tokio::sync::MutexGuard<'_, T>, StreamError> {
-    mutex
-        .try_lock()
-        .map_err(|_| StreamError::trap("concurrent access to resource not supported"))
-}
-
-fn try_lock_for_socket<T>(mutex: &Mutex<T>) -> SocketResult<tokio::sync::MutexGuard<'_, T>> {
-    mutex.try_lock().map_err(|_| {
-        SocketError::trap(wasmtime::format_err!(
-            "concurrent access to resource not supported"
-        ))
-    })
+#[async_trait::async_trait]
+impl Pollable for TcpWriter {
+    async fn ready(&mut self) {
+        poll_fn(|cx| self.0.lock().unwrap().poll_ready(cx).map(|_| ())).await;
+    }
 }

--- a/crates/wasi/src/p2/udp.rs
+++ b/crates/wasi/src/p2/udp.rs
@@ -1,27 +1,153 @@
-use crate::sockets::{SocketAddrCheck, SocketAddressFamily};
-use std::net::SocketAddr;
-use std::sync::Arc;
+use futures::TryFutureExt;
+
+use crate::{
+    p2::bindings::sockets::network::ErrorCode,
+    sockets::{MaybeReady, UdpSocket as P3Socket, noop_cx},
+};
+use std::{
+    net::SocketAddr,
+    sync::{Arc, Mutex},
+};
+
+/// A UDP socket + associated p2 bookkeeping.
+pub struct UdpSocket {
+    pub(crate) inner: Arc<Mutex<P3Socket>>,
+    pub(crate) in_progress_operation: Option<AsyncOperation>,
+}
+impl UdpSocket {
+    pub(crate) fn new(inner: P3Socket) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(inner)),
+            in_progress_operation: None,
+        }
+    }
+    pub(crate) fn get_mut(&mut self) -> Option<&mut P3Socket> {
+        Arc::get_mut(&mut self.inner)?.get_mut().ok()
+    }
+    pub(crate) fn lock(&self) -> std::sync::MutexGuard<'_, P3Socket> {
+        self.inner.lock().expect("other thread panicked")
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum AsyncOperation {
+    Bind,
+}
 
 pub struct IncomingDatagramStream {
-    pub(crate) inner: Arc<tokio::net::UdpSocket>,
+    pub(crate) inner: Arc<Mutex<P3Socket>>,
+    pub(crate) connected_addr: Option<SocketAddr>,
+    pub(crate) current_recv: Option<MaybeReady<Result<(Vec<u8>, SocketAddr), ErrorCode>>>,
+}
+impl IncomingDatagramStream {
+    pub(crate) fn new(inner: Arc<Mutex<P3Socket>>) -> Self {
+        let connected_addr = inner.lock().unwrap().remote_address().ok();
+        Self {
+            inner,
+            connected_addr,
+            current_recv: None,
+        }
+    }
+    pub(crate) fn poll_recv_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<()> {
+        if self.current_recv.is_none() {
+            let connected_addr = self.connected_addr;
+            let inner = self.inner.clone();
+            let recv = MaybeReady::poll_or_spawn(async move {
+                loop {
+                    let fut = inner.lock().unwrap().recv();
+                    let (data, addr) = fut.await?;
 
-    /// If this has a value, the stream is "connected".
-    pub(crate) remote_address: Option<SocketAddr>,
+                    // Only process the packet if it matches the expected remote
+                    // address (if connected). Under normal circumstances, the
+                    // OS should already do this filtering for us. However,
+                    // nothing in POSIX guarantees this behavior, especially
+                    // after (re)connecting a socket with already queued packets
+                    // from a different peer. Case in point: on Linux the
+                    // filtering happens when the packet is received from the
+                    // network, *not* when the packet is delivered to the
+                    // application as part of `recvfrom`.
+                    if let Some(connected_addr) = connected_addr
+                        && connected_addr != addr
+                    {
+                        continue;
+                    }
+
+                    return Ok((data, addr));
+                }
+            });
+            self.current_recv = Some(recv);
+        }
+
+        self.current_recv.as_mut().unwrap().poll_ready(cx)
+    }
+
+    pub(crate) fn try_recv(&mut self) -> Result<(Vec<u8>, SocketAddr), ErrorCode> {
+        let noop_cx = &mut noop_cx();
+        if self.poll_recv_ready(noop_cx).is_pending() {
+            return Err(ErrorCode::WouldBlock);
+        }
+
+        self.current_recv.take().unwrap().unwrap_ready()
+    }
 }
 
 pub struct OutgoingDatagramStream {
-    pub(crate) inner: Arc<tokio::net::UdpSocket>,
-
-    /// If this has a value, the stream is "connected".
-    pub(crate) remote_address: Option<SocketAddr>,
-
-    /// Socket address family.
-    pub(crate) family: SocketAddressFamily,
-
-    /// The check of allowed addresses
-    pub(crate) socket_addr_check: Option<SocketAddrCheck>,
-
-    /// Remaining number of datagrams permitted by most recent `check-send`
-    /// call.
+    pub(crate) inner: Arc<Mutex<P3Socket>>,
+    /// Number of datagrams permitted by most recent `check-send` call.
     pub(crate) check_send_permit_count: usize,
+    pub(crate) prev_send: Option<MaybeReady<Result<(), ErrorCode>>>,
+}
+impl OutgoingDatagramStream {
+    pub(crate) fn new(inner: Arc<Mutex<P3Socket>>) -> Self {
+        Self {
+            inner,
+            check_send_permit_count: 0,
+            prev_send: None,
+        }
+    }
+    pub(crate) fn poll_send_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<()> {
+        match &mut self.prev_send {
+            Some(send) => send.poll_ready(cx),
+            None => std::task::Poll::Ready(()),
+        }
+    }
+
+    pub(crate) fn try_send(
+        &mut self,
+        data: Vec<u8>,
+        addr: Option<std::net::SocketAddr>,
+    ) -> Result<(), ErrorCode> {
+        if let Some(send) = &mut self.prev_send {
+            if !send.poll_ready(&mut noop_cx()).is_ready() {
+                return Err(ErrorCode::WouldBlock);
+            }
+
+            let result = self.prev_send.take().unwrap().unwrap_ready();
+            if let Err(e) = result {
+                return Err(e);
+            }
+        }
+
+        debug_assert!(self.prev_send.is_none());
+
+        let mut send = MaybeReady::poll_or_spawn(
+            self.inner
+                .lock()
+                .unwrap()
+                .send(data, addr)
+                .map_err(|e| e.into()),
+        );
+        if send.poll_ready(&mut noop_cx()).is_ready() {
+            send.unwrap_ready()
+        } else {
+            self.prev_send = Some(send);
+            Ok(())
+        }
+    }
 }

--- a/crates/wasi/src/p3/bindings.rs
+++ b/crates/wasi/src/p3/bindings.rs
@@ -89,6 +89,7 @@ mod generated {
             "wasi:sockets/types.[method]tcp-socket.listen": async | store | tracing | trappable,
             "wasi:sockets/types.[method]tcp-socket.send": store | tracing | trappable,
             "wasi:sockets/types.[method]tcp-socket.receive": store | tracing | trappable,
+            "wasi:sockets/types.[static]udp-socket.create": async | tracing | trappable,
             "wasi:sockets/types.[method]udp-socket.bind": async | tracing | trappable,
             "wasi:sockets/types.[method]udp-socket.connect": async | tracing | trappable,
             default: tracing | trappable,

--- a/crates/wasi/src/p3/sockets/conv.rs
+++ b/crates/wasi/src/p3/sockets/conv.rs
@@ -207,7 +207,7 @@ impl From<&Errno> for types::ErrorCode {
 impl From<crate::sockets::util::ErrorCode> for types::ErrorCode {
     fn from(code: crate::sockets::util::ErrorCode) -> Self {
         match code {
-            crate::sockets::util::ErrorCode::Unknown => Self::Other(None),
+            crate::sockets::util::ErrorCode::Other => Self::Other(None),
             crate::sockets::util::ErrorCode::AccessDenied => Self::AccessDenied,
             crate::sockets::util::ErrorCode::NotSupported => Self::NotSupported,
             crate::sockets::util::ErrorCode::InvalidArgument => Self::InvalidArgument,
@@ -218,11 +218,10 @@ impl From<crate::sockets::util::ErrorCode> for types::ErrorCode {
             crate::sockets::util::ErrorCode::AddressInUse => Self::AddressInUse,
             crate::sockets::util::ErrorCode::RemoteUnreachable => Self::RemoteUnreachable,
             crate::sockets::util::ErrorCode::ConnectionRefused => Self::ConnectionRefused,
+            crate::sockets::util::ErrorCode::ConnectionBroken => Self::ConnectionBroken,
             crate::sockets::util::ErrorCode::ConnectionReset => Self::ConnectionReset,
             crate::sockets::util::ErrorCode::ConnectionAborted => Self::ConnectionAborted,
             crate::sockets::util::ErrorCode::DatagramTooLarge => Self::DatagramTooLarge,
-            crate::sockets::util::ErrorCode::NotInProgress => Self::InvalidState,
-            crate::sockets::util::ErrorCode::ConcurrencyConflict => Self::InvalidState,
         }
     }
 }

--- a/crates/wasi/src/p3/sockets/host/types/mod.rs
+++ b/crates/wasi/src/p3/sockets/host/types/mod.rs
@@ -1,8 +1,6 @@
 use crate::p3::bindings::sockets::types::{ErrorCode, Host};
-use crate::p3::sockets::{SocketError, WasiSockets};
-use crate::sockets::{SocketAddrCheck, SocketAddrUse, WasiSocketsCtxView};
-use core::net::SocketAddr;
-use wasmtime::component::Accessor;
+use crate::p3::sockets::SocketError;
+use crate::sockets::WasiSocketsCtxView;
 
 mod tcp;
 mod udp;
@@ -11,16 +9,4 @@ impl Host for WasiSocketsCtxView<'_> {
     fn convert_error_code(&mut self, error: SocketError) -> wasmtime::Result<ErrorCode> {
         error.downcast()
     }
-}
-
-fn get_socket_addr_check<T>(store: &Accessor<T, WasiSockets>) -> SocketAddrCheck {
-    store.with(|mut view| view.get().ctx.socket_addr_check.clone())
-}
-
-async fn is_addr_allowed<T>(
-    store: &Accessor<T, WasiSockets>,
-    addr: SocketAddr,
-    reason: SocketAddrUse,
-) -> bool {
-    get_socket_addr_check(store)(addr, reason).await
 }

--- a/crates/wasi/src/p3/sockets/host/types/tcp.rs
+++ b/crates/wasi/src/p3/sockets/host/types/tcp.rs
@@ -1,18 +1,16 @@
-use super::is_addr_allowed;
 use crate::p3::DEFAULT_BUFFER_CAPACITY;
 use crate::p3::bindings::sockets::types::{
     Duration, ErrorCode, HostTcpSocket, HostTcpSocketWithStore, IpAddressFamily, IpSocketAddress,
     TcpSocket,
 };
 use crate::p3::sockets::{SocketError, SocketResult, WasiSockets};
-use crate::sockets::{NonInheritedOptions, SocketAddrUse, SocketAddressFamily, WasiSocketsCtxView};
+use crate::sockets::{TcpListenStream, TcpReceiveStream, TcpSendStream, WasiSocketsCtxView};
 use bytes::BytesMut;
 use core::iter;
 use core::pin::Pin;
 use core::task::{Context, Poll};
-use std::net::{Shutdown, SocketAddr};
-use std::sync::Arc;
-use tokio::net::{TcpListener, TcpStream};
+use std::net::SocketAddr;
+use std::task::ready;
 use tokio::sync::oneshot;
 use wasmtime::component::{
     Access, Accessor, Destination, FutureReader, Resource, ResourceTable, Source, StreamConsumer,
@@ -42,9 +40,7 @@ fn get_socket_mut<'a>(
 }
 
 struct ListenStreamProducer<T> {
-    listener: Arc<TcpListener>,
-    family: SocketAddressFamily,
-    options: NonInheritedOptions,
+    listener: TcpListenStream,
     getter: for<'a> fn(&'a mut T) -> WasiSocketsCtxView<'a>,
 }
 
@@ -56,31 +52,28 @@ where
     type Buffer = Option<Self::Item>;
 
     fn poll_produce<'a>(
-        self: Pin<&mut Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         mut store: StoreContextMut<'a, D>,
         mut dst: Destination<'a, Self::Item, Self::Buffer>,
         finish: bool,
     ) -> Poll<wasmtime::Result<StreamResult>> {
-        // If the destination buffer is empty then this is a request on
-        // behalf of the guest to wait for this socket to be ready to accept
-        // without actually accepting something. The `TcpListener` in Tokio does
-        // not have this capability so we're forced to lie here and say instead
-        // "yes we're ready to accept" as a fallback.
-        //
-        // See WebAssembly/component-model#561 for some more information.
-        if dst.remaining(&mut store) == Some(0) {
-            return Poll::Ready(Ok(StreamResult::Completed));
+        if finish {
+            return Poll::Ready(Ok(StreamResult::Cancelled));
         }
-        let res = match self.listener.poll_accept(cx) {
-            Poll::Ready(res) => res.map(|(stream, _)| stream),
-            Poll::Pending if finish => return Poll::Ready(Ok(StreamResult::Cancelled)),
-            Poll::Pending => return Poll::Pending,
-        };
-        let socket = TcpSocket::new_accept(res, &self.options, self.family)
-            .unwrap_or_else(|err| TcpSocket::new_error(err, self.family));
-        let WasiSocketsCtxView { table, .. } = (self.getter)(store.data_mut());
-        let socket = table
+
+        // If the destination buffer is empty then this is a readiness check.
+        if dst.remaining(&mut store) == Some(0) {
+            return match self.listener.poll_ready(cx) {
+                Poll::Ready(()) => Poll::Ready(Ok(StreamResult::Completed)),
+                Poll::Pending => Poll::Pending,
+            };
+        }
+
+        let socket = ready!(self.listener.poll_accept(cx));
+        let ctx = (self.getter)(store.data_mut());
+        let socket = ctx
+            .table
             .push(socket)
             .context("failed to push socket resource to table")?;
         dst.set_buffer(Some(socket));
@@ -88,10 +81,7 @@ where
     }
 }
 
-struct ReceiveStreamProducer {
-    stream: Arc<TcpStream>,
-    result: Option<oneshot::Sender<Result<(), ErrorCode>>>,
-}
+struct ReceiveStreamProducer(Option<(TcpReceiveStream, oneshot::Sender<Result<(), ErrorCode>>)>);
 
 impl Drop for ReceiveStreamProducer {
     fn drop(&mut self) {
@@ -101,8 +91,7 @@ impl Drop for ReceiveStreamProducer {
 
 impl ReceiveStreamProducer {
     fn close(&mut self, res: Result<(), ErrorCode>) {
-        if let Some(tx) = self.result.take() {
-            _ = crate::sockets::util::shutdown(&self.stream, Shutdown::Read);
+        if let Some((_, tx)) = self.0.take() {
             _ = tx.send(res);
         }
     }
@@ -119,50 +108,41 @@ impl<D> StreamProducer<D> for ReceiveStreamProducer {
         dst: Destination<'a, Self::Item, Self::Buffer>,
         finish: bool,
     ) -> Poll<wasmtime::Result<StreamResult>> {
-        let res = 'result: {
-            // 0-length reads are an indication that we should wait for
-            // readiness here, so use `poll_read_ready`.
-            if dst.remaining(store.as_context_mut()) == Some(0) {
-                return match self.stream.poll_read_ready(cx) {
-                    Poll::Ready(Ok(())) => Poll::Ready(Ok(StreamResult::Completed)),
-                    Poll::Ready(Err(err)) => break 'result Err(err.into()),
-                    Poll::Pending if finish => Poll::Ready(Ok(StreamResult::Cancelled)),
-                    Poll::Pending => Poll::Pending,
-                };
-            }
-
-            let mut dst = dst.as_direct(store, DEFAULT_BUFFER_CAPACITY);
-            let buf = dst.remaining();
-            loop {
-                match self.stream.try_read(buf) {
-                    Ok(0) => break 'result Ok(()),
-                    Ok(n) => {
-                        dst.mark_written(n);
-                        return Poll::Ready(Ok(StreamResult::Completed));
-                    }
-                    Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
-                        match self.stream.poll_read_ready(cx) {
-                            Poll::Ready(Ok(())) => continue,
-                            Poll::Ready(Err(err)) => break 'result Err(err.into()),
-                            Poll::Pending if finish => {
-                                return Poll::Ready(Ok(StreamResult::Cancelled));
-                            }
-                            Poll::Pending => return Poll::Pending,
-                        }
-                    }
-                    Err(err) => break 'result Err(err.into()),
-                }
-            }
+        let Some((stream, _)) = self.0.as_mut() else {
+            return Poll::Ready(Ok(StreamResult::Dropped));
         };
-        self.close(res);
-        Poll::Ready(Ok(StreamResult::Dropped))
+        if finish {
+            return Poll::Ready(Ok(StreamResult::Cancelled));
+        }
+
+        // 0-length read is a readiness check.
+        if dst.remaining(store.as_context_mut()) == Some(0) {
+            return match stream.poll_ready(cx) {
+                Poll::Ready(()) => Poll::Ready(Ok(StreamResult::Completed)),
+                Poll::Pending => Poll::Pending,
+            };
+        }
+
+        let mut dst = dst.as_direct(store, DEFAULT_BUFFER_CAPACITY);
+        let buf = dst.remaining();
+        match ready!(stream.poll_read(cx, buf)) {
+            Ok(0) => {
+                self.close(Ok(()));
+                Poll::Ready(Ok(StreamResult::Dropped))
+            }
+            Ok(n) => {
+                dst.mark_written(n);
+                Poll::Ready(Ok(StreamResult::Completed))
+            }
+            Err(err) => {
+                self.close(Err(err.into()));
+                Poll::Ready(Ok(StreamResult::Dropped))
+            }
+        }
     }
 }
 
-struct SendStreamConsumer {
-    stream: Arc<TcpStream>,
-    result: Option<oneshot::Sender<Result<(), ErrorCode>>>,
-}
+struct SendStreamConsumer(Option<(TcpSendStream, oneshot::Sender<Result<(), ErrorCode>>)>);
 
 impl Drop for SendStreamConsumer {
     fn drop(&mut self) {
@@ -172,8 +152,7 @@ impl Drop for SendStreamConsumer {
 
 impl SendStreamConsumer {
     fn close(&mut self, res: Result<(), ErrorCode>) {
-        if let Some(tx) = self.result.take() {
-            _ = crate::sockets::util::shutdown(&self.stream, Shutdown::Write);
+        if let Some((_, tx)) = self.0.take() {
             _ = tx.send(res);
         }
     }
@@ -189,48 +168,34 @@ impl<D> StreamConsumer<D> for SendStreamConsumer {
         src: Source<Self::Item>,
         finish: bool,
     ) -> Poll<wasmtime::Result<StreamResult>> {
-        let mut src = src.as_direct(store);
-        let res = 'result: {
-            // A 0-length write is a request to wait for readiness so use
-            // `poll_write_ready` to wait for the underlying object to be ready.
-            if src.remaining().is_empty() {
-                return match self.stream.poll_write_ready(cx) {
-                    Poll::Ready(Ok(())) => Poll::Ready(Ok(StreamResult::Completed)),
-                    Poll::Ready(Err(err)) => break 'result Err(err.into()),
-                    Poll::Pending if finish => Poll::Ready(Ok(StreamResult::Cancelled)),
-                    Poll::Pending => Poll::Pending,
-                };
-            }
-            loop {
-                match self.stream.try_write(src.remaining()) {
-                    Ok(n) => {
-                        debug_assert!(n > 0);
-                        src.mark_read(n);
-                        return Poll::Ready(Ok(StreamResult::Completed));
-                    }
-                    Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
-                        match self.stream.poll_write_ready(cx) {
-                            Poll::Ready(Ok(())) => continue,
-                            Poll::Ready(Err(err)) => break 'result Err(err.into()),
-                            Poll::Pending if finish => {
-                                return Poll::Ready(Ok(StreamResult::Cancelled));
-                            }
-                            Poll::Pending => return Poll::Pending,
-                        }
-                    }
-                    Err(err) => {
-                        break 'result Err(match err.kind() {
-                            // ECONNABORTED is the closest thing to EPIPE on Windows.
-                            std::io::ErrorKind::BrokenPipe
-                            | std::io::ErrorKind::ConnectionAborted => ErrorCode::ConnectionBroken,
-                            _ => err.into(),
-                        });
-                    }
-                }
-            }
+        let Some((stream, _)) = self.0.as_mut() else {
+            return Poll::Ready(Ok(StreamResult::Dropped));
         };
-        self.close(res);
-        Poll::Ready(Ok(StreamResult::Dropped))
+        if finish {
+            return Poll::Ready(Ok(StreamResult::Cancelled));
+        }
+
+        let mut src = src.as_direct(store);
+
+        // A 0-length write is a readiness check.
+        if src.remaining().is_empty() {
+            return match stream.poll_ready(cx) {
+                Poll::Ready(()) => Poll::Ready(Ok(StreamResult::Completed)),
+                Poll::Pending => Poll::Pending,
+            };
+        }
+
+        match ready!(stream.poll_write(cx, src.remaining())) {
+            Ok(n) => {
+                debug_assert!(n > 0);
+                src.mark_read(n);
+                Poll::Ready(Ok(StreamResult::Completed))
+            }
+            Err(err) => {
+                self.close(Err(err.into()));
+                Poll::Ready(Ok(StreamResult::Dropped))
+            }
+        }
     }
 }
 
@@ -241,23 +206,20 @@ impl<T: Send> HostTcpSocketWithStore<T> for WasiSockets {
         remote_address: IpSocketAddress,
     ) -> SocketResult<()> {
         let remote_address = SocketAddr::from(remote_address);
-        if !is_addr_allowed(store, remote_address, SocketAddrUse::TcpConnect).await {
-            return Err(ErrorCode::AccessDenied.into());
-        }
-        let sock = store.with(|mut store| {
+
+        store.with(|mut store| {
             let socket = get_socket_mut(store.get().table, &socket)?;
-            let socket = socket.start_connect(&remote_address)?;
+            let socket = socket.start_connect(remote_address)?;
             SocketResult::Ok(socket)
         })?;
 
-        // FIXME: handle possible cancellation of the outer `connect`
-        // https://github.com/bytecodealliance/wasmtime/pull/11291#discussion_r2223917986
-        let res = sock.connect(remote_address).await;
-        store.with(|mut store| {
-            let socket = get_socket_mut(store.get().table, &socket)?;
-            socket.finish_connect(res)?;
-            Ok(())
+        std::future::poll_fn(|cx| {
+            store.with(|mut store| -> Poll<SocketResult<()>> {
+                let socket = get_socket_mut(store.get().table, &socket)?;
+                socket.poll_finish_connect(cx).map_err(SocketError::from)
+            })
         })
+        .await
     }
 
     async fn listen(
@@ -267,64 +229,10 @@ impl<T: Send> HostTcpSocketWithStore<T> for WasiSockets {
         let getter = store.getter();
         let socket = get_socket_mut(store.get().table, &socket_resource)?;
 
-        // If this socket has not yet been explicitly bound then it's never hit
-        // the `socket_addr_check` callback/function. An unbound socket here
-        // implicitly performs a bind, so to ensure the address is checked this
-        // function explicitly performs a bind against the implicit bind
-        // address.
-        //
-        // In addition to this some platforms automatically perform an implicit
-        // bind as part of the `listen` syscall. However this is not ubiquitous
-        // behavior:
-        // - Linux mentions it in their docs [0] that they perform an
-        //   implicit bind. This behavior has been experimentally verified.
-        // - Windows requires a `bind` before `listen`. This is both
-        //   documented [1] and experimentally verified.
-        // - Other platforms (e.g. macOS, FreeBSD) do not explicitly
-        //   document it either way and instead leave it up to the
-        //   individual protocol to decide [2]. However, experiments
-        //   show that MacOS in fact _does_ perform an implicit bind.
-        //
-        // Thus to ensure the socket address check is used and to additionally
-        // ensure consistent behavior across all platforms, we perform the
-        // implicit bind ourselves here for unbound sockets.
-        //
-        // [0]: https://man7.org/linux/man-pages/man7/ip.7.html
-        // > An ephemeral port is allocated to a socket in the following
-        // > circumstances: (...) listen(2) is called on a stream socket
-        // > that was not previously bound;
-        //
-        // [1]: https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-listen
-        // > WSAEINVAL: The socket has not been bound with bind.
-        //
-        // [2]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/listen.html
-        // > EDESTADDRREQ: The socket is not bound to a local address,
-        // > and the protocol does not support listening on an unbound
-        // > socket.
-        if !socket.is_bound() {
-            let implicit_addr = crate::sockets::util::implicit_bind_addr(socket.address_family());
-            store
-                .get()
-                .bind_addr(&socket_resource, implicit_addr)
-                .await?;
-        }
+        let listener = socket.listen().await?;
 
-        let socket = get_socket_mut(store.get().table, &socket_resource)?;
-        socket.start_listen()?;
-        socket.finish_listen()?;
-        let listener = socket.tcp_listener_arc().unwrap().clone();
-        let family = socket.address_family();
-        let options = socket.non_inherited_options().clone();
-        let ret = StreamReader::new(
-            &mut store,
-            ListenStreamProducer {
-                listener,
-                family,
-                options,
-                getter,
-            },
-        )
-        .map_err(SocketError::trap)?;
+        let ret = StreamReader::new(&mut store, ListenStreamProducer { listener, getter })
+            .map_err(SocketError::trap)?;
         Ok(ret)
     }
 
@@ -337,18 +245,15 @@ impl<T: Send> HostTcpSocketWithStore<T> for WasiSockets {
         match socket.take_send_stream() {
             Ok(stream) => {
                 let (result_tx, result_rx) = oneshot::channel();
-                data.pipe(
-                    &mut store,
-                    SendStreamConsumer {
-                        stream,
-                        result: Some(result_tx),
-                    },
-                )?;
+                data.pipe(&mut store, SendStreamConsumer(Some((stream, result_tx))))?;
                 FutureReader::new(&mut store, result_rx)
             }
             Err(err) => {
                 data.close(&mut store)?;
-                FutureReader::new(&mut store, async { wasmtime::error::Ok(Err(err.into())) })
+                FutureReader::new(
+                    &mut store,
+                    async move { wasmtime::error::Ok(Err(err.into())) },
+                )
             }
         }
     }
@@ -364,35 +269,19 @@ impl<T: Send> HostTcpSocketWithStore<T> for WasiSockets {
                 Ok((
                     StreamReader::new(
                         &mut store,
-                        ReceiveStreamProducer {
-                            stream,
-                            result: Some(result_tx),
-                        },
+                        ReceiveStreamProducer(Some((stream, result_tx))),
                     )?,
                     FutureReader::new(&mut store, result_rx)?,
                 ))
             }
             Err(err) => Ok((
                 StreamReader::new(&mut store, iter::empty())?,
-                FutureReader::new(&mut store, async { wasmtime::error::Ok(Err(err.into())) })?,
+                FutureReader::new(
+                    &mut store,
+                    async move { wasmtime::error::Ok(Err(err.into())) },
+                )?,
             )),
         }
-    }
-}
-
-impl WasiSocketsCtxView<'_> {
-    async fn bind_addr(
-        &mut self,
-        socket: &Resource<TcpSocket>,
-        local_address: SocketAddr,
-    ) -> SocketResult<()> {
-        if !(self.ctx.socket_addr_check)(local_address, SocketAddrUse::TcpBind).await {
-            return Err(ErrorCode::AccessDenied.into());
-        }
-        let socket = get_socket_mut(self.table, socket)?;
-        socket.start_bind(local_address)?;
-        socket.finish_bind()?;
-        Ok(())
     }
 }
 
@@ -403,7 +292,9 @@ impl HostTcpSocket for WasiSocketsCtxView<'_> {
         local_address: IpSocketAddress,
     ) -> SocketResult<()> {
         let local_address = SocketAddr::from(local_address);
-        self.bind_addr(&socket, local_address).await
+        let socket = get_socket_mut(self.table, &socket)?;
+        socket.bind(local_address).await?;
+        Ok(())
     }
 
     fn create(&mut self, address_family: IpAddressFamily) -> SocketResult<Resource<TcpSocket>> {
@@ -418,7 +309,7 @@ impl HostTcpSocket for WasiSocketsCtxView<'_> {
     }
 
     fn get_local_address(&mut self, socket: Resource<TcpSocket>) -> SocketResult<IpSocketAddress> {
-        let sock = get_socket(self.table, &socket)?;
+        let sock = get_socket_mut(self.table, &socket)?;
         Ok(sock.local_address()?.into())
     }
 

--- a/crates/wasi/src/p3/sockets/host/types/tcp.rs
+++ b/crates/wasi/src/p3/sockets/host/types/tcp.rs
@@ -10,7 +10,6 @@ use core::iter;
 use core::pin::Pin;
 use core::task::{Context, Poll};
 use std::net::SocketAddr;
-use std::task::ready;
 use tokio::sync::oneshot;
 use wasmtime::component::{
     Access, Accessor, Destination, FutureReader, Resource, ResourceTable, Source, StreamConsumer,
@@ -58,19 +57,20 @@ where
         mut dst: Destination<'a, Self::Item, Self::Buffer>,
         finish: bool,
     ) -> Poll<wasmtime::Result<StreamResult>> {
-        if finish {
-            return Poll::Ready(Ok(StreamResult::Cancelled));
-        }
-
         // If the destination buffer is empty then this is a readiness check.
         if dst.remaining(&mut store) == Some(0) {
             return match self.listener.poll_ready(cx) {
                 Poll::Ready(()) => Poll::Ready(Ok(StreamResult::Completed)),
+                Poll::Pending if finish => Poll::Ready(Ok(StreamResult::Cancelled)),
                 Poll::Pending => Poll::Pending,
             };
         }
 
-        let socket = ready!(self.listener.poll_accept(cx));
+        let socket = match self.listener.poll_accept(cx) {
+            Poll::Ready(socket) => socket,
+            Poll::Pending if finish => return Poll::Ready(Ok(StreamResult::Cancelled)),
+            Poll::Pending => return Poll::Pending,
+        };
         let ctx = (self.getter)(store.data_mut());
         let socket = ctx
             .table
@@ -111,33 +111,33 @@ impl<D> StreamProducer<D> for ReceiveStreamProducer {
         let Some((stream, _)) = self.0.as_mut() else {
             return Poll::Ready(Ok(StreamResult::Dropped));
         };
-        if finish {
-            return Poll::Ready(Ok(StreamResult::Cancelled));
-        }
 
         // 0-length read is a readiness check.
         if dst.remaining(store.as_context_mut()) == Some(0) {
             return match stream.poll_ready(cx) {
                 Poll::Ready(()) => Poll::Ready(Ok(StreamResult::Completed)),
+                Poll::Pending if finish => Poll::Ready(Ok(StreamResult::Cancelled)),
                 Poll::Pending => Poll::Pending,
             };
         }
 
         let mut dst = dst.as_direct(store, DEFAULT_BUFFER_CAPACITY);
         let buf = dst.remaining();
-        match ready!(stream.poll_read(cx, buf)) {
-            Ok(0) => {
+        match stream.poll_read(cx, buf) {
+            Poll::Ready(Ok(0)) => {
                 self.close(Ok(()));
                 Poll::Ready(Ok(StreamResult::Dropped))
             }
-            Ok(n) => {
+            Poll::Ready(Ok(n)) => {
                 dst.mark_written(n);
                 Poll::Ready(Ok(StreamResult::Completed))
             }
-            Err(err) => {
+            Poll::Ready(Err(err)) => {
                 self.close(Err(err.into()));
                 Poll::Ready(Ok(StreamResult::Dropped))
             }
+            Poll::Pending if finish => Poll::Ready(Ok(StreamResult::Cancelled)),
+            Poll::Pending => Poll::Pending,
         }
     }
 }
@@ -171,9 +171,6 @@ impl<D> StreamConsumer<D> for SendStreamConsumer {
         let Some((stream, _)) = self.0.as_mut() else {
             return Poll::Ready(Ok(StreamResult::Dropped));
         };
-        if finish {
-            return Poll::Ready(Ok(StreamResult::Cancelled));
-        }
 
         let mut src = src.as_direct(store);
 
@@ -181,20 +178,23 @@ impl<D> StreamConsumer<D> for SendStreamConsumer {
         if src.remaining().is_empty() {
             return match stream.poll_ready(cx) {
                 Poll::Ready(()) => Poll::Ready(Ok(StreamResult::Completed)),
+                Poll::Pending if finish => Poll::Ready(Ok(StreamResult::Cancelled)),
                 Poll::Pending => Poll::Pending,
             };
         }
 
-        match ready!(stream.poll_write(cx, src.remaining())) {
-            Ok(n) => {
+        match stream.poll_write(cx, src.remaining()) {
+            Poll::Ready(Ok(n)) => {
                 debug_assert!(n > 0);
                 src.mark_read(n);
                 Poll::Ready(Ok(StreamResult::Completed))
             }
-            Err(err) => {
+            Poll::Ready(Err(err)) => {
                 self.close(Err(err.into()));
                 Poll::Ready(Ok(StreamResult::Dropped))
             }
+            Poll::Pending if finish => Poll::Ready(Ok(StreamResult::Cancelled)),
+            Poll::Pending => Poll::Pending,
         }
     }
 }

--- a/crates/wasi/src/p3/sockets/host/types/udp.rs
+++ b/crates/wasi/src/p3/sockets/host/types/udp.rs
@@ -1,10 +1,9 @@
-use super::is_addr_allowed;
 use crate::TrappableError;
 use crate::p3::bindings::sockets::types::{
-    ErrorCode, HostUdpSocket, HostUdpSocketWithStore, IpAddressFamily, IpSocketAddress,
+    HostUdpSocket, HostUdpSocketWithStore, IpAddressFamily, IpSocketAddress,
 };
 use crate::p3::sockets::{SocketResult, WasiSockets};
-use crate::sockets::{MAX_UDP_DATAGRAM_SIZE, SocketAddrUse, UdpSocket, WasiSocketsCtxView};
+use crate::sockets::{UdpSocket, WasiSocketsCtxView};
 use std::net::SocketAddr;
 use wasmtime::component::{Accessor, Resource, ResourceTable};
 use wasmtime::error::Context as _;
@@ -36,58 +35,12 @@ impl<T> HostUdpSocketWithStore<T> for WasiSockets {
         data: Vec<u8>,
         remote_address: Option<IpSocketAddress>,
     ) -> SocketResult<()> {
-        if data.len() > MAX_UDP_DATAGRAM_SIZE {
-            return Err(ErrorCode::DatagramTooLarge.into());
-        }
-        let remote_address = remote_address.map(SocketAddr::from);
-
-        if let Some(addr) = remote_address {
-            if !is_addr_allowed(store, addr, SocketAddrUse::UdpOutgoingDatagram).await {
-                return Err(ErrorCode::AccessDenied.into());
-            }
-        }
-
-        // If this socket is not yet explicitly bound then part of this
-        // operation is performing an implicit bind. This is done for a few
-        // reasons:
-        //
-        // * The host's `socket_addr_check` callback, if any, gets an
-        //   opportunity to have an opinion about the implicit use of this
-        //   address.
-        // * On the first send the OS will automatically assign a free local
-        //   port. However, if the `send` syscall failed, we can't reliably know
-        //   which state the socket is in at the kernel level and our own
-        //   state bookkeeping may have become out-of-sync.
-        //
-        // To avoid that, we perform the implicit bind ourselves here. This way,
-        // we always leave the socket in a consistent state: Bound.
-        //
-        // Note that implicit binding only happens when the socket isn't bound
-        // and the remote address is `Some`. If the remote address is `None` and
-        // we're unbound then that's an invalid state that `send_p3` below will
-        // reject.
-        let (needs_implicit_bind, family) = store.with(|mut view| -> SocketResult<_> {
-            let socket = get_socket_mut(view.get().table, &socket)?;
-            let needs_implicit_bind = !socket.is_bound() && remote_address.is_some();
-            Ok((needs_implicit_bind, socket.address_family()))
-        })?;
-        if needs_implicit_bind {
-            let implicit_addr = crate::sockets::util::implicit_bind_addr(family);
-            if !is_addr_allowed(store, implicit_addr, SocketAddrUse::UdpBind).await {
-                return Err(ErrorCode::AccessDenied.into());
-            }
-            store.with(|mut view| -> SocketResult<_> {
+        store
+            .with(|mut view| -> SocketResult<_> {
                 let socket = get_socket_mut(view.get().table, &socket)?;
-                socket.bind(implicit_addr)?;
-                socket.finish_bind()?;
-                Ok(())
-            })?;
-        }
-
-        let fut = store.with(|mut view| {
-            get_socket_mut(view.get().table, &socket).map(|sock| sock.send_p3(data, remote_address))
-        })?;
-        fut.await?;
+                Ok(socket.send(data, remote_address.map(SocketAddr::from)))
+            })?
+            .await?;
         Ok(())
     }
 
@@ -95,10 +48,13 @@ impl<T> HostUdpSocketWithStore<T> for WasiSockets {
         store: &Accessor<T, Self>,
         socket: Resource<UdpSocket>,
     ) -> SocketResult<(Vec<u8>, IpSocketAddress)> {
-        let fut = store
-            .with(|mut view| get_socket(view.get().table, &socket).map(|sock| sock.receive_p3()))?;
-        let (result, addr) = fut.await?;
-        Ok((result, addr.into()))
+        let (data, addr) = store
+            .with(|mut view| -> SocketResult<_> {
+                let socket = get_socket_mut(view.get().table, &socket)?;
+                Ok(socket.recv())
+            })?
+            .await?;
+        Ok((data, addr.into()))
     }
 }
 
@@ -109,12 +65,8 @@ impl HostUdpSocket for WasiSocketsCtxView<'_> {
         local_address: IpSocketAddress,
     ) -> SocketResult<()> {
         let local_address = SocketAddr::from(local_address);
-        if !(self.ctx.socket_addr_check)(local_address, SocketAddrUse::UdpBind).await {
-            return Err(ErrorCode::AccessDenied.into());
-        }
         let socket = get_socket_mut(self.table, &socket)?;
-        socket.bind(local_address)?;
-        socket.finish_bind()?;
+        socket.bind(local_address).await?;
         Ok(())
     }
 
@@ -124,16 +76,16 @@ impl HostUdpSocket for WasiSocketsCtxView<'_> {
         remote_address: IpSocketAddress,
     ) -> SocketResult<()> {
         let remote_address = SocketAddr::from(remote_address);
-        if !(self.ctx.socket_addr_check)(remote_address, SocketAddrUse::UdpConnect).await {
-            return Err(ErrorCode::AccessDenied.into());
-        }
         let socket = get_socket_mut(self.table, &socket)?;
-        socket.connect_p3(remote_address)?;
+        socket.connect(remote_address).await?;
         Ok(())
     }
 
-    fn create(&mut self, address_family: IpAddressFamily) -> SocketResult<Resource<UdpSocket>> {
-        let socket = UdpSocket::new(self.ctx, address_family.into())?;
+    async fn create(
+        &mut self,
+        address_family: IpAddressFamily,
+    ) -> SocketResult<Resource<UdpSocket>> {
+        let socket = UdpSocket::new(self.ctx, address_family.into()).await?;
         self.table
             .push(socket)
             .context("failed to push socket resource to table")
@@ -147,12 +99,12 @@ impl HostUdpSocket for WasiSocketsCtxView<'_> {
     }
 
     fn get_local_address(&mut self, socket: Resource<UdpSocket>) -> SocketResult<IpSocketAddress> {
-        let sock = get_socket(self.table, &socket)?;
+        let sock = get_socket_mut(self.table, &socket)?;
         Ok(sock.local_address()?.into())
     }
 
     fn get_remote_address(&mut self, socket: Resource<UdpSocket>) -> SocketResult<IpSocketAddress> {
-        let sock = get_socket(self.table, &socket)?;
+        let sock = get_socket_mut(self.table, &socket)?;
         Ok(sock.remote_address()?.into())
     }
 

--- a/crates/wasi/src/sockets/mod.rs
+++ b/crates/wasi/src/sockets/mod.rs
@@ -1,17 +1,15 @@
 use core::future::Future;
 use core::ops::Deref;
-use std::net::SocketAddr;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::{net::SocketAddr, task::Poll};
 use wasmtime::component::{HasData, ResourceTable};
 
 mod tcp;
 mod udp;
 pub(crate) mod util;
-
-#[cfg(feature = "p3")]
-pub(crate) use tcp::NonInheritedOptions;
 pub use tcp::TcpSocket;
+pub(crate) use tcp::{TcpListenStream, TcpReceiveStream, TcpSendStream};
 pub use udp::UdpSocket;
 
 /// A helper struct which implements [`HasData`] for the `wasi:sockets` APIs.
@@ -181,20 +179,117 @@ impl Default for SocketAddrCheck {
 /// The reason what a socket address is being used for.
 #[derive(Clone, Copy, Debug)]
 pub enum SocketAddrUse {
-    /// Binding TCP socket
+    /// Binding TCP socket.
+    ///
+    /// This is invoked for both explicit calls to `bind` as well as implicit
+    /// binds that are about to be performed by the OS as part of
+    /// e.g. `connect` & `listen`.
+    ///
+    /// The address that is passed to the check is the address provided to
+    /// `bind` for explicit binds, or the wildcard address for implicit binds.
     TcpBind,
-    /// Connecting TCP socket
+
+    /// Put a TCP socket in listener mode.
+    ///
+    /// If the socket was already bound at the time of the call, the actual
+    /// local address of the socket is passed to the check. If the socket is
+    /// about to be implicitly bound by `listen`, the wildcard address is passed.
+    TcpListen,
+
+    /// Accepting a new client TCP socket.
+    ///
+    /// The address passed to the check is the remote address of the client that
+    /// is being accepted. If the check fails, the client socket will be
+    /// silently dropped before reaching the guest.
+    TcpAccept,
+
+    /// Connecting a TCP socket.
+    ///
+    /// The address passed to the check is the remote address that the socket is
+    /// attempting to connect to.
     TcpConnect,
-    /// Binding UDP socket
+
+    /// Binding UDP socket.
+    ///
+    /// This is invoked for both explicit calls to `bind` as well as implicit
+    /// binds that are about to be performed by the OS as part of
+    /// e.g. `connect` & `send`.
+    ///
+    /// The address that is passed to the check is the address provided to
+    /// `bind` for explicit binds, or the wildcard address for implicit binds.
     UdpBind,
-    /// Connecting UDP socket
-    UdpConnect,
-    /// Sending datagram on non-connected UDP socket
-    UdpOutgoingDatagram,
+
+    /// Sending a datagram on a UDP socket.
+    ///
+    /// The address passed to the check is the remote address that the socket is
+    /// attempting to send to.
+    UdpSend,
+
+    /// Receiving a datagram on a UDP socket.
+    ///
+    /// The address passed to the check is the remote address of the datagram
+    /// that is being received. If the check fails, the datagram will be
+    /// silently dropped before reaching the guest.
+    UdpReceive,
 }
 
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub(crate) enum SocketAddressFamily {
     Ipv4,
     Ipv6,
+}
+
+/// A utility type that separates
+/// (1) polling a future for completion and
+/// (2) obtaining the output of a future
+/// into separate operations. This is a common pattern in WASI 0.2.
+pub(crate) enum MaybeReady<T> {
+    Pending(Pin<Box<dyn Future<Output = T> + Send>>),
+    Ready(T),
+}
+impl<T> MaybeReady<T> {
+    pub(crate) fn new(fut: impl Future<Output = T> + Send + 'static) -> Self {
+        Self::Pending(Box::pin(fut))
+    }
+
+    /// Poll the future and attempt to resolve it immediately. If the future is
+    /// not ready yet, it will be moved to a background task.
+    pub(crate) fn poll_or_spawn(fut: impl Future<Output = T> + Send + 'static) -> Self
+    where
+        T: Send + 'static,
+    {
+        let mut fut = Box::pin(fut);
+        match fut.as_mut().poll(&mut noop_cx()) {
+            Poll::Ready(val) => Self::Ready(val),
+            Poll::Pending => Self::new(crate::runtime::spawn(fut)),
+        }
+    }
+    pub(crate) fn unwrap_ready(self) -> T {
+        match self {
+            Self::Ready(val) => val,
+            Self::Pending(_) => panic!("future not ready"),
+        }
+    }
+    pub(crate) fn poll_ready(&mut self, cx: &mut std::task::Context<'_>) -> Poll<()> {
+        match self {
+            Self::Pending(fut) => match fut.as_mut().poll(cx) {
+                Poll::Ready(val) => {
+                    *self = Self::Ready(val);
+                    Poll::Ready(())
+                }
+                Poll::Pending => Poll::Pending,
+            },
+            Self::Ready(_) => Poll::Ready(()),
+        }
+    }
+    pub(crate) async fn into_future(self) -> T {
+        match self {
+            Self::Ready(val) => val,
+            Self::Pending(fut) => fut.await,
+        }
+    }
+}
+
+pub(crate) fn noop_cx() -> std::task::Context<'static> {
+    std::task::Context::from_waker(futures::task::noop_waker_ref())
 }

--- a/crates/wasi/src/sockets/tcp.rs
+++ b/crates/wasi/src/sockets/tcp.rs
@@ -1,84 +1,51 @@
-use crate::p2::P2TcpStreamingState;
 use crate::runtime::with_ambient_tokio_runtime;
 use crate::sockets::util::{
     ErrorCode, get_unicast_hop_limit, is_valid_address_family, is_valid_remote_address,
     is_valid_unicast_address, receive_buffer_size, send_buffer_size, set_keep_alive_count,
     set_keep_alive_idle_time, set_keep_alive_interval, set_receive_buffer_size,
-    set_send_buffer_size, set_unicast_hop_limit, tcp_bind,
+    set_send_buffer_size, set_unicast_hop_limit, shutdown, tcp_accept, tcp_bind, tcp_reset,
+    unspecified_addr,
 };
-use crate::sockets::{DEFAULT_TCP_BACKLOG, SocketAddressFamily, WasiSocketsCtx};
+use crate::sockets::{
+    DEFAULT_TCP_BACKLOG, MaybeReady, SocketAddrCheck, SocketAddrUse, SocketAddressFamily,
+    WasiSocketsCtx,
+};
+use rustix::fd::AsFd;
 use rustix::io::Errno;
 use rustix::net::sockopt;
 use std::fmt::Debug;
-use std::io;
+use std::future::poll_fn;
 use std::mem;
-use std::net::SocketAddr;
-use std::pin::Pin;
+use std::net::{Shutdown, SocketAddr};
 use std::sync::Arc;
-use std::task::{Context, Poll, Waker};
+use std::task::{Poll, ready};
 use std::time::Duration;
 
 /// The state of a TCP socket.
 ///
 /// This represents the various states a socket can be in during the
-/// activities of binding, listening, accepting, and connecting. Note that this
-/// state machine encompasses both WASIp2 and WASIp3.
+/// activities of listening, accepting, and connecting.
 enum TcpState {
     /// The initial state for a newly-created socket.
     ///
-    /// From here a socket can transition to `BindStarted`, `ListenStarted`, or
-    /// `Connecting`.
+    /// The socket may be bound to a local address in this state, but doesn't
+    /// have to.
+    ///
+    /// From here a socket can transition to `Listening` or `Connecting`.
     Default(tokio::net::TcpSocket),
-
-    /// A state indicating that a bind has been started and must be finished
-    /// subsequently with `finish_bind`.
-    ///
-    /// From here a socket can transition to `Bound`.
-    BindStarted(tokio::net::TcpSocket),
-
-    /// Binding finished. The socket has an address but is not yet listening for
-    /// connections.
-    ///
-    /// From here a socket can transition to `ListenStarted`, or `Connecting`.
-    Bound(tokio::net::TcpSocket),
-
-    /// Listening on a socket has started and must be completed with
-    /// `finish_listen`.
-    ///
-    /// From here a socket can transition to `Listening`.
-    ListenStarted(tokio::net::TcpSocket),
 
     /// The socket is now listening and waiting for an incoming connection.
     ///
     /// Sockets will not leave this state.
-    Listening {
-        /// The raw tokio-basd TCP listener managing the underlying socket.
-        listener: Arc<tokio::net::TcpListener>,
-
-        /// The last-accepted connection, set during the `ready` method and read
-        /// during the `accept` method. Note that this is only used for WASIp2
-        /// at this time.
-        pending_accept: Option<io::Result<tokio::net::TcpStream>>,
-    },
+    Listening(Arc<tokio::net::TcpListener>),
 
     /// An outgoing connection is started.
     ///
-    /// This is created via the `start_connect` method. The payload here is an
-    /// optionally-specified owned future for the result of the connect. In
-    /// WASIp2 the future lives here, but in WASIp3 it lives on the event loop
-    /// so this is `None`.
+    /// This is created via the `start_connect` method. The payload is a future
+    /// for the eventual result of the connect.
     ///
-    /// From here a socket can transition to `ConnectReady` or `Connected`.
-    Connecting(Option<Pin<Box<dyn Future<Output = io::Result<tokio::net::TcpStream>> + Send>>>),
-
-    /// A connection via `Connecting` has completed.
-    ///
-    /// This is present for WASIp2 where the `Connecting` state stores `Some` of
-    /// a future, and the result of that future is recorded here when it
-    /// finishes as part of the `ready` method.
-    ///
-    /// From here a socket can transition to `Connected`.
-    ConnectReady(io::Result<tokio::net::TcpStream>),
+    /// From here a socket can transition to `Connected` or `Closed`.
+    Connecting(MaybeReady<Result<tokio::net::TcpStream, ErrorCode>>),
 
     /// A connection has been established.
     ///
@@ -88,53 +55,35 @@ enum TcpState {
     /// A socket will not transition out of this state.
     Connected {
         stream: Arc<tokio::net::TcpStream>,
-        taken_streams: TakenStreams,
-        p2_state: Option<P2TcpStreamingState>,
+        receive_taken: bool,
+        send_taken: bool,
     },
 
-    /// This is not actually a socket but a deferred error.
-    ///
-    /// This error came out of `accept` and is deferred until the socket is
-    /// operated on.
-    #[cfg(feature = "p3")]
-    Error(io::Error),
-
     /// The socket is closed and no more operations can be performed.
-    Closed,
+    Closed(ErrorCode),
 }
 impl TcpState {
     fn connected(stream: tokio::net::TcpStream) -> Self {
         TcpState::Connected {
             stream: Arc::new(stream),
-            taken_streams: TakenStreams {
-                receive: false,
-                send: false,
-            },
-            p2_state: None,
+            receive_taken: false,
+            send_taken: false,
         }
+    }
+    fn take(&mut self) -> Self {
+        mem::replace(self, TcpState::Closed(ErrorCode::Other))
     }
 }
 impl Debug for TcpState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Default(_) => f.debug_tuple("Default").finish(),
-            Self::BindStarted(_) => f.debug_tuple("BindStarted").finish(),
-            Self::Bound(_) => f.debug_tuple("Bound").finish(),
-            Self::ListenStarted { .. } => f.debug_tuple("ListenStarted").finish(),
             Self::Listening { .. } => f.debug_tuple("Listening").finish(),
             Self::Connecting(..) => f.debug_tuple("Connecting").finish(),
-            Self::ConnectReady(..) => f.debug_tuple("ConnectReady").finish(),
             Self::Connected { .. } => f.debug_tuple("Connected").finish(),
-            #[cfg(feature = "p3")]
-            Self::Error(..) => f.debug_tuple("Error").finish(),
-            Self::Closed => write!(f, "Closed"),
+            Self::Closed(..) => write!(f, "Closed"),
         }
     }
-}
-
-struct TakenStreams {
-    receive: bool,
-    send: bool,
 }
 
 /// A host TCP socket, plus associated bookkeeping.
@@ -147,7 +96,16 @@ pub struct TcpSocket {
 
     family: SocketAddressFamily,
 
-    options: NonInheritedOptions,
+    /// The checks to perform before doing any noteworthy syscall.
+    permissions: SocketAddrCheck,
+
+    /// Persisted socket options to manually apply to newly accepted client
+    /// sockets on platforms that don't inherit socket options from the listener.
+    listener_options: NonInheritedOptions,
+
+    /// Cached value of whether the socket is bound. Various methods use the
+    /// `.is_bound()` method, so we cache it to avoid redundant syscalls.
+    is_bound: bool,
 }
 
 impl TcpSocket {
@@ -168,329 +126,278 @@ impl TcpSocket {
                 }
             };
 
-            Ok(Self::from_state(TcpState::Default(socket), family))
+            Ok(Self {
+                tcp_state: TcpState::Default(socket),
+                listen_backlog_size: DEFAULT_TCP_BACKLOG,
+                family,
+                is_bound: false,
+                listener_options: Default::default(),
+                permissions: ctx.socket_addr_check.clone(),
+            })
         })
     }
 
-    #[cfg(feature = "p3")]
-    pub(crate) fn new_error(err: io::Error, family: SocketAddressFamily) -> Self {
-        TcpSocket::from_state(TcpState::Error(err), family)
-    }
-
-    /// Creates a new socket with the `result` of an accepted socket from a
-    /// `TcpListener`.
-    ///
-    /// This will handle the `result` internally and `result` should be the raw
-    /// result from a TCP listen operation.
-    pub(crate) fn new_accept(
-        result: io::Result<tokio::net::TcpStream>,
-        options: &NonInheritedOptions,
-        family: SocketAddressFamily,
-    ) -> io::Result<Self> {
-        let client = result.map_err(|err| match Errno::from_io_error(&err) {
-            // From: https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-accept#:~:text=WSAEINPROGRESS
-            // > WSAEINPROGRESS: A blocking Windows Sockets 1.1 call is in progress,
-            // > or the service provider is still processing a callback function.
-            //
-            // wasi-sockets doesn't have an equivalent to the EINPROGRESS error,
-            // because in POSIX this error is only returned by a non-blocking
-            // `connect` and wasi-sockets has a different solution for that.
-            #[cfg(windows)]
-            Some(Errno::INPROGRESS) => Errno::INTR.into(),
-
-            // Normalize Linux' non-standard behavior.
-            //
-            // From https://man7.org/linux/man-pages/man2/accept.2.html:
-            // > Linux accept() passes already-pending network errors on the
-            // > new socket as an error code from accept(). This behavior
-            // > differs from other BSD socket implementations. (...)
-            #[cfg(target_os = "linux")]
-            Some(
-                Errno::CONNRESET
-                | Errno::NETRESET
-                | Errno::HOSTUNREACH
-                | Errno::HOSTDOWN
-                | Errno::NETDOWN
-                | Errno::NETUNREACH
-                | Errno::PROTO
-                | Errno::NOPROTOOPT
-                | Errno::NONET
-                | Errno::OPNOTSUPP,
-            ) => Errno::CONNABORTED.into(),
-
-            _ => err,
-        })?;
-        options.apply(family, &client);
-        Ok(Self::from_state(TcpState::connected(client), family))
-    }
-
-    /// Create a `TcpSocket` from an existing socket.
-    fn from_state(state: TcpState, family: SocketAddressFamily) -> Self {
-        Self {
-            tcp_state: state,
-            listen_backlog_size: DEFAULT_TCP_BACKLOG,
-            family,
-            options: Default::default(),
-        }
-    }
-
-    fn as_std_view(&self) -> Result<StdView<'_>, ErrorCode> {
+    fn as_fd(&self) -> Result<rustix::fd::BorrowedFd<'_>, ErrorCode> {
         match &self.tcp_state {
-            TcpState::Default(socket)
-            | TcpState::BindStarted(socket)
-            | TcpState::Bound(socket)
-            | TcpState::ListenStarted(socket) => Ok(StdView::Socket(socket)),
-            TcpState::Connected { stream, .. } => Ok(StdView::Stream(stream)),
-            TcpState::Listening { listener, .. } => Ok(StdView::Listener(listener)),
-            TcpState::Connecting(..) | TcpState::ConnectReady(_) | TcpState::Closed => {
-                Err(ErrorCode::InvalidState)
-            }
-            #[cfg(feature = "p3")]
-            TcpState::Error(err) => Err(err.into()),
+            TcpState::Default(socket) => Ok(socket.as_fd()),
+            TcpState::Connected { stream, .. } => Ok(stream.as_fd()),
+            TcpState::Listening(listener) => Ok(listener.as_fd()),
+            TcpState::Connecting(..) => Err(ErrorCode::InvalidState),
+            TcpState::Closed(err) => Err(*err),
         }
     }
 
-    pub(crate) fn start_bind(&mut self, addr: SocketAddr) -> Result<(), ErrorCode> {
-        let ip = addr.ip();
-        if !is_valid_unicast_address(ip) || !is_valid_address_family(ip, self.family) {
-            return Err(ErrorCode::InvalidArgument);
+    pub(crate) fn is_bound(&mut self) -> bool {
+        // Once bound, a TCP socket can never become unbound again. So we can
+        // skip all work after a previous call has already determined the
+        // socket to be bound.
+        if !self.is_bound {
+            self.is_bound = match &self.tcp_state {
+                TcpState::Default(socket) => socket
+                    .local_addr()
+                    .is_ok_and(|addr| addr != unspecified_addr(self.family)),
+                _ => true,
+            };
         }
-        match mem::replace(&mut self.tcp_state, TcpState::Closed) {
-            TcpState::Default(sock) => {
-                if let Err(err) = tcp_bind(&sock, addr) {
-                    self.tcp_state = TcpState::Default(sock);
-                    Err(err)
-                } else {
-                    self.tcp_state = TcpState::BindStarted(sock);
-                    Ok(())
-                }
-            }
-            tcp_state => {
-                self.tcp_state = tcp_state;
-                Err(ErrorCode::InvalidState)
-            }
-        }
+        self.is_bound
     }
 
-    pub(crate) fn finish_bind(&mut self) -> Result<(), ErrorCode> {
-        match mem::replace(&mut self.tcp_state, TcpState::Closed) {
-            TcpState::BindStarted(socket) => {
-                self.tcp_state = TcpState::Bound(socket);
-                Ok(())
-            }
-            current_state => {
-                // Reset the state so that the outside world doesn't see this socket as closed
-                self.tcp_state = current_state;
-                Err(ErrorCode::NotInProgress)
-            }
+    pub(crate) async fn bind(&mut self, addr: SocketAddr) -> Result<(), ErrorCode> {
+        if self.is_bound() {
+            return Err(ErrorCode::InvalidState);
         }
-    }
-
-    pub(crate) fn start_connect(
-        &mut self,
-        addr: &SocketAddr,
-    ) -> Result<tokio::net::TcpSocket, ErrorCode> {
-        match self.tcp_state {
-            TcpState::Default(..) | TcpState::Bound(..) => {}
-            TcpState::Connecting(..) => {
-                return Err(ErrorCode::ConcurrencyConflict);
-            }
-            _ => return Err(ErrorCode::InvalidState),
+        let TcpState::Default(sock) = &self.tcp_state else {
+            return Err(ErrorCode::InvalidState);
         };
 
+        if !is_valid_unicast_address(addr.ip()) || !is_valid_address_family(addr.ip(), self.family)
+        {
+            return Err(ErrorCode::InvalidArgument);
+        }
+
+        self.permissions.check(addr, SocketAddrUse::TcpBind).await?;
+        tcp_bind(sock, addr)?;
+        Ok(())
+    }
+
+    pub(crate) fn start_connect(&mut self, addr: SocketAddr) -> Result<(), ErrorCode> {
+        let TcpState::Default(_) = &self.tcp_state else {
+            return Err(ErrorCode::InvalidState);
+        };
+
+        let permissions = self.permissions.clone();
+        let family = self.family;
+        let already_bound = self.is_bound();
+
         if !is_valid_unicast_address(addr.ip())
-            || !is_valid_remote_address(*addr)
-            || !is_valid_address_family(addr.ip(), self.family)
+            || !is_valid_remote_address(addr)
+            || !is_valid_address_family(addr.ip(), family)
         {
             return Err(ErrorCode::InvalidArgument);
         };
 
-        let (TcpState::Default(tokio_socket) | TcpState::Bound(tokio_socket)) =
-            mem::replace(&mut self.tcp_state, TcpState::Connecting(None))
-        else {
+        let TcpState::Default(sock) = self.tcp_state.take() else {
             unreachable!();
         };
 
-        Ok(tokio_socket)
-    }
-
-    /// For WASIp2 this is used to record the actual connection future as part
-    /// of `start_connect` within this socket state.
-    pub(crate) fn set_pending_connect(
-        &mut self,
-        future: impl Future<Output = io::Result<tokio::net::TcpStream>> + Send + 'static,
-    ) -> Result<(), ErrorCode> {
-        match &mut self.tcp_state {
-            TcpState::Connecting(slot @ None) => {
-                *slot = Some(Box::pin(future));
-                Ok(())
-            }
-            _ => Err(ErrorCode::InvalidState),
-        }
-    }
-
-    /// For WASIp2 this retrieves the result from the future passed to
-    /// `set_pending_connect`.
-    ///
-    /// Return states here are:
-    ///
-    /// * `Ok(Some(res))` - where `res` is the result of the connect operation.
-    /// * `Ok(None)` - the connect operation isn't ready yet.
-    /// * `Err(e)` - a connect operation is not in progress.
-    pub(crate) fn take_pending_connect(
-        &mut self,
-    ) -> Result<Option<io::Result<tokio::net::TcpStream>>, ErrorCode> {
-        match mem::replace(&mut self.tcp_state, TcpState::Connecting(None)) {
-            TcpState::ConnectReady(result) => Ok(Some(result)),
-            TcpState::Connecting(Some(mut future)) => {
-                let mut cx = Context::from_waker(Waker::noop());
-                match with_ambient_tokio_runtime(|| future.as_mut().poll(&mut cx)) {
-                    Poll::Ready(result) => Ok(Some(result)),
-                    Poll::Pending => {
-                        self.tcp_state = TcpState::Connecting(Some(future));
-                        Ok(None)
-                    }
+        self.tcp_state = TcpState::Connecting(MaybeReady::new(async move {
+            // Perform all checks before doing any syscalls.
+            {
+                if !already_bound {
+                    // If not explicitly bound, the OS will implicitly bind the
+                    // socket to an ephemeral port when connecting. Unlike other
+                    // operations (e.g. `listen`), we will *not* do the implicit
+                    // bind ourselves because that may accelerate port exhaustion.
+                    // For more info, see IP_BIND_ADDRESS_NO_PORT (Linux) or
+                    // SO_REUSE_UNICASTPORT (Windows).
+                    //
+                    // Instead we check the permission to bind, but not perform
+                    // the actual bind:
+                    let implicit = unspecified_addr(family);
+                    permissions.check(implicit, SocketAddrUse::TcpBind).await?;
                 }
+
+                permissions.check(addr, SocketAddrUse::TcpConnect).await?;
             }
-            current_state => {
-                self.tcp_state = current_state;
-                Err(ErrorCode::NotInProgress)
-            }
-        }
+
+            let stream = sock.connect(addr).await?;
+            Ok(stream)
+        }));
+
+        Ok(())
     }
 
-    pub(crate) fn finish_connect(
+    pub(crate) fn poll_finish_connect(
         &mut self,
-        result: io::Result<tokio::net::TcpStream>,
-    ) -> Result<(), ErrorCode> {
-        if !matches!(self.tcp_state, TcpState::Connecting(None)) {
-            return Err(ErrorCode::InvalidState);
+        cx: &mut std::task::Context<'_>,
+    ) -> Poll<Result<(), ErrorCode>> {
+        match &mut self.tcp_state {
+            TcpState::Connecting(connect) => {
+                ready!(with_ambient_tokio_runtime(|| connect.poll_ready(cx)));
+            }
+            TcpState::Connected { .. } => return Poll::Ready(Ok(())),
+            TcpState::Closed(e) => return Poll::Ready(Err(*e)),
+            _ => return Poll::Ready(Err(ErrorCode::InvalidState)),
         }
-        match result {
+        let TcpState::Connecting(connect) = self.tcp_state.take() else {
+            unreachable!();
+        };
+
+        match connect.unwrap_ready() {
             Ok(stream) => {
                 self.tcp_state = TcpState::connected(stream);
-                Ok(())
+                Poll::Ready(Ok(()))
             }
             Err(err) => {
-                self.tcp_state = TcpState::Closed;
-                Err(ErrorCode::from(err))
+                self.tcp_state = TcpState::Closed(err);
+                Poll::Ready(Err(err))
             }
         }
     }
 
-    /// Start listening using p2 semantics. (no implicit bind)
-    pub(crate) fn start_listen(&mut self) -> Result<(), ErrorCode> {
-        match mem::replace(&mut self.tcp_state, TcpState::Closed) {
-            TcpState::Bound(tokio_socket) => {
-                self.tcp_state = TcpState::ListenStarted(tokio_socket);
-                Ok(())
-            }
-            previous_state => {
-                self.tcp_state = previous_state;
-                Err(ErrorCode::InvalidState)
-            }
-        }
-    }
-
-    pub(crate) fn finish_listen(&mut self) -> Result<(), ErrorCode> {
-        let tokio_socket = match mem::replace(&mut self.tcp_state, TcpState::Closed) {
-            TcpState::ListenStarted(tokio_socket) => tokio_socket,
-            previous_state => {
-                self.tcp_state = previous_state;
-                return Err(ErrorCode::NotInProgress);
+    pub(crate) async fn listen(&mut self) -> Result<TcpListenStream, ErrorCode> {
+        let already_bound = self.is_bound();
+        let sock = match self.tcp_state.take() {
+            TcpState::Default(sock) => sock,
+            tcp_state => {
+                self.tcp_state = tcp_state;
+                return Err(ErrorCode::InvalidState);
             }
         };
 
-        self.listen_common(tokio_socket)
-    }
-
-    /// Returns whether this socket is in the bound state.
-    #[cfg(feature = "p3")]
-    pub(crate) fn is_bound(&self) -> bool {
-        match &self.tcp_state {
-            TcpState::Bound(_) => true,
-            _ => false,
-        }
-    }
-
-    fn listen_common(&mut self, tokio_socket: tokio::net::TcpSocket) -> Result<(), ErrorCode> {
-        match with_ambient_tokio_runtime(|| tokio_socket.listen(self.listen_backlog_size)) {
-            Ok(listener) => {
-                self.tcp_state = TcpState::Listening {
-                    listener: Arc::new(listener),
-                    pending_accept: None,
-                };
-                Ok(())
+        // Perform all checks before doing any syscalls.
+        {
+            if already_bound {
+                self.permissions
+                    .check(sock.local_addr()?, SocketAddrUse::TcpListen)
+                    .await?;
+            } else {
+                let implicit = unspecified_addr(self.family);
+                self.permissions
+                    .check(implicit, SocketAddrUse::TcpBind)
+                    .await?;
+                self.permissions
+                    .check(implicit, SocketAddrUse::TcpListen)
+                    .await?;
             }
-            Err(err) => {
-                self.tcp_state = TcpState::Closed;
+        }
 
-                Err(match Errno::from_io_error(&err) {
-                    // See: https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-listen#:~:text=WSAEMFILE
-                    // According to the docs, `listen` can return EMFILE on Windows.
-                    // This is odd, because we're not trying to create a new socket
-                    // or file descriptor of any kind. So we rewrite it to less
-                    // surprising error code.
-                    //
-                    // At the time of writing, this behavior has never been experimentally
-                    // observed by any of the wasmtime authors, so we're relying fully
-                    // on Microsoft's documentation here.
-                    #[cfg(windows)]
-                    Some(Errno::MFILE) => Errno::NOBUFS.into(),
+        // Some platforms automatically perform an implicit bind as part of
+        // the `listen` syscall. However this is not ubiquitous behavior:
+        // - Linux mentions it in their docs [0] that they perform an
+        //   implicit bind. This behavior has been experimentally verified.
+        // - Windows requires a `bind` before `listen`. This is both
+        //   documented [1] and experimentally verified.
+        // - Other platforms (e.g. macOS, FreeBSD) do not explicitly
+        //   document it either way and instead leave it up to the
+        //   individual protocol to decide [2]. However, experiments
+        //   show that MacOS in fact _does_ perform an implicit bind.
+        //
+        // Thus to ensure consistent behavior across all platforms, we
+        // perform the implicit bind ourselves here for unbound sockets.
+        //
+        // [0]: https://man7.org/linux/man-pages/man7/ip.7.html
+        // > An ephemeral port is allocated to a socket in the following
+        // > circumstances: (...) listen(2) is called on a stream socket
+        // > that was not previously bound;
+        //
+        // [1]: https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-listen
+        // > WSAEINVAL: The socket has not been bound with bind.
+        //
+        // [2]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/listen.html
+        // > EDESTADDRREQ: The socket is not bound to a local address,
+        // > and the protocol does not support listening on an unbound
+        // > socket.
+        if !already_bound {
+            let implicit = unspecified_addr(self.family);
+            tcp_bind(&sock, implicit)?;
+        }
 
-                    _ => err.into(),
+        let listener = sock.listen(self.listen_backlog_size).map_err(|err| {
+            match Errno::from_io_error(&err) {
+                // See: https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-listen#:~:text=WSAEMFILE
+                // According to the docs, `listen` can return EMFILE on Windows.
+                // This is odd, because we're not trying to create a new socket
+                // or file descriptor of any kind. So we rewrite it to less
+                // surprising error code.
+                //
+                // At the time of writing, this behavior has never been experimentally
+                // observed by any of the wasmtime authors, so we're relying fully
+                // on Microsoft's documentation here.
+                #[cfg(windows)]
+                Some(Errno::MFILE) => Errno::NOBUFS.into(),
+
+                _ => err,
+            }
+        })?;
+        let listener = Arc::new(listener);
+        self.tcp_state = TcpState::Listening(listener.clone());
+
+        Ok(TcpListenStream {
+            inner: listener,
+            listener_options: self.listener_options.clone(),
+            family: self.family,
+            permissions: self.permissions.clone(),
+            pending_accept: None,
+        })
+    }
+
+    pub(crate) fn take_send_stream(&mut self) -> Result<TcpSendStream, ErrorCode> {
+        match &mut self.tcp_state {
+            TcpState::Connected {
+                stream, send_taken, ..
+            } if !*send_taken => {
+                *send_taken = true;
+                Ok(TcpSendStream {
+                    inner: stream.clone(),
                 })
             }
+            TcpState::Closed(err) => Err(*err),
+            _ => Err(ErrorCode::InvalidState),
         }
     }
 
-    pub(crate) fn accept(&mut self) -> Result<Option<Self>, ErrorCode> {
-        let TcpState::Listening {
-            listener,
-            pending_accept,
-        } = &mut self.tcp_state
-        else {
-            return Err(ErrorCode::InvalidState);
-        };
-
-        let result = match pending_accept.take() {
-            Some(result) => result,
-            None => {
-                let mut cx = std::task::Context::from_waker(Waker::noop());
-                match with_ambient_tokio_runtime(|| listener.poll_accept(&mut cx))
-                    .map_ok(|(stream, _)| stream)
-                {
-                    Poll::Ready(result) => result,
-                    Poll::Pending => return Ok(None),
-                }
+    pub(crate) fn take_receive_stream(&mut self) -> Result<TcpReceiveStream, ErrorCode> {
+        match &mut self.tcp_state {
+            TcpState::Connected {
+                stream,
+                receive_taken,
+                ..
+            } if !*receive_taken => {
+                *receive_taken = true;
+                Ok(TcpReceiveStream {
+                    inner: stream.clone(),
+                })
             }
-        };
-
-        Ok(Some(Self::new_accept(result, &self.options, self.family)?))
+            TcpState::Closed(err) => Err(*err),
+            _ => Err(ErrorCode::InvalidState),
+        }
     }
 
-    pub(crate) fn local_address(&self) -> Result<SocketAddr, ErrorCode> {
+    pub(crate) fn local_address(&mut self) -> Result<SocketAddr, ErrorCode> {
+        if !self.is_bound() {
+            return Err(ErrorCode::InvalidState);
+        }
+
         match &self.tcp_state {
-            TcpState::Bound(socket) => Ok(socket.local_addr()?),
+            TcpState::Default(socket) => Ok(socket.local_addr()?),
+            TcpState::Connecting(_) => Err(ErrorCode::InvalidState),
             TcpState::Connected { stream, .. } => Ok(stream.local_addr()?),
-            TcpState::Listening { listener, .. } => Ok(listener.local_addr()?),
-            #[cfg(feature = "p3")]
-            TcpState::Error(err) => Err(err.into()),
-            _ => Err(ErrorCode::InvalidState),
+            TcpState::Listening(listener) => Ok(listener.local_addr()?),
+            TcpState::Closed(err) => Err(*err),
         }
     }
 
     pub(crate) fn remote_address(&self) -> Result<SocketAddr, ErrorCode> {
         match &self.tcp_state {
             TcpState::Connected { stream, .. } => Ok(stream.peer_addr()?),
-            #[cfg(feature = "p3")]
-            TcpState::Error(err) => Err(err.into()),
+            TcpState::Closed(err) => Err(*err),
             _ => Err(ErrorCode::InvalidState),
         }
     }
 
     pub(crate) fn is_listening(&self) -> bool {
-        matches!(self.tcp_state, TcpState::Listening { .. })
+        matches!(self.tcp_state, TcpState::Listening(_))
     }
 
     pub(crate) fn address_family(&self) -> SocketAddressFamily {
@@ -510,12 +417,12 @@ impl TcpSocket {
             .unwrap_or(MAX_BACKLOG)
             .clamp(MIN_BACKLOG, MAX_BACKLOG);
         match &self.tcp_state {
-            TcpState::Default(..) | TcpState::Bound(..) => {
+            TcpState::Default(..) => {
                 // Socket not listening yet. Stash value for first invocation to `listen`.
                 self.listen_backlog_size = value;
                 Ok(())
             }
-            TcpState::Listening { listener, .. } => {
+            TcpState::Listening(listener) => {
                 // Try to update the backlog by calling `listen` again.
                 // Not all platforms support this. We'll only update our own value if the OS supports changing the backlog size after the fact.
                 if rustix::net::listen(&listener, value.try_into().unwrap_or(i32::MAX)).is_err() {
@@ -524,216 +431,246 @@ impl TcpSocket {
                 self.listen_backlog_size = value;
                 Ok(())
             }
-            #[cfg(feature = "p3")]
-            TcpState::Error(err) => Err(err.into()),
+            TcpState::Closed(err) => Err(*err),
             _ => Err(ErrorCode::InvalidState),
         }
     }
 
     pub(crate) fn keep_alive_enabled(&self) -> Result<bool, ErrorCode> {
-        let fd = self.as_std_view()?;
+        let fd = self.as_fd()?;
         let v = sockopt::socket_keepalive(fd)?;
         Ok(v)
     }
 
     pub(crate) fn set_keep_alive_enabled(&self, value: bool) -> Result<(), ErrorCode> {
-        let fd = self.as_std_view()?;
+        let fd = self.as_fd()?;
         sockopt::set_socket_keepalive(fd, value)?;
         Ok(())
     }
 
     pub(crate) fn keep_alive_idle_time(&self) -> Result<u64, ErrorCode> {
-        let fd = self.as_std_view()?;
+        let fd = self.as_fd()?;
         let v = sockopt::tcp_keepidle(fd)?;
         Ok(v.as_nanos().try_into().unwrap_or(u64::MAX))
     }
 
     pub(crate) fn set_keep_alive_idle_time(&mut self, value: u64) -> Result<(), ErrorCode> {
         let value = {
-            let fd = self.as_std_view()?;
+            let fd = self.as_fd()?;
             set_keep_alive_idle_time(fd, value)?
         };
-        self.options.set_keep_alive_idle_time(value);
+        self.listener_options.set_keep_alive_idle_time(value);
         Ok(())
     }
 
     pub(crate) fn keep_alive_interval(&self) -> Result<u64, ErrorCode> {
-        let fd = self.as_std_view()?;
+        let fd = self.as_fd()?;
         let v = sockopt::tcp_keepintvl(fd)?;
         Ok(v.as_nanos().try_into().unwrap_or(u64::MAX))
     }
 
     pub(crate) fn set_keep_alive_interval(&self, value: u64) -> Result<(), ErrorCode> {
-        let fd = self.as_std_view()?;
+        let fd = self.as_fd()?;
         set_keep_alive_interval(fd, Duration::from_nanos(value))?;
         Ok(())
     }
 
     pub(crate) fn keep_alive_count(&self) -> Result<u32, ErrorCode> {
-        let fd = self.as_std_view()?;
+        let fd = self.as_fd()?;
         let v = sockopt::tcp_keepcnt(fd)?;
         Ok(v)
     }
 
     pub(crate) fn set_keep_alive_count(&self, value: u32) -> Result<(), ErrorCode> {
-        let fd = self.as_std_view()?;
+        let fd = self.as_fd()?;
         set_keep_alive_count(fd, value)?;
         Ok(())
     }
 
     pub(crate) fn hop_limit(&self) -> Result<u8, ErrorCode> {
-        let fd = self.as_std_view()?;
+        let fd = self.as_fd()?;
         let n = get_unicast_hop_limit(fd, self.family)?;
         Ok(n)
     }
 
     pub(crate) fn set_hop_limit(&mut self, value: u8) -> Result<(), ErrorCode> {
         {
-            let fd = self.as_std_view()?;
+            let fd = self.as_fd()?;
             set_unicast_hop_limit(fd, self.family, value)?;
         }
-        self.options.set_hop_limit(value);
+        self.listener_options.set_hop_limit(value);
         Ok(())
     }
 
     pub(crate) fn receive_buffer_size(&self) -> Result<u64, ErrorCode> {
-        let fd = self.as_std_view()?;
+        let fd = self.as_fd()?;
         let n = receive_buffer_size(fd)?;
         Ok(n)
     }
 
     pub(crate) fn set_receive_buffer_size(&mut self, value: u64) -> Result<(), ErrorCode> {
         let res = {
-            let fd = self.as_std_view()?;
+            let fd = self.as_fd()?;
             set_receive_buffer_size(fd, value)?
         };
-        self.options.set_receive_buffer_size(res);
+        self.listener_options.set_receive_buffer_size(res);
         Ok(())
     }
 
     pub(crate) fn send_buffer_size(&self) -> Result<u64, ErrorCode> {
-        let fd = self.as_std_view()?;
+        let fd = self.as_fd()?;
         let n = send_buffer_size(fd)?;
         Ok(n)
     }
 
     pub(crate) fn set_send_buffer_size(&mut self, value: u64) -> Result<(), ErrorCode> {
         let res = {
-            let fd = self.as_std_view()?;
+            let fd = self.as_fd()?;
             set_send_buffer_size(fd, value)?
         };
-        self.options.set_send_buffer_size(res);
+        self.listener_options.set_send_buffer_size(res);
         Ok(())
     }
+}
 
-    #[cfg(feature = "p3")]
-    pub(crate) fn non_inherited_options(&self) -> &NonInheritedOptions {
-        &self.options
-    }
-
-    #[cfg(feature = "p3")]
-    pub(crate) fn tcp_listener_arc(&self) -> Result<&Arc<tokio::net::TcpListener>, ErrorCode> {
-        match &self.tcp_state {
-            TcpState::Listening { listener, .. } => Ok(listener),
-            #[cfg(feature = "p3")]
-            TcpState::Error(err) => Err(err.into()),
-            _ => Err(ErrorCode::InvalidState),
-        }
-    }
-
-    pub(crate) fn take_receive_stream(&mut self) -> Result<Arc<tokio::net::TcpStream>, ErrorCode> {
-        self.take_stream(|s| &mut s.receive)
-    }
-
-    pub(crate) fn take_send_stream(&mut self) -> Result<Arc<tokio::net::TcpStream>, ErrorCode> {
-        self.take_stream(|s| &mut s.send)
-    }
-
-    fn take_stream(
-        &mut self,
-        direction: impl FnOnce(&mut TakenStreams) -> &mut bool,
-    ) -> Result<Arc<tokio::net::TcpStream>, ErrorCode> {
-        match &mut self.tcp_state {
-            TcpState::Connected {
-                stream,
-                taken_streams,
-                ..
-            } => {
-                let taken = direction(taken_streams);
-                if *taken {
-                    return Err(ErrorCode::InvalidState);
+pub(crate) struct TcpListenStream {
+    inner: Arc<tokio::net::TcpListener>,
+    family: SocketAddressFamily,
+    listener_options: NonInheritedOptions,
+    permissions: SocketAddrCheck,
+    pending_accept: Option<MaybeReady<Result<tokio::net::TcpStream, ErrorCode>>>,
+}
+impl TcpListenStream {
+    pub(crate) fn poll_accept(&mut self, cx: &mut std::task::Context<'_>) -> Poll<TcpSocket> {
+        ready!(self.poll_ready(cx));
+        let result = self.pending_accept.take().unwrap().unwrap_ready();
+        Poll::Ready(TcpSocket {
+            tcp_state: match result {
+                Ok(client) => {
+                    self.listener_options.apply(self.family, &client);
+                    TcpState::connected(client)
                 }
-                *taken = true;
-                Ok(stream.clone())
-            }
-            #[cfg(feature = "p3")]
-            TcpState::Error(err) => Err((&*err).into()),
-            _ => Err(ErrorCode::InvalidState),
-        }
+                Err(err) => TcpState::Closed(err),
+            },
+            listen_backlog_size: DEFAULT_TCP_BACKLOG,
+            family: self.family,
+            is_bound: true,
+            listener_options: Default::default(),
+            permissions: self.permissions.clone(),
+        })
     }
 
-    pub(crate) fn p2_streaming_state(&self) -> Result<&P2TcpStreamingState, ErrorCode> {
-        match &self.tcp_state {
-            TcpState::Connected {
-                p2_state: Some(state),
-                ..
-            } => Ok(state),
-            #[cfg(feature = "p3")]
-            TcpState::Error(err) => Err(err.into()),
-            _ => Err(ErrorCode::InvalidState),
+    pub(crate) fn poll_ready(&mut self, cx: &mut std::task::Context<'_>) -> Poll<()> {
+        if self.pending_accept.is_none() {
+            let listener = self.inner.clone();
+            let permissions = self.permissions.clone();
+
+            self.pending_accept = Some(MaybeReady::new(async move {
+                loop {
+                    match tcp_accept(&listener).await {
+                        Ok((client, addr)) => {
+                            if permissions
+                                .check(addr, SocketAddrUse::TcpAccept)
+                                .await
+                                .is_ok()
+                            {
+                                return Ok(client);
+                            } else {
+                                tcp_reset(client);
+                                continue;
+                            }
+                        }
+                        Err(err) => {
+                            return Err(err.into());
+                        }
+                    }
+                }
+            }));
         }
+
+        with_ambient_tokio_runtime(|| self.pending_accept.as_mut().unwrap().poll_ready(cx))
+    }
+}
+
+pub(crate) struct TcpSendStream {
+    inner: Arc<tokio::net::TcpStream>,
+}
+impl TcpSendStream {
+    pub(crate) fn poll_ready(&mut self, cx: &mut std::task::Context<'_>) -> Poll<()> {
+        self.inner.poll_write_ready(cx).map(|_| ())
     }
 
-    pub(crate) fn set_p2_streaming_state(
+    pub(crate) fn poll_write(
         &mut self,
-        state: P2TcpStreamingState,
-    ) -> Result<(), ErrorCode> {
-        if let TcpState::Connected { p2_state, .. } = &mut self.tcp_state {
-            *p2_state = Some(state);
-            Ok(())
-        } else {
-            Err(ErrorCode::InvalidState)
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, ErrorCode>> {
+        loop {
+            return match self.inner.try_write(buf) {
+                Ok(n) => Poll::Ready(Ok(n)),
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    match self.inner.poll_write_ready(cx) {
+                        Poll::Ready(Ok(())) => continue,
+                        Poll::Ready(Err(e)) => Poll::Ready(Err(e.into())),
+                        Poll::Pending => Poll::Pending,
+                    }
+                }
+                Err(e) => Poll::Ready(Err(match Errno::from_io_error(&e) {
+                    #[cfg(windows)]
+                    Some(Errno::SHUTDOWN) | Some(Errno::CONNABORTED) => ErrorCode::ConnectionBroken,
+                    #[cfg(not(windows))]
+                    Some(Errno::PIPE) => ErrorCode::ConnectionBroken,
+
+                    _ => e.into(),
+                })),
+            };
         }
     }
+    pub(crate) async fn write(&mut self, buf: &[u8]) -> Result<usize, ErrorCode> {
+        poll_fn(|cx| self.poll_write(cx, buf)).await
+    }
+}
+impl Drop for TcpSendStream {
+    fn drop(&mut self) {
+        _ = shutdown(&self.inner, Shutdown::Write);
+    }
+}
 
-    /// Used for `Pollable` in the WASIp2 implementation this awaits the socket
-    /// to be connected, if in the connecting state, or for a TCP accept to be
-    /// ready, if this is in the listening state.
-    ///
-    /// For all other states this method immediately returns.
-    pub(crate) async fn ready(&mut self) {
-        match &mut self.tcp_state {
-            TcpState::Default(..)
-            | TcpState::BindStarted(..)
-            | TcpState::Bound(..)
-            | TcpState::ListenStarted(..)
-            | TcpState::ConnectReady(..)
-            | TcpState::Closed
-            | TcpState::Connected { .. }
-            | TcpState::Connecting(None)
-            | TcpState::Listening {
-                pending_accept: Some(_),
-                ..
-            } => {}
+pub(crate) struct TcpReceiveStream {
+    inner: Arc<tokio::net::TcpStream>,
+}
+impl TcpReceiveStream {
+    pub(crate) fn poll_ready(&mut self, cx: &mut std::task::Context<'_>) -> Poll<()> {
+        self.inner.poll_read_ready(cx).map(|_| ())
+    }
 
-            #[cfg(feature = "p3")]
-            TcpState::Error(_) => {}
-
-            TcpState::Connecting(Some(future)) => {
-                self.tcp_state = TcpState::ConnectReady(future.as_mut().await);
-            }
-
-            TcpState::Listening {
-                listener,
-                pending_accept: slot @ None,
-            } => {
-                let result = futures::future::poll_fn(|cx| {
-                    listener.poll_accept(cx).map_ok(|(stream, _)| stream)
-                })
-                .await;
-                *slot = Some(result);
-            }
+    pub(crate) fn poll_read(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<Result<usize, ErrorCode>> {
+        if buf.is_empty() {
+            return Poll::Ready(Ok(0));
         }
+        loop {
+            return match self.inner.try_read(buf) {
+                Ok(0) => Poll::Ready(Ok(0)),
+                Ok(n) => Poll::Ready(Ok(n)),
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    match self.inner.poll_read_ready(cx) {
+                        Poll::Ready(Ok(())) => continue,
+                        Poll::Ready(Err(e)) => Poll::Ready(Err(e.into())),
+                        Poll::Pending => Poll::Pending,
+                    }
+                }
+                Err(e) => Poll::Ready(Err(e.into())),
+            };
+        }
+    }
+}
+impl Drop for TcpReceiveStream {
+    fn drop(&mut self) {
+        _ = shutdown(&self.inner, Shutdown::Read);
     }
 }
 
@@ -833,21 +770,6 @@ mod does_not_inherit_options {
                 // Ignore potential error.
                 _ = sockopt::set_tcp_keepidle(&stream, Duration::from_nanos(keep_alive_idle_time));
             }
-        }
-    }
-}
-enum StdView<'a> {
-    Socket(&'a tokio::net::TcpSocket),
-    Stream(&'a tokio::net::TcpStream),
-    Listener(&'a tokio::net::TcpListener),
-}
-
-impl rustix::fd::AsFd for StdView<'_> {
-    fn as_fd(&self) -> rustix::fd::BorrowedFd<'_> {
-        match self {
-            StdView::Socket(socket) => socket.as_fd(),
-            StdView::Stream(stream) => stream.as_fd(),
-            StdView::Listener(listener) => listener.as_fd(),
         }
     }
 }

--- a/crates/wasi/src/sockets/udp.rs
+++ b/crates/wasi/src/sockets/udp.rs
@@ -2,37 +2,15 @@ use crate::runtime::with_ambient_tokio_runtime;
 use crate::sockets::util::{
     ErrorCode, get_unicast_hop_limit, is_valid_address_family, is_valid_remote_address,
     receive_buffer_size, send_buffer_size, set_receive_buffer_size, set_send_buffer_size,
-    set_unicast_hop_limit, udp_bind, udp_connect, udp_disconnect, udp_socket,
+    set_unicast_hop_limit, udp_bind, udp_connect, udp_disconnect, udp_socket, unspecified_addr,
 };
-use crate::sockets::{SocketAddrCheck, SocketAddressFamily, WasiSocketsCtx};
+use crate::sockets::{
+    MAX_UDP_DATAGRAM_SIZE, SocketAddrCheck, SocketAddrUse, SocketAddressFamily, WasiSocketsCtx,
+};
 use rustix::io::Errno;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tracing::debug;
-
-/// The state of a UDP socket.
-///
-/// This represents the various states a socket can be in during the
-/// activities of binding, and connecting.
-enum UdpState {
-    /// The initial state for a newly-created socket.
-    Default,
-
-    /// A `bind` operation has started but has yet to complete with
-    /// `finish_bind`.
-    BindStarted,
-
-    /// Binding finished via `finish_bind`. The socket has an address but
-    /// is not yet listening for connections.
-    Bound,
-
-    /// The socket is "connected" to a peer address.
-    #[cfg_attr(
-        not(feature = "p3"),
-        expect(dead_code, reason = "p2 has its own way of managing sending/receiving")
-    )]
-    Connected(SocketAddr),
-}
 
 /// A host UDP socket, plus associated bookkeeping.
 ///
@@ -40,216 +18,265 @@ enum UdpState {
 /// used for implementing the stream types.
 pub struct UdpSocket {
     socket: Arc<tokio::net::UdpSocket>,
-
-    /// The current state in the bind/connect progression.
-    udp_state: UdpState,
-
-    /// Socket address family.
     family: SocketAddressFamily,
 
-    /// If set, use this custom check for addrs, otherwise use what's in
-    /// `WasiSocketsCtx`.
-    socket_addr_check: Option<SocketAddrCheck>,
+    /// The checks to perform before doing any noteworthy syscall.
+    permissions: SocketAddrCheck,
+
+    /// Cached value of whether the socket is bound. This is cached to avoid
+    /// redundant syscalls in every `send` & `receive`.
+    is_bound: bool,
+
+    /// Cached value of the remote address. This is cached to avoid redundant
+    /// syscalls in every `send`.
+    remote_addr: Option<SocketAddr>,
 }
 
 impl UdpSocket {
     /// Create a new socket in the given family.
-    pub(crate) fn new(cx: &WasiSocketsCtx, family: SocketAddressFamily) -> Result<Self, ErrorCode> {
+    pub(crate) async fn new(
+        cx: &WasiSocketsCtx,
+        family: SocketAddressFamily,
+    ) -> Result<Self, ErrorCode> {
         cx.allowed_network_uses.check_allowed_udp()?;
 
-        let fd = udp_socket(family)?;
-
-        if family == SocketAddressFamily::Ipv6 {
-            rustix::net::sockopt::set_ipv6_v6only(&fd, true)?;
-        }
-
         let socket = with_ambient_tokio_runtime(|| {
+            // Manually construct a new socket, because neither std nor tokio
+            // provides a way to create an unbound UDP socket.
+            let fd = udp_socket(family)?;
+            if family == SocketAddressFamily::Ipv6 {
+                rustix::net::sockopt::set_ipv6_v6only(&fd, true)?;
+            }
             tokio::net::UdpSocket::try_from(std::net::UdpSocket::from(fd))
         })?;
 
+        // Native UDP sockets are immediately writable after creation and
+        // existing guest code out in the wild depends on that. However, due to
+        // the way Tokio is structured internally, a newly created Tokio socket
+        // starts out as "not writable" and a background tokio thread updates
+        // this state asynchronously soon after. Some more info in this thread:
+        // https://github.com/bytecodealliance/wasmtime/issues/12612#issuecomment-3923714174
+        //
+        // To prevent exposing guests to this race condition, we wait for Tokio
+        // to finish its internal setup:
+        socket.writable().await?;
+
         Ok(Self {
             socket: Arc::new(socket),
-            udp_state: UdpState::Default,
+            is_bound: false,
+            remote_addr: None,
+            permissions: cx.socket_addr_check.clone(),
             family,
-            socket_addr_check: None,
         })
     }
 
-    pub(crate) fn bind(&mut self, addr: SocketAddr) -> Result<(), ErrorCode> {
-        if !matches!(self.udp_state, UdpState::Default) {
+    pub(crate) fn is_bound(&mut self) -> bool {
+        // Once bound, a UDP socket can never become unbound again. So we can
+        // skip all work after a previous call has already determined the
+        // socket to be bound.
+        if !self.is_bound {
+            self.is_bound = self
+                .socket
+                .local_addr()
+                .is_ok_and(|addr| addr != unspecified_addr(self.family));
+        }
+        self.is_bound
+    }
+
+    pub(crate) fn local_address(&mut self) -> Result<SocketAddr, ErrorCode> {
+        if !self.is_bound() {
+            return Err(ErrorCode::InvalidState);
+        }
+        self.socket.local_addr().map_err(|e| e.into())
+    }
+
+    pub(crate) fn remote_address(&mut self) -> Result<SocketAddr, ErrorCode> {
+        self.remote_addr.ok_or(ErrorCode::InvalidState)
+    }
+
+    pub(crate) fn is_connected(&mut self) -> bool {
+        self.remote_addr.is_some()
+    }
+
+    pub(crate) async fn bind(&mut self, addr: SocketAddr) -> Result<(), ErrorCode> {
+        if self.is_bound() {
             return Err(ErrorCode::InvalidState);
         }
         if !is_valid_address_family(addr.ip(), self.family) {
             return Err(ErrorCode::InvalidArgument);
         }
+
+        self.permissions.check(addr, SocketAddrUse::UdpBind).await?;
+
         udp_bind(&self.socket, addr)?;
-        self.udp_state = UdpState::BindStarted;
         Ok(())
     }
 
-    pub(crate) fn finish_bind(&mut self) -> Result<(), ErrorCode> {
-        match self.udp_state {
-            UdpState::BindStarted => {
-                self.udp_state = UdpState::Bound;
-                Ok(())
-            }
-            _ => Err(ErrorCode::NotInProgress),
+    pub(crate) async fn connect(&mut self, addr: SocketAddr) -> Result<(), ErrorCode> {
+        if !is_valid_address_family(addr.ip(), self.family) || !is_valid_remote_address(addr) {
+            return Err(ErrorCode::InvalidArgument);
         }
-    }
 
-    pub(crate) fn is_connected(&self) -> bool {
-        matches!(self.udp_state, UdpState::Connected(..))
-    }
+        // Perform all permission checks before doing any syscalls.
+        {
+            if !self.is_bound() {
+                // If not explicitly bound, the OS will implicitly bind the
+                // socket to an ephemeral port when connecting.
+                let implicit_bind_addr = unspecified_addr(self.family);
+                self.permissions
+                    .check(implicit_bind_addr, SocketAddrUse::UdpBind)
+                    .await?;
+            }
 
-    pub(crate) fn is_bound(&self) -> bool {
-        matches!(self.udp_state, UdpState::Connected(..) | UdpState::Bound)
+            // On UDP sockets, "connecting" is just a local operation that sets the
+            // default remote address for future sends and receives. It does not
+            // actually do any I/O on its own. We'll allow the `connect` call
+            // if the address is permitted for sending or receiving.
+            if self
+                .permissions
+                .check(addr, SocketAddrUse::UdpSend)
+                .await
+                .is_err()
+            {
+                self.permissions
+                    .check(addr, SocketAddrUse::UdpReceive)
+                    .await?;
+            }
+        }
+
+        let result = udp_connect(&self.socket, addr).map_err(|e| match e {
+            // The most common reason for AFNOSUPPORT is an invalid address
+            // family. This should have already been handled by our own
+            // validation slightly higher up in this function. This error
+            // mapping is here just in case there is an edge case we didn't catch.
+            Errno::AFNOSUPPORT => ErrorCode::InvalidArgument,
+            Errno::INPROGRESS => {
+                debug!("UDP connect returned EINPROGRESS, which should never happen");
+                ErrorCode::Other
+            }
+            err => err.into(),
+        });
+        self.update_remote_address();
+        result
     }
 
     pub(crate) fn disconnect(&mut self) -> Result<(), ErrorCode> {
         if !self.is_connected() {
             return Err(ErrorCode::InvalidState);
         }
-        udp_disconnect(&self.socket)?;
-        self.udp_state = UdpState::Bound;
-        Ok(())
+
+        // On Linux, disconnecting a UDP socket relinquishes its local port
+        // assignment in some cases. If the socket was bound to the wildcard
+        // address, its local address will then read `0.0.0.0:0` or `[::]:0`
+        // which is indistinguishable from an unbound socket. To ensure
+        // `is_bound()` will continue to return `true` after the disconnect, we
+        // manually settle the `is_bound` state here:
+        self.is_bound = true;
+
+        let result = udp_disconnect(&self.socket).map_err(|e| e.into());
+        self.update_remote_address();
+        result
     }
 
-    /// Connect using p2 semantics. (no implicit bind)
-    pub(crate) fn connect_p2(&mut self, addr: SocketAddr) -> Result<(), ErrorCode> {
-        match self.udp_state {
-            UdpState::Bound | UdpState::Connected(_) => {}
-            _ => return Err(ErrorCode::InvalidState),
-        }
-
-        self.connect_common(addr)
-    }
-
-    /// Connect using p3 semantics. (with implicit bind)
-    #[cfg(feature = "p3")]
-    pub(crate) fn connect_p3(&mut self, addr: SocketAddr) -> Result<(), ErrorCode> {
-        match self.udp_state {
-            UdpState::Default | UdpState::Bound | UdpState::Connected(_) => {}
-            _ => return Err(ErrorCode::InvalidState),
-        }
-
-        self.connect_common(addr)
-    }
-
-    fn connect_common(&mut self, addr: SocketAddr) -> Result<(), ErrorCode> {
-        if !is_valid_address_family(addr.ip(), self.family) || !is_valid_remote_address(addr) {
-            return Err(ErrorCode::InvalidArgument);
-        }
-
-        match udp_connect(&self.socket, addr) {
-            Ok(()) => {
-                self.udp_state = UdpState::Connected(addr);
-                Ok(())
-            }
-            Err(e) => {
-                // Revert to a consistent state:
-                _ = udp_disconnect(&self.socket);
-                self.udp_state = UdpState::Bound;
-
-                Err(match e {
-                    Errno::AFNOSUPPORT => ErrorCode::InvalidArgument, // See `udp_bind` implementation.
-                    Errno::INPROGRESS => {
-                        debug!("UDP connect returned EINPROGRESS, which should never happen");
-                        ErrorCode::Unknown
-                    }
-                    err => err.into(),
-                })
-            }
+    /// Update our internal bookkeeping based on the actual state of the socket.
+    /// This should be called after any operation that may change the remote
+    /// address.
+    fn update_remote_address(&mut self) {
+        self.remote_addr = if let Ok(addr) = self.socket.peer_addr()
+            && addr != unspecified_addr(self.family)
+        {
+            Some(addr)
+        } else {
+            None
         }
     }
 
-    /// Send data using p3 semantics. (with implicit bind)
-    #[cfg(feature = "p3")]
-    pub(crate) fn send_p3(
+    pub(crate) fn send(
         &mut self,
-        buf: Vec<u8>,
+        data: Vec<u8>,
         addr: Option<SocketAddr>,
-    ) -> impl Future<Output = Result<(), ErrorCode>> + use<> {
-        enum Mode {
-            Send(Arc<tokio::net::UdpSocket>),
-            SendTo(Arc<tokio::net::UdpSocket>, SocketAddr),
-        }
-        let socket = match (&self.udp_state, addr) {
-            (UdpState::BindStarted, _) | (UdpState::Default, Some(_)) => {
-                Err(ErrorCode::InvalidState)
-            }
-            (UdpState::Bound | UdpState::Default, None) => Err(ErrorCode::InvalidArgument),
-            (UdpState::Bound, Some(addr)) => {
-                if is_valid_remote_address(addr) && is_valid_address_family(addr.ip(), self.family)
-                {
-                    Ok(Mode::SendTo(Arc::clone(&self.socket), addr))
-                } else {
-                    Err(ErrorCode::InvalidArgument)
-                }
-            }
-            (UdpState::Connected(..), None) => Ok(Mode::Send(Arc::clone(&self.socket))),
-            (UdpState::Connected(caddr), Some(addr)) => {
-                if addr == *caddr {
-                    Ok(Mode::Send(Arc::clone(&self.socket)))
-                } else {
-                    Err(ErrorCode::InvalidArgument)
-                }
-            }
-        };
+    ) -> impl Future<Output = Result<(), ErrorCode>> + Send + use<> {
+        let family = self.family;
+        let socket = self.socket.clone();
+        let permissions = self.permissions.clone();
+        let connected_addr = self.remote_address().ok();
+        let is_bound = self.is_bound();
 
         async move {
-            match socket? {
-                Mode::Send(socket) => send(&socket, &buf).await,
-                Mode::SendTo(socket, addr) => send_to(&socket, &buf, addr).await,
+            if data.len() > MAX_UDP_DATAGRAM_SIZE {
+                return Err(ErrorCode::DatagramTooLarge);
             }
-        }
-    }
 
-    /// Receive data using p3 semantics.
-    #[cfg(feature = "p3")]
-    pub(crate) fn receive_p3(
-        &self,
-    ) -> impl Future<Output = Result<(Vec<u8>, SocketAddr), ErrorCode>> + use<> {
-        enum Mode {
-            Recv(Arc<tokio::net::UdpSocket>, SocketAddr),
-            RecvFrom(Arc<tokio::net::UdpSocket>),
-        }
-        let socket = match self.udp_state {
-            UdpState::Default | UdpState::BindStarted => Err(ErrorCode::InvalidState),
-            UdpState::Bound => Ok(Mode::RecvFrom(Arc::clone(&self.socket))),
-            UdpState::Connected(addr) => Ok(Mode::Recv(Arc::clone(&self.socket), addr)),
-        };
-        async move {
-            let socket = socket?;
-            let mut buf = vec![0; super::MAX_UDP_DATAGRAM_SIZE];
-            let (n, addr) = match socket {
-                Mode::Recv(socket, addr) => {
-                    let n = socket.recv(&mut buf).await?;
-                    (n, addr)
+            let effective_addr = if let Some(addr) = addr {
+                if !is_valid_remote_address(addr) || !is_valid_address_family(addr.ip(), family) {
+                    return Err(ErrorCode::InvalidArgument);
                 }
-                Mode::RecvFrom(socket) => {
-                    let (n, addr) = socket.recv_from(&mut buf).await?;
-                    (n, addr)
+
+                // If the socket is connected, the provided address must match the
+                // connected address.
+                if connected_addr.is_some() && connected_addr != Some(addr) {
+                    return Err(ErrorCode::InvalidArgument);
                 }
+
+                addr
+            } else if let Some(connected_addr) = connected_addr {
+                connected_addr
+            } else {
+                return Err(ErrorCode::InvalidArgument);
             };
-            buf.truncate(n);
-            Ok((buf, addr))
+
+            // Perform all permission checks before doing any syscalls.
+            {
+                if !is_bound {
+                    // If not explicitly bound, the OS will implicitly bind the
+                    // socket to an ephemeral port when sending.
+                    let implicit_bind_addr = unspecified_addr(family);
+                    permissions
+                        .check(implicit_bind_addr, SocketAddrUse::UdpBind)
+                        .await?;
+                }
+
+                permissions
+                    .check(effective_addr, SocketAddrUse::UdpSend)
+                    .await?;
+            }
+
+            if connected_addr == Some(effective_addr) {
+                socket.send(&data).await?;
+            } else {
+                socket.send_to(&data, effective_addr).await?;
+            }
+
+            Ok(())
         }
     }
 
-    pub(crate) fn local_address(&self) -> Result<SocketAddr, ErrorCode> {
-        if matches!(self.udp_state, UdpState::Default | UdpState::BindStarted) {
-            return Err(ErrorCode::InvalidState);
-        }
-        let addr = self.socket.local_addr()?;
-        Ok(addr)
-    }
+    pub(crate) fn recv(
+        &mut self,
+    ) -> impl Future<Output = Result<(Vec<u8>, SocketAddr), ErrorCode>> + Send + use<> {
+        let socket = self.socket.clone();
+        let permissions = self.permissions.clone();
+        let is_bound = self.is_bound();
 
-    pub(crate) fn remote_address(&self) -> Result<SocketAddr, ErrorCode> {
-        if !matches!(self.udp_state, UdpState::Connected(..)) {
-            return Err(ErrorCode::InvalidState);
+        async move {
+            if !is_bound {
+                return Err(ErrorCode::InvalidState);
+            }
+
+            loop {
+                let mut data = vec![0; super::MAX_UDP_DATAGRAM_SIZE];
+                let (len, addr) = socket.recv_from(&mut data).await?;
+                data.truncate(len);
+
+                match permissions.check(addr, SocketAddrUse::UdpReceive).await {
+                    Ok(()) => return Ok((data, addr)),
+                    Err(_) => {
+                        // Not allowed. Drop the packet and poll again.
+                        continue;
+                    }
+                }
+            }
         }
-        let addr = self.socket.peer_addr()?;
-        Ok(addr)
     }
 
     pub(crate) fn address_family(&self) -> SocketAddressFamily {
@@ -283,48 +310,6 @@ impl UdpSocket {
 
     pub(crate) fn set_send_buffer_size(&self, value: u64) -> Result<(), ErrorCode> {
         set_send_buffer_size(&self.socket, value)?;
-        Ok(())
-    }
-
-    pub(crate) fn socket(&self) -> &Arc<tokio::net::UdpSocket> {
-        &self.socket
-    }
-
-    pub(crate) fn socket_addr_check(&self) -> Option<&SocketAddrCheck> {
-        self.socket_addr_check.as_ref()
-    }
-
-    pub(crate) fn set_socket_addr_check(&mut self, check: Option<SocketAddrCheck>) {
-        self.socket_addr_check = check;
-    }
-}
-
-#[cfg(feature = "p3")]
-async fn send(socket: &tokio::net::UdpSocket, buf: &[u8]) -> Result<(), ErrorCode> {
-    let n = socket.send(buf).await?;
-    // From Rust stdlib docs:
-    // > Note that the operating system may refuse buffers larger than 65507.
-    // > However, partial writes are not possible until buffer sizes above `i32::MAX`.
-    //
-    // For example, on Windows, at most `i32::MAX` bytes will be written
-    if n != buf.len() {
-        Err(ErrorCode::Unknown)
-    } else {
-        Ok(())
-    }
-}
-
-#[cfg(feature = "p3")]
-async fn send_to(
-    socket: &tokio::net::UdpSocket,
-    buf: &[u8],
-    addr: SocketAddr,
-) -> Result<(), ErrorCode> {
-    let n = socket.send_to(buf, addr).await?;
-    // See [`send`] documentation
-    if n != buf.len() {
-        Err(ErrorCode::Unknown)
-    } else {
         Ok(())
     }
 }

--- a/crates/wasi/src/sockets/util.rs
+++ b/crates/wasi/src/sockets/util.rs
@@ -8,9 +8,8 @@ use rustix::io::Errno;
 use rustix::net::{bind, connect, connect_unspec, sockopt};
 use tracing::debug;
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum ErrorCode {
-    Unknown,
     AccessDenied,
     NotSupported,
     InvalidArgument,
@@ -21,11 +20,11 @@ pub enum ErrorCode {
     AddressInUse,
     RemoteUnreachable,
     ConnectionRefused,
+    ConnectionBroken,
     ConnectionReset,
     ConnectionAborted,
     DatagramTooLarge,
-    NotInProgress,
-    ConcurrencyConflict,
+    Other,
 }
 
 impl fmt::Display for ErrorCode {
@@ -133,9 +132,13 @@ impl From<&std::io::Error> for ErrorCode {
             std::io::ErrorKind::PermissionDenied => Self::AccessDenied,
             std::io::ErrorKind::TimedOut => Self::Timeout,
             std::io::ErrorKind::Unsupported => Self::NotSupported,
+            std::io::ErrorKind::HostUnreachable => Self::RemoteUnreachable,
+            std::io::ErrorKind::NetworkUnreachable => Self::RemoteUnreachable,
+            std::io::ErrorKind::NetworkDown => Self::RemoteUnreachable,
+            std::io::ErrorKind::BrokenPipe => Self::ConnectionBroken,
             _ => {
                 debug!("unknown I/O error: {value}");
-                Self::Unknown
+                Self::Other
             }
         }
     }
@@ -156,6 +159,8 @@ impl From<&Errno> for ErrorCode {
             Errno::ADDRINUSE => Self::AddressInUse,
             Errno::ADDRNOTAVAIL => Self::AddressNotBindable,
             Errno::TIMEDOUT => Self::Timeout,
+            #[cfg(not(windows))]
+            Errno::PIPE => Self::ConnectionBroken,
             Errno::CONNREFUSED => Self::ConnectionRefused,
             Errno::CONNRESET => Self::ConnectionReset,
             Errno::CONNABORTED => Self::ConnectionAborted,
@@ -184,7 +189,7 @@ impl From<&Errno> for ErrorCode {
             // FYI, EINPROGRESS should have already been handled by connect.
             _ => {
                 debug!("unknown I/O error: {value}");
-                Self::Unknown
+                Self::Other
             }
         }
     }
@@ -365,6 +370,52 @@ pub fn tcp_bind(
         })
 }
 
+pub async fn tcp_accept(
+    listener: &tokio::net::TcpListener,
+) -> std::io::Result<(tokio::net::TcpStream, SocketAddr)> {
+    listener
+        .accept()
+        .await
+        .map_err(|err| match Errno::from_io_error(&err) {
+            // From: https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-accept#:~:text=WSAEINPROGRESS
+            // > WSAEINPROGRESS: A blocking Windows Sockets 1.1 call is in progress,
+            // > or the service provider is still processing a callback function.
+            //
+            // wasi-sockets doesn't have an equivalent to the EINPROGRESS error,
+            // because in POSIX this error is only returned by a non-blocking
+            // `connect` and wasi-sockets has a different solution for that.
+            #[cfg(windows)]
+            Some(Errno::INPROGRESS) => Errno::INTR.into(),
+
+            // Normalize Linux' non-standard behavior.
+            //
+            // From https://man7.org/linux/man-pages/man2/accept.2.html:
+            // > Linux accept() passes already-pending network errors on the
+            // > new socket as an error code from accept(). This behavior
+            // > differs from other BSD socket implementations. (...)
+            #[cfg(target_os = "linux")]
+            Some(
+                Errno::CONNRESET
+                | Errno::NETRESET
+                | Errno::HOSTUNREACH
+                | Errno::HOSTDOWN
+                | Errno::NETDOWN
+                | Errno::NETUNREACH
+                | Errno::PROTO
+                | Errno::NOPROTOOPT
+                | Errno::NONET
+                | Errno::OPNOTSUPP,
+            ) => Errno::CONNABORTED.into(),
+
+            _ => err,
+        })
+}
+
+pub fn tcp_reset(socket: tokio::net::TcpStream) {
+    _ = socket.set_zero_linger();
+    drop(socket);
+}
+
 /// Creates a non-blocking/cloexec UDP socket.
 pub fn udp_socket(family: SocketAddressFamily) -> std::io::Result<rustix::fd::OwnedFd> {
     // Let the standard library be responsible for handling `WSAStartup`.
@@ -478,8 +529,7 @@ pub fn parse_host(name: &str) -> Result<url::Host, ErrorCode> {
     }
 }
 
-#[cfg(feature = "p3")]
-pub fn implicit_bind_addr(family: SocketAddressFamily) -> SocketAddr {
+pub fn unspecified_addr(family: SocketAddressFamily) -> SocketAddr {
     let ip = match family {
         SocketAddressFamily::Ipv4 => IpAddr::V4(Ipv4Addr::UNSPECIFIED),
         SocketAddressFamily::Ipv6 => IpAddr::V6(Ipv6Addr::UNSPECIFIED),

--- a/crates/wasi/tests/all/p2/async_.rs
+++ b/crates/wasi/tests/all/p2/async_.rs
@@ -360,6 +360,10 @@ async fn p2_udp_states() {
     run(P2_UDP_STATES_COMPONENT, |_| {}).await.unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn p2_udp_stream() {
+    run(P2_UDP_STREAM_COMPONENT, |_| {}).await.unwrap()
+}
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn p2_udp_bind() {
     run(P2_UDP_BIND_COMPONENT, |_| {}).await.unwrap()
 }

--- a/crates/wasi/tests/all/p2/sync.rs
+++ b/crates/wasi/tests/all/p2/sync.rs
@@ -334,6 +334,10 @@ fn p2_udp_states() {
     run(P2_UDP_STATES_COMPONENT, |_| {}).unwrap()
 }
 #[test_log::test]
+fn p2_udp_stream() {
+    run(P2_UDP_STREAM_COMPONENT, |_| {}).unwrap()
+}
+#[test_log::test]
 fn p2_udp_bind() {
     run(P2_UDP_BIND_COMPONENT, |_| {}).unwrap()
 }


### PR DESCRIPTION
Currently, the shared socket code (`crates/wasi/src/sockets/*`) is modeled after the
p2 interface, with p3 bindings papering over the differences. Some
functionality is duplicated between the `p2/*` and `p3/*` implementations. This has
already [caused bugs in the past](https://github.com/bytecodealliance/wasmtime/pull/13631).

Since the p3 interface is strictly a superset of p2, I think it makes more sense to invert that relationship. This PR updates the shared code to become the canonical (p3-shaped)
implementation with the p3's bindings now a thin wrapper around it. All
p2-only behavior & state is moved into the p2 bindings layer. Think of: artificial restrictions like disallowing implicit
binds, and the start/finish async bookkeeping.

Other notable changes:
- Each socket now stores its own copy of the `WasiCtx`'s
  `socket_addr_check` at creation time, allowing all permission checks to live in
  the shared socket code instead of being split across p2/p3. The p2
  `Network` resource is now just an unforgeable capability token (its
  permission-checking responsibilities are gone).
- Removed the `Bound` state; whether a socket is bound is now determined
  lazily via `getsockname`/`local_addr` instead of tracked explicitly.
  This simplifies the implementation of `UdpSocket::send`, allowing it to return a future that can run to completion independently, without needing to rendezvous back with the socket to update its state.
- Updated `SocketAddrUse`:
    - added `TcpListen`, `TcpAccept`, `UdpReceive` checks.
    - replaced `UdpConnect` with calls to `UdpSend` and `UdpReceive`. On UDP sockets, "connecting" is just a local operation that sets the default remote address for future sends and receives. It does not actually do any I/O on its own.
    - **Note to reviewer:** this is a breaking change.
- `Tcp&UdpSocket::connect` now also issue a permission
  check for the implicit bind that the OS performs when connecting an
  unbound socket, matching the check already done for explicit binds. Following through the changes of https://github.com/bytecodealliance/wasmtime/pull/13677
- Removed the `StdView` type introduced in https://github.com/bytecodealliance/wasmtime/pull/13872 infavour of direct usage of `BorrowedFd`

Added test coverage for previously-untested behavior:

- `test_udp_disconnect_local_address` (p2 & p3): disconnecting a UDP
  socket should keep it bound. Exercises the removal of the explicit `Bound`
  state in favor of lazily-derived bound status.
- `test_udp_send_receive_multiple` (p2): a single `send`/`receive` call
  can carry multiple datagrams at once (bulk send/receive over a
  connected `stream()`).
- `test_udp_receive_after_connect` (p2): datagrams from different peers
  queued before a socket is connected are correctly filtered so that
  `stream(Some(addr))` only returns datagrams from the provided address.

---

All-in-all, the goal of this PR is to consolidate the socket code (even further) into a single place and make it less error-prone to maintain. I realize there's quite a bit of unannounced code movement here, so let me know what you think.