### PR TITLE
Cranelift: simplify `DataValue::eq`

### DIFF
--- a/cranelift/codegen/src/data_value.rs
+++ b/cranelift/codegen/src/data_value.rs
@@ -32,31 +32,19 @@ impl PartialEq for DataValue {
         use DataValue::*;
         match (self, other) {
             (I8(l), I8(r)) => l == r,
-            (I8(_), _) => false,
             (I16(l), I16(r)) => l == r,
-            (I16(_), _) => false,
             (I32(l), I32(r)) => l == r,
-            (I32(_), _) => false,
             (I64(l), I64(r)) => l == r,
-            (I64(_), _) => false,
             (I128(l), I128(r)) => l == r,
-            (I128(_), _) => false,
             (F16(l), F16(r)) => l.partial_cmp(&r) == Some(Ordering::Equal),
-            (F16(_), _) => false,
             (F32(l), F32(r)) => l.as_f32() == r.as_f32(),
-            (F32(_), _) => false,
             (F64(l), F64(r)) => l.as_f64() == r.as_f64(),
-            (F64(_), _) => false,
             (F128(l), F128(r)) => l.partial_cmp(&r) == Some(Ordering::Equal),
-            (F128(_), _) => false,
             (V128(l), V128(r)) => l == r,
-            (V128(_), _) => false,
             (V64(l), V64(r)) => l == r,
-            (V64(_), _) => false,
             (V32(l), V32(r)) => l == r,
-            (V32(_), _) => false,
             (V16(l), V16(r)) => l == r,
-            (V16(_), _) => false,
+            _ => false
         }
     }
 }


### PR DESCRIPTION
This simplifies the `PartialEq` implementation for `DataValue` by replacing the repeated `... => false` match arms with a single wildcard arm.

No functional changes intended.
