### PR TITLE
fix `AGENTS.md` import path

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,1 +1,1 @@
-@../../AGENTS.md
+@../AGENTS.md


### PR DESCRIPTION
The `AGENTS.md` import in `CLAUDE.md` is not valid, since it refers to a path outside the repo