### PR TITLE
Disallow TCP/UDP socket creation by default

### DIFF
--- a/crates/wasi-tls/tests/p2/mod.rs
+++ b/crates/wasi-tls/tests/p2/mod.rs
@@ -40,6 +40,8 @@ async fn run_test(provider: Box<dyn TlsProvider>, path: &str) -> Result<()> {
             .inherit_stderr()
             .inherit_network()
             .allow_ip_name_lookup(true)
+            .allow_tcp(true)
+            .allow_udp(true)
             .build(),
         wasi_tls_ctx: WasiTlsCtxBuilder::new().provider(provider).build(),
     };

--- a/crates/wasi-tls/tests/p3/mod.rs
+++ b/crates/wasi-tls/tests/p3/mod.rs
@@ -38,6 +38,8 @@ async fn run_test(provider: Box<dyn TlsProvider>, path: &str) -> Result<()> {
             .inherit_stderr()
             .inherit_network()
             .allow_ip_name_lookup(true)
+            .allow_tcp(true)
+            .allow_udp(true)
             .build(),
         wasi_tls_ctx: WasiTlsCtxBuilder::new().provider(provider).build(),
     };

--- a/crates/wasi/src/sockets/mod.rs
+++ b/crates/wasi/src/sockets/mod.rs
@@ -81,21 +81,11 @@ pub trait WasiSocketsView: Send {
     fn sockets(&mut self) -> WasiSocketsCtxView<'_>;
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Default)]
 pub(crate) struct AllowedNetworkUses {
     pub(crate) ip_name_lookup: bool,
     pub(crate) udp: bool,
     pub(crate) tcp: bool,
-}
-
-impl Default for AllowedNetworkUses {
-    fn default() -> Self {
-        Self {
-            ip_name_lookup: false,
-            udp: true,
-            tcp: true,
-        }
-    }
 }
 
 impl AllowedNetworkUses {

--- a/crates/wasi/tests/all/store.rs
+++ b/crates/wasi/tests/all/store.rs
@@ -48,6 +48,8 @@ impl<T> Ctx<T> {
         builder
             .args(&[name, "."])
             .inherit_network()
+            .allow_tcp(true)
+            .allow_udp(true)
             .allow_ip_name_lookup(true);
         println!("preopen: {workspace:?}");
         builder.preopened_dir(workspace.path(), ".", DirPerms::all(), FilePerms::all())?;

--- a/src/common.rs
+++ b/src/common.rs
@@ -364,6 +364,9 @@ impl RunCommon {
 
         if self.common.wasi.inherit_network == Some(true) {
             builder.inherit_network();
+            // Implicitly enable TCP/UDP if the entire network is being
+            // inherited to avoid the need to also pass `-Stcp,udp`.
+            builder.allow_tcp(true).allow_udp(true);
         }
         if let Some(enable) = self.common.wasi.allow_ip_name_lookup {
             builder.allow_ip_name_lookup(enable);

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -3008,7 +3008,7 @@ start a print 1234
 
     #[test]
     fn p3_cli_deny_listen() -> Result<()> {
-        run_wasmtime(&["run", P3_CLI_DENY_LISTEN_COMPONENT])?;
+        run_wasmtime(&["run", "-Stcp", P3_CLI_DENY_LISTEN_COMPONENT])?;
         Ok(())
     }
 }

--- a/tests/wasi.rs
+++ b/tests/wasi.rs
@@ -132,6 +132,7 @@ fn execute(path: &Path) -> Result<()> {
                 if path.iter().any(|p| p == "wasm32-wasip3") {
                     cmd.arg("-Sp3").arg("-Wcomponent-model-async");
                 }
+                cmd.arg("-Stcp,udp");
                 for proposal in proposals.as_deref().unwrap_or(&[]) {
                     match proposal {
                         WasiProposal::Sockets => {


### PR DESCRIPTION
Historically the `wasmtime-wasi` crate has allowed creation of TCP/UDP sockets by default, but disallowed addresses by default. This in theory denies all sockets by default but this is a bit of a brittle check and it feels more robust to me to just deny TCP/UDP entirely by default. Historical behavior is preserved in the CLI where `-Sinherit-network` auto-enables TCP/UDP to then get optionally shadowed by explicit `-Stcp=n` flags if specified.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
