### PR TITLE
Make dev mode configurable

### DIFF
--- a/cranelift/isle/veri/veri/src/bin/explorer.rs
+++ b/cranelift/isle/veri/veri/src/bin/explorer.rs
@@ -29,6 +29,10 @@ struct Opts {
     /// Whether to enable graph generation.
     #[arg(long, env = "ISLE_EXPLORER_GRAPHS")]
     graphs: bool,
+
+    /// Enable development mode.
+    #[arg(long)]
+    dev: bool,
 }
 
 impl Opts {
@@ -78,6 +82,7 @@ fn main() -> Result<()> {
         &prog,
         expander.chaining(),
         expander.expansions(),
+        opts.dev,
     );
     if opts.graphs {
         explorer_writer.enable_graphs();

--- a/cranelift/isle/veri/veri/src/explorer.rs
+++ b/cranelift/isle/veri/veri/src/explorer.rs
@@ -34,6 +34,7 @@ impl<'a> ExplorerWriter<'a> {
         prog: &'a Program,
         chaining: &'a Chaining<'a>,
         expansions: &'a Vec<Expansion>,
+        dev: bool,
     ) -> Self {
         Self {
             prog,
@@ -42,7 +43,7 @@ impl<'a> ExplorerWriter<'a> {
             root,
             base: PathBuf::new(),
             graphs: false,
-            dev: true, // TODO(mbm): configurable dev mode
+            dev,
         }
     }
 


### PR DESCRIPTION
> This addresses the existing `TODO(mbm): configurable dev mode`.

This change makes the explorer's development mode configurable via a `--dev` command-line flag.

Previously, development mode was always enabled, causing the explorer to always create a symlink to the assets directory. With this change, development mode is enabled only when `--dev` is specified, while the default behavior embeds and writes the assets as intended for normal use.