### PR TITLE
Update component-model spec test suite

### DIFF
--- a/crates/test-util/src/wast.rs
+++ b/crates/test-util/src/wast.rs
@@ -193,22 +193,17 @@ fn component_test_config(test: &Path) -> TestConfig {
     ret.reference_types = Some(true);
     ret.multi_memory = Some(true);
     ret.component_model_implements = Some(true);
+    ret.bulk_memory = Some(true);
+    ret.component_model_async = Some(true);
+    ret.component_model_more_async_builtins = Some(true);
+    ret.component_model_async_stackful = Some(true);
+    ret.component_model_threading = Some(true);
+
+    if test.ends_with("memory64.wast") {
+        ret.component_model_memory64 = Some(true);
+    }
 
     if let Some(parent) = test.parent() {
-        if parent.ends_with("async")
-            || [
-                "trap-in-post-return.wast",
-                "resources.wast",
-                "multiple-resources.wast",
-            ]
-            .into_iter()
-            .any(|name| Some(name) == test.file_name().and_then(|s| s.to_str()))
-        {
-            ret.component_model_async = Some(true);
-            ret.component_model_async_stackful = Some(true);
-            ret.component_model_more_async_builtins = Some(true);
-            ret.component_model_threading = Some(true);
-        }
         if parent.ends_with("wasm-tools") {
             ret.memory64 = Some(true);
             ret.threads = Some(true);
@@ -472,9 +467,8 @@ impl WastTest {
         }
 
         let unsupported = [
-            // Can be re-enabled once the tests/component-model submodule has been bumped to a commit that includes
-            // https://github.com/WebAssembly/component-model/pull/676
-            "test/wasm-tools/memory64.wast",
+            // needs to be updated after WebAssembly/component-model#680
+            "test/values/post-return.wast",
         ];
         if unsupported.iter().any(|part| self.path.ends_with(part)) {
             return true;

--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -4063,9 +4063,13 @@ impl Instance {
                         store.suspend(SuspendReason::Yielding {
                             thread: caller,
                             cancellable: false,
-                            // `subtask.cancel` is not allowed to be called in a
-                            // sync context, so we cannot skip the may-block check.
-                            skip_may_block_check: false,
+                            // We've already checked that for a sync version of
+                            // this intrinsic we're allowed to block (start of
+                            // the function here), and otherwise this is similar
+                            // to `suspension_intrinsic` where we're doing a
+                            // brief yield to deliver the event, so there's no
+                            // need to check may-block again.
+                            skip_may_block_check: true,
                         })?;
                         break;
                     } else if let GuestThreadState::Ready {
@@ -4079,7 +4083,8 @@ impl Instance {
                         store.suspend(SuspendReason::Yielding {
                             thread: caller,
                             cancellable: false,
-                            skip_may_block_check: false,
+                            // See the comment above for why this is `true`
+                            skip_may_block_check: true,
                         })?;
                         break;
                     }


### PR DESCRIPTION
* Update some required features for tests
* Flag `memory64.wast` as now-passing
* Temporarily allow `post-return.wast` to fail while #13949 and WebAssembly/component-model#680 are being aligned.
* Fix a debug assert tripping erroneously in an async `subtask.cancel` intrinsic.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
