### PR TITLE
Enable `call-hook` feature with MPK

### DIFF
--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -340,7 +340,12 @@ call-hook = []
 
 # Enables support for "memory protection keys" which can be used in conjunction
 # with the pooling allocator on x64 to compact linear memory allocations.
-memory-protection-keys = ["pooling-allocator"]
+memory-protection-keys = [
+  "pooling-allocator",
+  # MPK currently relies on call-hooks to manage the PKRU register for the host,
+  # so this is implicitly enabled when MPK is enabled.
+  "call-hook",
+]
 
 # Enables a re-export of wasmparser, so that an embedder of Wasmtime can use
 # exactly the version of the parser library that Wasmtime does. Sometimes this


### PR DESCRIPTION
MPK implicitly relies on `StoreOpaque::call_hook`, so go ahead and enable it so it's managed correctly.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
