### PR TITLE
winch(aarch64) v128 nan canon

### DIFF
--- a/crates/test-util/src/wast.rs
+++ b/crates/test-util/src/wast.rs
@@ -533,6 +533,7 @@ impl WastTest {
                 "misc_testsuite/simd/almost-extmul.wast",
                 "misc_testsuite/simd/sse-cannot-fold-unaligned-loads.wast",
                 "misc_testsuite/simd/issue_3327_bnot_lowering.wast",
+                "misc_testsuite/simd/canonicalize-nan.wast",
             ];
             if now_supported.iter().any(|part| self.path.ends_with(part)) {
                 return false;

--- a/tests/disas/winch/aarch64/f32x4_add/nan_canon.wat
+++ b/tests/disas/winch/aarch64/f32x4_add/nan_canon.wat
@@ -1,0 +1,47 @@
+;;! target = "aarch64"
+;;! test = "winch"
+;;! flags = ["-Wnan-canonicalization"]
+
+(module
+    (func (param v128 v128) (result v128)
+        local.get 0
+        local.get 1
+        f32x4.add
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
+;;       mov     x28, sp
+;;       ldur    x16, [x0, #8]
+;;       ldur    x16, [x16, #0x18]
+;;       mov     x17, #0
+;;       movk    x17, #0x30
+;;       add     x16, x16, x17
+;;       cmp     sp, x16
+;;       b.lo    #0x88
+;;   2c: mov     x9, x0
+;;       sub     x28, x28, #0x30
+;;       mov     sp, x28
+;;       stur    x0, [x28, #0x28]
+;;       stur    x1, [x28, #0x20]
+;;       stur    q0, [x28, #0x10]
+;;       stur    q1, [x28]
+;;       ldur    q0, [x28]
+;;       ldur    q1, [x28, #0x10]
+;;       fadd    v1.4s, v1.4s, v0.4s
+;;       fcmeq   v31.4s, v1.4s, v1.4s
+;;       and     v1.16b, v1.16b, v31.16b
+;;       mvn     v31.16b, v31.16b
+;;       ushr    v31.4s, v31.4s, #0x17
+;;       shl     v31.4s, v31.4s, #0x16
+;;       orr     v1.16b, v1.16b, v31.16b
+;;       mov     v0.16b, v1.16b
+;;       add     x28, x28, #0x30
+;;       mov     sp, x28
+;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret
+;;   88: udf     #0xc11f

--- a/tests/disas/winch/aarch64/f64x2_add/nan_canon.wat
+++ b/tests/disas/winch/aarch64/f64x2_add/nan_canon.wat
@@ -1,0 +1,47 @@
+;;! target = "aarch64"
+;;! test = "winch"
+;;! flags = ["-Wnan-canonicalization"]
+
+(module
+    (func (param v128 v128) (result v128)
+        local.get 0
+        local.get 1
+        f64x2.add
+    )
+)
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
+;;       mov     x28, sp
+;;       ldur    x16, [x0, #8]
+;;       ldur    x16, [x16, #0x18]
+;;       mov     x17, #0
+;;       movk    x17, #0x30
+;;       add     x16, x16, x17
+;;       cmp     sp, x16
+;;       b.lo    #0x88
+;;   2c: mov     x9, x0
+;;       sub     x28, x28, #0x30
+;;       mov     sp, x28
+;;       stur    x0, [x28, #0x28]
+;;       stur    x1, [x28, #0x20]
+;;       stur    q0, [x28, #0x10]
+;;       stur    q1, [x28]
+;;       ldur    q0, [x28]
+;;       ldur    q1, [x28, #0x10]
+;;       fadd    v1.2d, v1.2d, v0.2d
+;;       fcmeq   v31.2d, v1.2d, v1.2d
+;;       and     v1.16b, v1.16b, v31.16b
+;;       mvn     v31.16b, v31.16b
+;;       ushr    v31.2d, v31.2d, #0x34
+;;       shl     v31.2d, v31.2d, #0x33
+;;       orr     v1.16b, v1.16b, v31.16b
+;;       mov     v0.16b, v1.16b
+;;       add     x28, x28, #0x30
+;;       mov     sp, x28
+;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret
+;;   88: udf     #0xc11f

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -811,13 +811,54 @@ impl Masm for MacroAssembler {
 
     fn maybe_canonicalize_v128_nan(
         &mut self,
-        _reg: WritableReg,
-        _lane_size: OperandSize,
+        reg: WritableReg,
+        lane_size: OperandSize,
     ) -> Result<()> {
         if !self.shared_flags.enable_nan_canonicalization() {
             return Ok(());
         }
-        bail!(CodeGenError::unimplemented_masm_instruction())
+
+        // Derive the canonical NaN in the NaN lanes with shifts instead of
+        // loading it as a constant.
+        let (vector_size, ushr, shl) = match lane_size {
+            OperandSize::S32 => (VectorSize::Size32x4, 23, 22),
+            OperandSize::S64 => (VectorSize::Size64x2, 52, 51),
+            _ => bail!(CodeGenError::unexpected_operand_size()),
+        };
+        self.with_scratch::<FloatScratch, _>(|masm, mask| {
+            // All ones in the lanes that are not NaN.
+            masm.asm.vec_rrr(
+                VecALUOp::Fcmeq,
+                reg.to_reg(),
+                reg.to_reg(),
+                mask.writable(),
+                vector_size,
+            );
+            // Zero the NaN lanes, preserving the rest.
+            masm.asm
+                .vec_rrr(VecALUOp::And, reg.to_reg(), mask.inner(), reg, vector_size);
+            // All ones in the NaN lanes.
+            masm.asm
+                .vec_misc(VecMisc2::Not, mask.inner(), mask.writable(), vector_size);
+            // Reduce the NaN lanes to canonical NaNs.
+            masm.asm.vec_shift_imm(
+                VecShiftImmOp::Ushr,
+                ushr,
+                mask.inner(),
+                mask.writable(),
+                vector_size,
+            );
+            masm.asm.vec_shift_imm(
+                VecShiftImmOp::Shl,
+                shl,
+                mask.inner(),
+                mask.writable(),
+                vector_size,
+            );
+            masm.asm
+                .vec_rrr(VecALUOp::Orr, reg.to_reg(), mask.inner(), reg, vector_size);
+        });
+        Ok(())
     }
 
     fn and(&mut self, dst: WritableReg, lhs: Reg, rhs: RegImm, size: OperandSize) -> Result<()> {


### PR DESCRIPTION
This implements the v128 half of NaN canonicalization. which is the last piece of
v128 support for #9925. 