### PR TITLE
feat: allow Wizer context reuse

### DIFF
--- a/crates/wizer/src/component.rs
+++ b/crates/wizer/src/component.rs
@@ -34,15 +34,15 @@ impl Wizer {
     /// Same as [`Wizer::snapshot`], except for components.
     pub async fn snapshot_component(
         &self,
-        mut cx: ComponentContext<'_>,
+        cx: &ComponentContext<'_>,
         instance: &mut impl ComponentInstanceState,
     ) -> Result<Vec<u8>> {
         if !self.func_renames.is_empty() {
             bail!("components do not support renaming functions");
         }
 
-        let snapshot = snapshot::snapshot(&cx, instance).await;
-        let rewritten_wasm = self.rewrite_component(&mut cx, &snapshot);
+        let snapshot = snapshot::snapshot(cx, instance).await;
+        let rewritten_wasm = self.rewrite_component(cx, &snapshot);
         self.debug_assert_valid_wasm(&rewritten_wasm, "rewritten component");
 
         Ok(rewritten_wasm)

--- a/crates/wizer/src/component/info.rs
+++ b/crates/wizer/src/component/info.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 /// [`Wizer::instrument_component`].
 ///
 /// [`Wizer::instrument_component`]: crate::Wizer::instrument_component
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct ComponentContext<'a> {
     /// Sections of the component, which are either raw bytes or a parsed module
     /// using `ModuleContext`.
@@ -31,6 +31,7 @@ pub struct ComponentContext<'a> {
 }
 
 /// Generated accessors during instrumentation and the metadata about them.
+#[derive(Clone)]
 pub(crate) enum Accessor {
     /// This accessor retrieves the value of a wasm global.
     Global {
@@ -64,6 +65,7 @@ pub(crate) enum Accessor {
 }
 
 /// A section of a component, learned during parsing.
+#[derive(Clone)]
 pub(crate) enum RawSection<'a> {
     /// A non-module section, whose raw contents are stored here.
     Raw(wasm_encoder::RawSection<'a>),

--- a/crates/wizer/src/component/rewrite.rs
+++ b/crates/wizer/src/component/rewrite.rs
@@ -12,7 +12,7 @@ impl Wizer {
     /// updates module sections with whatever [`Wizer::rewrite`] returns.
     pub(crate) fn rewrite_component(
         &self,
-        component: &mut ComponentContext<'_>,
+        component: &ComponentContext<'_>,
         snapshot: &ComponentSnapshot,
     ) -> Vec<u8> {
         let mut encoder = wasm_encoder::Component::new();
@@ -23,7 +23,7 @@ impl Wizer {
         };
 
         let mut module_index = 0;
-        for section in component.sections.iter_mut() {
+        for section in component.sections.iter() {
             match section {
                 RawSection::Module(module) => {
                     let snapshot = snapshot

--- a/crates/wizer/src/component/wasmtime.rs
+++ b/crates/wizer/src/component/wasmtime.rs
@@ -33,7 +33,7 @@ impl Wizer {
         self.initialize_component(store, &instance, index, args, &mut rets)
             .await?;
         let snap = self
-            .snapshot_component(cx, &mut WasmtimeWizerComponent { store, instance })
+            .snapshot_component(&cx, &mut WasmtimeWizerComponent { store, instance })
             .await?;
         Ok((snap, rets))
     }

--- a/crates/wizer/src/info.rs
+++ b/crates/wizer/src/info.rs
@@ -6,7 +6,7 @@ use std::ops::Range;
 ///
 /// These are created during our `parse` pass and then used throughout
 /// our later passes.
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct ModuleContext<'a> {
     /// The raw sections from the original Wasm input.
     raw_sections: Vec<wasm_encoder::RawSection<'a>>,

--- a/crates/wizer/src/lib.rs
+++ b/crates/wizer/src/lib.rs
@@ -232,14 +232,14 @@ impl Wizer {
     /// pre-initialized.
     pub async fn snapshot(
         &self,
-        mut cx: ModuleContext<'_>,
+        cx: &ModuleContext<'_>,
         instance: &mut impl InstanceState,
     ) -> Result<Vec<u8>> {
         // Parse rename spec.
         let renames = FuncRenames::parse(&self.func_renames)?;
 
-        let snapshot = snapshot::snapshot(&cx, instance).await;
-        let rewritten_wasm = self.rewrite(&mut cx, &snapshot, &renames, true);
+        let snapshot = snapshot::snapshot(cx, instance).await;
+        let rewritten_wasm = self.rewrite(cx, &snapshot, &renames, true);
 
         self.debug_assert_valid_wasm(&rewritten_wasm, "rewritten module");
 

--- a/crates/wizer/src/rewrite.rs
+++ b/crates/wizer/src/rewrite.rs
@@ -12,7 +12,7 @@ impl Wizer {
     ///
     pub(crate) fn rewrite(
         &self,
-        module: &mut ModuleContext<'_>,
+        module: &ModuleContext<'_>,
         snapshot: &Snapshot,
         renames: &FuncRenames,
         remove_wasi_initialize: bool,

--- a/crates/wizer/src/wasmtime.rs
+++ b/crates/wizer/src/wasmtime.rs
@@ -22,7 +22,7 @@ impl Wizer {
 
         let instance = instantiate(store, &module).await?;
         self.initialize(store, &instance).await?;
-        self.snapshot(cx, &mut WasmtimeWizer { store, instance })
+        self.snapshot(&cx, &mut WasmtimeWizer { store, instance })
             .await
     }
 

--- a/src/commands/wizer.rs
+++ b/src/commands/wizer.rs
@@ -127,7 +127,7 @@ impl WizerCommand {
             (WizerInfo::Core(cx), CliInstance::Core(instance)) => {
                 self.wizer
                     .snapshot(
-                        cx,
+                        &cx,
                         &mut wasmtime_wizer::WasmtimeWizer {
                             store: &mut store,
                             instance,
@@ -140,7 +140,7 @@ impl WizerCommand {
             (WizerInfo::Component(cx), CliInstance::Component(instance)) => {
                 self.wizer
                     .snapshot_component(
-                        cx,
+                        &cx,
                         &mut wasmtime_wizer::WasmtimeWizerComponent {
                             store: &mut store,
                             instance,


### PR DESCRIPTION
I would like to use Wizer to instrument a single Wasm component, instantiate it multiple times and then snapshot the state of each individual instance.
Currently that requires instrumenting the component N times for each instance, since snapshotting *moves* the context, which is itself not `Clone`.
I first added a `Clone` implementation to the context, but then realized that it is never actually mutated, so switched snapshot functions to *borrow* the context instead as well.