### PR TITLE
cranelift: Fix some i128-related panics in the backend

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/lower.isle
+++ b/cranelift/codegen/src/isa/aarch64/lower.isle
@@ -1574,7 +1574,7 @@
 ;; Shift for vector types.
 (rule -3 (lower (ishl (ty_vec128 ty) x y))
       (let ((size VectorSize (vector_size ty))
-            (masked_shift_amt Reg (and_imm $I32 y (shift_mask ty)))
+            (masked_shift_amt Reg (and_imm $I32 (lo_reg y) (shift_mask ty)))
             (shift Reg (vec_dup masked_shift_amt size)))
         (sshl x shift size)))
 (rule -2 (lower (ishl (ty_vec128 ty) x (iconst _ (u64_from_imm64 n))))
@@ -1645,7 +1645,7 @@
 ;; the input anyway.
 (rule -4 (lower (ushr (ty_vec128 ty) x y))
       (let ((size VectorSize (vector_size ty))
-            (masked_shift_amt Reg (and_imm $I32 y (shift_mask ty)))
+            (masked_shift_amt Reg (and_imm $I32 (lo_reg y) (shift_mask ty)))
             (shift Reg (vec_dup (sub $I64 (zero_reg) masked_shift_amt) size)))
         (ushl x shift size)))
 (rule -3 (lower (ushr (ty_vec128 ty) x (iconst _ (u64_from_imm64 n))))
@@ -1703,7 +1703,7 @@
 ;; input anyway.
 (rule -3 (lower (sshr (ty_vec128 ty) x y))
       (let ((size VectorSize (vector_size ty))
-            (masked_shift_amt Reg (and_imm $I32 y (shift_mask ty)))
+            (masked_shift_amt Reg (and_imm $I32 (lo_reg y) (shift_mask ty)))
             (shift Reg (vec_dup (sub $I64 (zero_reg) masked_shift_amt) size)))
         (sshl x shift size)))
 (rule -2 (lower (sshr (ty_vec128 ty) x (iconst _ (u64_from_imm64 n))))

--- a/cranelift/codegen/src/isa/pulley_shared/inst.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/inst.isle
@@ -468,6 +468,11 @@
 (rule (put_in_xreg val) (xreg_new (put_in_reg val)))
 (convert Value XReg put_in_xreg)
 
+;; Returns `Value` in an `XReg` if it's <=64 bits, or the low 64-bits if
+;; it's an i128.
+(decl lo_xreg (Value) XReg)
+(rule (lo_xreg val) (xreg_new (lo_reg val)))
+
 ;; Construct an `InstOutput` out of a single XReg register.
 (decl output_xreg (XReg) InstOutput)
 (rule (output_xreg x) (output_reg x))

--- a/cranelift/codegen/src/isa/pulley_shared/lower.isle
+++ b/cranelift/codegen/src/isa/pulley_shared/lower.isle
@@ -18,6 +18,10 @@
 (rule 0 (lower_cond val @ (value_type (fits_in_32 _))) (Cond.If32 (zext32 val)))
 (rule 1 (lower_cond val @ (value_type $I64))
   (Cond.IfXneq64I32 val 0))
+(rule 1 (lower_cond val @ (value_type $I128))
+  (Cond.IfXneq64I32 (pulley_xbor64 (value_regs_get val 0)
+                                   (value_regs_get val 1))
+                    0))
 
 ;; Peel away explicit `uextend` values to take a look at the inner value.
 (rule 2 (lower_cond (uextend _ val)) (lower_cond val))
@@ -495,16 +499,16 @@
 ;;;; Rules for `ishl` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (ishl $I8 a b))
-  (pulley_xshl32 a (pulley_xband32_s8 b 7)))
+  (pulley_xshl32 a (pulley_xband32_s8 (lo_xreg b) 7)))
 
 (rule (lower (ishl $I16 a b))
-  (pulley_xshl32 a (pulley_xband32_s8 b 15)))
+  (pulley_xshl32 a (pulley_xband32_s8 (lo_xreg b) 15)))
 
 (rule (lower (ishl $I32 a b))
-  (pulley_xshl32 a b))
+  (pulley_xshl32 a (lo_xreg b)))
 
 (rule (lower (ishl $I64 a b))
-  (pulley_xshl64 a b))
+  (pulley_xshl64 a (lo_xreg b)))
 
 ;; Special-case constant shift amounts.
 (rule 1 (lower (ishl $I32 a b))
@@ -516,10 +520,10 @@
 
 ;; vector shifts
 
-(rule (lower (ishl $I8X16 a b)) (pulley_vshli8x16 a b))
-(rule (lower (ishl $I16X8 a b)) (pulley_vshli16x8 a b))
-(rule (lower (ishl $I32X4 a b)) (pulley_vshli32x4 a b))
-(rule (lower (ishl $I64X2 a b)) (pulley_vshli64x2 a b))
+(rule (lower (ishl $I8X16 a b)) (pulley_vshli8x16 a (lo_xreg b)))
+(rule (lower (ishl $I16X8 a b)) (pulley_vshli16x8 a (lo_xreg b)))
+(rule (lower (ishl $I32X4 a b)) (pulley_vshli32x4 a (lo_xreg b)))
+(rule (lower (ishl $I64X2 a b)) (pulley_vshli64x2 a (lo_xreg b)))
 
 ;; Helper to extract a constant from `Value`, mask it to 6 bits, and then make a
 ;; `U6`.
@@ -534,16 +538,16 @@
 ;;;; Rules for `ushr` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (ushr $I8 a b))
-  (pulley_xshr32_u (zext32 a) (pulley_xband32_s8 b 7)))
+  (pulley_xshr32_u (zext32 a) (pulley_xband32_s8 (lo_xreg b) 7)))
 
 (rule (lower (ushr $I16 a b))
-  (pulley_xshr32_u (zext32 a) (pulley_xband32_s8 b 15)))
+  (pulley_xshr32_u (zext32 a) (pulley_xband32_s8 (lo_xreg b) 15)))
 
 (rule (lower (ushr $I32 a b))
-  (pulley_xshr32_u a b))
+  (pulley_xshr32_u a (lo_xreg b)))
 
 (rule (lower (ushr $I64 a b))
-  (pulley_xshr64_u a b))
+  (pulley_xshr64_u a (lo_xreg b)))
 
 ;; Special-case constant shift amounts.
 (rule 1 (lower (ushr $I32 a b))
@@ -555,24 +559,24 @@
 
 ;; vector shifts
 
-(rule (lower (ushr $I8X16 a b)) (pulley_vshri8x16_u a b))
-(rule (lower (ushr $I16X8 a b)) (pulley_vshri16x8_u a b))
-(rule (lower (ushr $I32X4 a b)) (pulley_vshri32x4_u a b))
-(rule (lower (ushr $I64X2 a b)) (pulley_vshri64x2_u a b))
+(rule (lower (ushr $I8X16 a b)) (pulley_vshri8x16_u a (lo_xreg b)))
+(rule (lower (ushr $I16X8 a b)) (pulley_vshri16x8_u a (lo_xreg b)))
+(rule (lower (ushr $I32X4 a b)) (pulley_vshri32x4_u a (lo_xreg b)))
+(rule (lower (ushr $I64X2 a b)) (pulley_vshri64x2_u a (lo_xreg b)))
 
 ;;;; Rules for `sshr` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (sshr $I8 a b))
-  (pulley_xshr32_u (sext32 a) (pulley_xband32_s8 b 7)))
+  (pulley_xshr32_u (sext32 a) (pulley_xband32_s8 (lo_xreg b) 7)))
 
 (rule (lower (sshr $I16 a b))
-  (pulley_xshr32_u (sext32 a) (pulley_xband32_s8 b 15)))
+  (pulley_xshr32_u (sext32 a) (pulley_xband32_s8 (lo_xreg b) 15)))
 
 (rule (lower (sshr $I32 a b))
-  (pulley_xshr32_s a b))
+  (pulley_xshr32_s a (lo_xreg b)))
 
 (rule (lower (sshr $I64 a b))
-  (pulley_xshr64_s a b))
+  (pulley_xshr64_s a (lo_xreg b)))
 
 ;; Special-case constant shift amounts.
 (rule 1 (lower (sshr $I32 a b))
@@ -584,10 +588,10 @@
 
 ;; vector shifts
 
-(rule (lower (sshr $I8X16 a b)) (pulley_vshri8x16_s a b))
-(rule (lower (sshr $I16X8 a b)) (pulley_vshri16x8_s a b))
-(rule (lower (sshr $I32X4 a b)) (pulley_vshri32x4_s a b))
-(rule (lower (sshr $I64X2 a b)) (pulley_vshri64x2_s a b))
+(rule (lower (sshr $I8X16 a b)) (pulley_vshri8x16_s a (lo_xreg b)))
+(rule (lower (sshr $I16X8 a b)) (pulley_vshri16x8_s a (lo_xreg b)))
+(rule (lower (sshr $I32X4 a b)) (pulley_vshri32x4_s a (lo_xreg b)))
+(rule (lower (sshr $I64X2 a b)) (pulley_vshri64x2_s a (lo_xreg b)))
 
 ;;;; Rules for `band` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -727,13 +731,13 @@
 
 ;;;; Rules for `rotl` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule (lower (rotl $I32 a b)) (pulley_xrotl32 a b))
-(rule (lower (rotl $I64 a b)) (pulley_xrotl64 a b))
+(rule (lower (rotl $I32 a b)) (pulley_xrotl32 a (lo_xreg b)))
+(rule (lower (rotl $I64 a b)) (pulley_xrotl64 a (lo_xreg b)))
 
 ;;;; Rules for `rotr` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule (lower (rotr $I32 a b)) (pulley_xrotr32 a b))
-(rule (lower (rotr $I64 a b)) (pulley_xrotr64 a b))
+(rule (lower (rotr $I32 a b)) (pulley_xrotr32 a (lo_xreg b)))
+(rule (lower (rotr $I64 a b)) (pulley_xrotr64 a (lo_xreg b)))
 
 ;;;; Rules for `icmp` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -789,7 +789,7 @@
 
 (decl mask_xmm_shift (Type Value) RegMemImm)
 (rule (mask_xmm_shift ty amt)
-      (gpr_to_reg (x64_and $I64 amt (RegMemImm.Imm (shift_mask ty)))))
+      (gpr_to_reg (x64_and $I64 (lo_gpr amt) (RegMemImm.Imm (shift_mask ty)))))
 (rule 1 (mask_xmm_shift ty (iconst _ n))
       (RegMemImm.Imm (shift_amount_masked ty n)))
 
@@ -855,7 +855,7 @@
 ;;   hi.i16x8 = [(s8, s8), (s9, s9), ..., (s15, s15)]
 ;;   shifted_hi.i16x8 = shift each lane of `high`
 ;;   result = [s0'', s1'', ..., s15'']
-(rule (lower (sshr ty @ $I8X16 src amt @ (value_type amt_ty)))
+(rule (lower (sshr ty @ $I8X16 src amt))
       (let ((src_ Xmm (put_in_xmm src))
             ;; Mask the amount to ensure wrapping behaviour
             (masked_amt RegMemImm (mask_xmm_shift ty amt))
@@ -864,21 +864,24 @@
             ;; fill in the upper bits appropriately.
             (lo Xmm (x64_punpcklbw src_ src_))
             (hi Xmm (x64_punpckhbw src_ src_))
-            (amt_ XmmMemImm (sshr_i8x16_bigger_shift amt_ty masked_amt))
+            (amt_ XmmMemImm (sshr_i8x16_bigger_shift masked_amt))
             (shifted_lo Xmm (x64_psraw lo amt_))
             (shifted_hi Xmm (x64_psraw hi amt_)))
         (x64_packsswb shifted_lo shifted_hi)))
 
-(decl sshr_i8x16_bigger_shift (Type RegMemImm) XmmMemImm)
-(rule (sshr_i8x16_bigger_shift _ty (RegMemImm.Imm i))
+;; NB: the amount here has already been masked to at most 7 by `mask_xmm_shift`,
+;; so the addition is always done at `$I32` regardless of the type of the
+;; original shift amount
+(decl sshr_i8x16_bigger_shift (RegMemImm) XmmMemImm)
+(rule (sshr_i8x16_bigger_shift (RegMemImm.Imm i))
       (xmm_mem_imm_new (RegMemImm.Imm (u32_wrapping_add i 8))))
-(rule (sshr_i8x16_bigger_shift ty (RegMemImm.Reg r))
-      (mov_rmi_to_xmm (RegMemImm.Reg (x64_add ty
+(rule (sshr_i8x16_bigger_shift (RegMemImm.Reg r))
+      (mov_rmi_to_xmm (RegMemImm.Reg (x64_add $I32
                                           r
                                           (RegMemImm.Imm 8)))))
-(rule (sshr_i8x16_bigger_shift ty rmi @ (RegMemImm.Mem _m))
-      (mov_rmi_to_xmm (RegMemImm.Reg (x64_add ty
-                                          (imm ty 8)
+(rule (sshr_i8x16_bigger_shift rmi @ (RegMemImm.Mem _m))
+      (mov_rmi_to_xmm (RegMemImm.Reg (x64_add $I32
+                                          (imm $I32 8)
                                           rmi))))
 
 ;; `sshr.{i16x8,i32x4}` can be a simple `psra{w,d}`, we just have to make sure
@@ -901,14 +904,14 @@
 (rule 2 (lower (sshr ty @ $I64X2 src amt))
         (if-let true (has_avx512vl))
         (if-let true (has_avx512f))
-        (let ((masked Gpr (x64_and $I64 amt (RegMemImm.Imm (shift_mask ty)))))
+        (let ((masked Gpr (x64_and $I64 (lo_gpr amt) (RegMemImm.Imm (shift_mask ty)))))
           (x64_vpsraq src (x64_movd_to_xmm masked))))
 
 (rule 1 (lower (sshr $I64X2 src (u32_from_iconst amt)))
         (lower_i64x2_sshr_imm src (u32_and amt 63)))
 
 (rule (lower (sshr $I64X2 src amt))
-      (lower_i64x2_sshr_gpr src (x64_and $I64 amt (RegMemImm.Imm 63))))
+      (lower_i64x2_sshr_gpr src (x64_and $I64 (lo_gpr amt) (RegMemImm.Imm 63))))
 
 (decl lower_i64x2_sshr_imm (Xmm u32) Xmm)
 
@@ -4479,7 +4482,7 @@
           (x64_shrq_mi result 8)))
 
 ;; Same as the above rule but for 16-to-64 bit types.
-(rule 2 (lower (srem _ a @ (value_type ty) (iconst _ imm)))
+(rule 2 (lower (srem _ a @ (value_type (fits_in_64 ty)) (iconst _ imm)))
         (if-let n (safe_divisor_from_imm64 ty imm))
         (let (
             (a Gpr a)
@@ -4492,7 +4495,7 @@
 (rule 1 (lower (srem _ a @ (value_type $I8) b))
   (x64_shrq_mi (x64_checked_srem_seq8 (x64_cbtw_zo a) b) 8))
 
-(rule (lower (srem _ a @ (value_type ty) b))
+(rule (lower (srem _ a @ (value_type (fits_in_64 ty)) b))
       (let (
           (a Gpr a)
           (size OperandSize (raw_operand_size_of_type ty))

--- a/cranelift/filetests/filetests/runtests/i128-br.clif
+++ b/cranelift/filetests/filetests/runtests/i128-br.clif
@@ -5,6 +5,10 @@ target s390x
 target x86_64
 target riscv64
 target riscv64 has_c has_zcb
+target pulley32
+target pulley32be
+target pulley64
+target pulley64be
 
 function %i128_brif_false(i128) -> i8 {
 block0(v0: i128):

--- a/cranelift/filetests/filetests/runtests/rotl.clif
+++ b/cranelift/filetests/filetests/runtests/rotl.clif
@@ -231,6 +231,65 @@ block0(v0: i8, v1: i8):
 ; run: %rotl_i8_i8(0xe4, 66) == 0x93
 
 
+function %rotl_i64_i128(i64, i64, i64) -> i64 {
+block0(v0: i64, v1: i64, v2: i64):
+    v3 = iconcat v1, v2
+    v4 = rotl.i64 v0, v3
+    return v4
+}
+; run: %rotl_i64_i128(0xe0000000_00000000, 0, 0) == 0xe0000000_00000000
+; run: %rotl_i64_i128(0xe0000000_00000000, 1, 0) == 0xc0000000_00000001
+; run: %rotl_i64_i128(0xe000000f_0000000f, 0, 0) == 0xe000000f_0000000f
+; run: %rotl_i64_i128(0xe000000f_0000000f, 4, 0) == 0x000000f0_000000fe
+; run: %rotl_i64_i128(0xe0000000_00000004, 64, 0) == 0xe0000000_00000004
+; run: %rotl_i64_i128(0xe0000000_00000004, 65, 0) == 0xc0000000_00000009
+; run: %rotl_i64_i128(0xe0000000_00000004, 66, 0) == 0x80000000_00000013
+; run: %rotl_i64_i128(0xe0000000_00000004, 66, 0xffffffff_ffffffff) == 0x80000000_00000013
+
+function %rotl_i32_i128(i32, i64, i64) -> i32 {
+block0(v0: i32, v1: i64, v2: i64):
+    v3 = iconcat v1, v2
+    v4 = rotl.i32 v0, v3
+    return v4
+}
+; run: %rotl_i32_i128(0xe0000000, 0, 0) == 0xe0000000
+; run: %rotl_i32_i128(0xe0000000, 1, 0) == 0xc0000001
+; run: %rotl_i32_i128(0xe00f000f, 0, 0) == 0xe00f000f
+; run: %rotl_i32_i128(0xe00f000f, 4, 0) == 0x00f000fe
+; run: %rotl_i32_i128(0xe0000004, 64, 0) == 0xe0000004
+; run: %rotl_i32_i128(0xe0000004, 65, 0) == 0xc0000009
+; run: %rotl_i32_i128(0xe0000004, 66, 0) == 0x80000013
+; run: %rotl_i32_i128(0xe0000004, 66, 0xffffffff_ffffffff) == 0x80000013
+
+function %rotl_i16_i128(i16, i64, i64) -> i16 {
+block0(v0: i16, v1: i64, v2: i64):
+    v3 = iconcat v1, v2
+    v4 = rotl.i16 v0, v3
+    return v4
+}
+; run: %rotl_i16_i128(0xe000, 0, 0) == 0xe000
+; run: %rotl_i16_i128(0xe000, 1, 0) == 0xc001
+; run: %rotl_i16_i128(0xef0f, 0, 0) == 0xef0f
+; run: %rotl_i16_i128(0xef0f, 4, 0) == 0xf0fe
+; run: %rotl_i16_i128(0xe004, 64, 0) == 0xe004
+; run: %rotl_i16_i128(0xe004, 65, 0) == 0xc009
+; run: %rotl_i16_i128(0xe004, 66, 0) == 0x8013
+; run: %rotl_i16_i128(0xe004, 66, 0xffffffff_ffffffff) == 0x8013
+
+function %rotl_i8_i128(i8, i64, i64) -> i8 {
+block0(v0: i8, v1: i64, v2: i64):
+    v3 = iconcat v1, v2
+    v4 = rotl.i8 v0, v3
+    return v4
+}
+; run: %rotl_i8_i128(0xe0, 0, 0) == 0xe0
+; run: %rotl_i8_i128(0xe0, 1, 0) == 0xc1
+; run: %rotl_i8_i128(0xef, 0, 0) == 0xef
+; run: %rotl_i8_i128(0xef, 4, 0) == 0xfe
+; run: %rotl_i8_i128(0xe4, 64, 0) == 0xe4
+; run: %rotl_i8_i128(0xe4, 65, 0) == 0xc9
+; run: %rotl_i8_i128(0xe4, 66, 0) == 0x93
+; run: %rotl_i8_i128(0xe4, 66, 0xffffffff_ffffffff) == 0x93
 
 ;; This is a regression test for rotates on x64
 ;; See: https://github.com/bytecodealliance/wasmtime/pull/3610

--- a/cranelift/filetests/filetests/runtests/rotr.clif
+++ b/cranelift/filetests/filetests/runtests/rotr.clif
@@ -231,6 +231,66 @@ block0(v0: i8, v1: i8):
 ; run: %rotr_i8_i8(0xe0, 65) == 0x70
 ; run: %rotr_i8_i8(0xe0, 66) == 0x38
 
+function %rotr_i64_i128(i64, i64, i64) -> i64 {
+block0(v0: i64, v1: i64, v2: i64):
+    v3 = iconcat v1, v2
+    v4 = rotr.i64 v0, v3
+    return v4
+}
+; run: %rotr_i64_i128(0xe0000000_00000000, 0, 0) == 0xe0000000_00000000
+; run: %rotr_i64_i128(0xe0000000_00000000, 1, 0) == 0x70000000_00000000
+; run: %rotr_i64_i128(0xe000000f_0000000f, 0, 0) == 0xe000000f_0000000f
+; run: %rotr_i64_i128(0xe000000f_0000000f, 4, 0) == 0xfe000000_f0000000
+; run: %rotr_i64_i128(0xe0000000_00000004, 64, 0) == 0xe0000000_00000004
+; run: %rotr_i64_i128(0xe0000000_00000004, 65, 0) == 0x70000000_00000002
+; run: %rotr_i64_i128(0xe0000000_00000004, 66, 0) == 0x38000000_00000001
+; run: %rotr_i64_i128(0xe0000000_00000004, 66, 0xffffffff_ffffffff) == 0x38000000_00000001
+
+function %rotr_i32_i128(i32, i64, i64) -> i32 {
+block0(v0: i32, v1: i64, v2: i64):
+    v3 = iconcat v1, v2
+    v4 = rotr.i32 v0, v3
+    return v4
+}
+; run: %rotr_i32_i128(0xe0000000, 0, 0) == 0xe0000000
+; run: %rotr_i32_i128(0xe0000000, 1, 0) == 0x70000000
+; run: %rotr_i32_i128(0xe00f000f, 0, 0) == 0xe00f000f
+; run: %rotr_i32_i128(0xe00f000f, 4, 0) == 0xfe00f000
+; run: %rotr_i32_i128(0xe0000004, 64, 0) == 0xe0000004
+; run: %rotr_i32_i128(0xe0000004, 65, 0) == 0x70000002
+; run: %rotr_i32_i128(0xe0000004, 66, 0) == 0x38000001
+; run: %rotr_i32_i128(0xe0000004, 66, 0xffffffff_ffffffff) == 0x38000001
+
+function %rotr_i16_i128(i16, i64, i64) -> i16 {
+block0(v0: i16, v1: i64, v2: i64):
+    v3 = iconcat v1, v2
+    v4 = rotr.i16 v0, v3
+    return v4
+}
+; run: %rotr_i16_i128(0xe000, 0, 0) == 0xe000
+; run: %rotr_i16_i128(0xe000, 1, 0) == 0x7000
+; run: %rotr_i16_i128(0xef0f, 0, 0) == 0xef0f
+; run: %rotr_i16_i128(0xef0f, 4, 0) == 0xfef0
+; run: %rotr_i16_i128(0xe004, 64, 0) == 0xe004
+; run: %rotr_i16_i128(0xe004, 65, 0) == 0x7002
+; run: %rotr_i16_i128(0xe004, 66, 0) == 0x3801
+; run: %rotr_i16_i128(0xe004, 66, 0xffffffff_ffffffff) == 0x3801
+
+function %rotr_i8_i128(i8, i64, i64) -> i8 {
+block0(v0: i8, v1: i64, v2: i64):
+    v3 = iconcat v1, v2
+    v4 = rotr.i8 v0, v3
+    return v4
+}
+; run: %rotr_i8_i128(0xe0, 0, 0) == 0xe0
+; run: %rotr_i8_i128(0xe0, 1, 0) == 0x70
+; run: %rotr_i8_i128(0xef, 0, 0) == 0xef
+; run: %rotr_i8_i128(0xef, 4, 0) == 0xfe
+; run: %rotr_i8_i128(0xe0, 64, 0) == 0xe0
+; run: %rotr_i8_i128(0xe0, 65, 0) == 0x70
+; run: %rotr_i8_i128(0xe0, 66, 0) == 0x38
+; run: %rotr_i8_i128(0xe0, 66, 0xffffffff_ffffffff) == 0x38
+
 function %rotr_iconst_select_iconsts_i8(i8) -> i8 {
 block0(v0: i8):
     v1 = iconst.i8 1

--- a/cranelift/filetests/filetests/runtests/select.clif
+++ b/cranelift/filetests/filetests/runtests/select.clif
@@ -35,6 +35,20 @@ block0(v0: i8):
 ; run: %select_i8(2) == 42
 ; run: %select_i8(-1) == 42
 
+function %select_i128_cond(i64, i64) -> i32 {
+block0(v0: i64, v1: i64):
+    v2 = iconcat v0, v1
+    v3 = iconst.i32 42
+    v4 = iconst.i32 97
+    v5 = select v2, v3, v4
+    return v5
+}
+; run: %select_i128_cond(0, 0) == 97
+; run: %select_i128_cond(1, 0) == 42
+; run: %select_i128_cond(0, 1) == 42
+; run: %select_i128_cond(0, 0x80000000_00000000) == 42
+; run: %select_i128_cond(-1, -1) == 42
+
 function %select_ne_f64(f64, f64) -> i32 {
 block0(v0: f64, v1: f64):
     v2 = fcmp ne v0, v1

--- a/cranelift/filetests/filetests/runtests/shifts.clif
+++ b/cranelift/filetests/filetests/runtests/shifts.clif
@@ -718,8 +718,203 @@ block0(v0: i8, v1: i8):
 ; run: %sshr_i8_i8(0x40, 33) == 0x20
 ; run: %sshr_i8_i8(0x40, 34) == 0x10
 
+function %ishl_i64_i128(i64, i64, i64) -> i64 {
+block0(v0: i64, v1: i64, v2: i64):
+    v3 = iconcat v1, v2
+    v4 = ishl.i64 v0, v3
+    return v4
+}
+; run: %ishl_i64_i128(0x00000000_00000000, 0, 0) == 0x00000000_00000000
+; run: %ishl_i64_i128(0x00000000_00000000, 1, 0) == 0x00000000_00000000
+; run: %ishl_i64_i128(0x0000000f_0000000f, 0, 0) == 0x0000000f_0000000f
+; run: %ishl_i64_i128(0x0000000f_0000000f, 4, 0) == 0x000000f0_000000f0
+; run: %ishl_i64_i128(0x00000000_00000004, 64, 0) == 0x00000000_00000004
+; run: %ishl_i64_i128(0x00000000_00000004, 65, 0) == 0x00000000_00000008
+; run: %ishl_i64_i128(0x00000000_00000004, 66, 0) == 0x00000000_00000010
+; run: %ishl_i64_i128(0x00000000_00000004, 66, 0xffffffff_ffffffff) == 0x00000000_00000010
 
+function %ishl_i32_i128(i32, i64, i64) -> i32 {
+block0(v0: i32, v1: i64, v2: i64):
+    v3 = iconcat v1, v2
+    v4 = ishl.i32 v0, v3
+    return v4
+}
+; run: %ishl_i32_i128(0x00000000, 0, 0) == 0x00000000
+; run: %ishl_i32_i128(0x00000000, 1, 0) == 0x00000000
+; run: %ishl_i32_i128(0x0000000f, 0, 0) == 0x0000000f
+; run: %ishl_i32_i128(0x0000000f, 4, 0) == 0x000000f0
+; run: %ishl_i32_i128(0x00000004, 32, 0) == 0x00000004
+; run: %ishl_i32_i128(0x00000004, 33, 0) == 0x00000008
+; run: %ishl_i32_i128(0x00000004, 34, 0) == 0x00000010
+; run: %ishl_i32_i128(0x00000004, 34, 0xffffffff_ffffffff) == 0x00000010
 
+function %ishl_i16_i128(i16, i64, i64) -> i16 {
+block0(v0: i16, v1: i64, v2: i64):
+    v3 = iconcat v1, v2
+    v4 = ishl.i16 v0, v3
+    return v4
+}
+; run: %ishl_i16_i128(0x0000, 0, 0) == 0x0000
+; run: %ishl_i16_i128(0x0000, 1, 0) == 0x0000
+; run: %ishl_i16_i128(0x000f, 0, 0) == 0x000f
+; run: %ishl_i16_i128(0x000f, 4, 0) == 0x00f0
+; run: %ishl_i16_i128(0x0004, 16, 0) == 0x0004
+; run: %ishl_i16_i128(0x0004, 17, 0) == 0x0008
+; run: %ishl_i16_i128(0x0004, 18, 0) == 0x0010
+; run: %ishl_i16_i128(0x0004, 32, 0) == 0x0004
+; run: %ishl_i16_i128(0x0004, 33, 0) == 0x0008
+; run: %ishl_i16_i128(0x0004, 34, 0) == 0x0010
+; run: %ishl_i16_i128(0x0004, 34, 0xffffffff_ffffffff) == 0x0010
+
+function %ishl_i8_i128(i8, i64, i64) -> i8 {
+block0(v0: i8, v1: i64, v2: i64):
+    v3 = iconcat v1, v2
+    v4 = ishl.i8 v0, v3
+    return v4
+}
+; run: %ishl_i8_i128(0x00, 0, 0) == 0x00
+; run: %ishl_i8_i128(0x00, 1, 0) == 0x00
+; run: %ishl_i8_i128(0x0f, 0, 0) == 0x0f
+; run: %ishl_i8_i128(0x0f, 4, 0) == 0xf0
+; run: %ishl_i8_i128(0x04, 8, 0) == 0x04
+; run: %ishl_i8_i128(0x04, 9, 0) == 0x08
+; run: %ishl_i8_i128(0x04, 10, 0) == 0x10
+; run: %ishl_i8_i128(0x04, 32, 0) == 0x04
+; run: %ishl_i8_i128(0x04, 33, 0) == 0x08
+; run: %ishl_i8_i128(0x04, 34, 0) == 0x10
+; run: %ishl_i8_i128(0x04, 34, 0xffffffff_ffffffff) == 0x10
+
+function %ushr_i64_i128(i64, i64, i64) -> i64 {
+block0(v0: i64, v1: i64, v2: i64):
+    v3 = iconcat v1, v2
+    v4 = ushr.i64 v0, v3
+    return v4
+}
+; run: %ushr_i64_i128(0x10000000_10000000, 0, 0) == 0x10000000_10000000
+; run: %ushr_i64_i128(0x10000000_10000000, 1, 0) == 0x08000000_08000000
+; run: %ushr_i64_i128(0xf0000000_f0000000, 0, 0) == 0xf0000000_f0000000
+; run: %ushr_i64_i128(0xf0000000_f0000000, 4, 0) == 0x0f000000_0f000000
+; run: %ushr_i64_i128(0x40000000_40000000, 64, 0) == 0x40000000_40000000
+; run: %ushr_i64_i128(0x40000000_40000000, 65, 0) == 0x20000000_20000000
+; run: %ushr_i64_i128(0x40000000_40000000, 66, 0) == 0x10000000_10000000
+; run: %ushr_i64_i128(0x40000000_40000000, 66, 0xffffffff_ffffffff) == 0x10000000_10000000
+
+function %ushr_i32_i128(i32, i64, i64) -> i32 {
+block0(v0: i32, v1: i64, v2: i64):
+    v3 = iconcat v1, v2
+    v4 = ushr.i32 v0, v3
+    return v4
+}
+; run: %ushr_i32_i128(0x10000000, 0, 0) == 0x10000000
+; run: %ushr_i32_i128(0x10000000, 1, 0) == 0x08000000
+; run: %ushr_i32_i128(0xf0000000, 0, 0) == 0xf0000000
+; run: %ushr_i32_i128(0xf0000000, 4, 0) == 0x0f000000
+; run: %ushr_i32_i128(0x40000000, 32, 0) == 0x40000000
+; run: %ushr_i32_i128(0x40000000, 33, 0) == 0x20000000
+; run: %ushr_i32_i128(0x40000000, 34, 0) == 0x10000000
+; run: %ushr_i32_i128(0x40000000, 34, 0xffffffff_ffffffff) == 0x10000000
+
+function %ushr_i16_i128(i16, i64, i64) -> i16 {
+block0(v0: i16, v1: i64, v2: i64):
+    v3 = iconcat v1, v2
+    v4 = ushr.i16 v0, v3
+    return v4
+}
+; run: %ushr_i16_i128(0x1000, 0, 0) == 0x1000
+; run: %ushr_i16_i128(0x1000, 1, 0) == 0x0800
+; run: %ushr_i16_i128(0xf000, 0, 0) == 0xf000
+; run: %ushr_i16_i128(0xf000, 4, 0) == 0x0f00
+; run: %ushr_i16_i128(0x4000, 16, 0) == 0x4000
+; run: %ushr_i16_i128(0x4000, 17, 0) == 0x2000
+; run: %ushr_i16_i128(0x4000, 18, 0) == 0x1000
+; run: %ushr_i16_i128(0x4000, 32, 0) == 0x4000
+; run: %ushr_i16_i128(0x4000, 33, 0) == 0x2000
+; run: %ushr_i16_i128(0x4000, 34, 0) == 0x1000
+; run: %ushr_i16_i128(0x4000, 34, 0xffffffff_ffffffff) == 0x1000
+
+function %ushr_i8_i128(i8, i64, i64) -> i8 {
+block0(v0: i8, v1: i64, v2: i64):
+    v3 = iconcat v1, v2
+    v4 = ushr.i8 v0, v3
+    return v4
+}
+; run: %ushr_i8_i128(0x10, 0, 0) == 0x10
+; run: %ushr_i8_i128(0x10, 1, 0) == 0x08
+; run: %ushr_i8_i128(0xf0, 0, 0) == 0xf0
+; run: %ushr_i8_i128(0xf0, 4, 0) == 0x0f
+; run: %ushr_i8_i128(0x40, 8, 0) == 0x40
+; run: %ushr_i8_i128(0x40, 9, 0) == 0x20
+; run: %ushr_i8_i128(0x40, 10, 0) == 0x10
+; run: %ushr_i8_i128(0x40, 32, 0) == 0x40
+; run: %ushr_i8_i128(0x40, 33, 0) == 0x20
+; run: %ushr_i8_i128(0x40, 34, 0) == 0x10
+; run: %ushr_i8_i128(0x40, 34, 0xffffffff_ffffffff) == 0x10
+
+function %sshr_i64_i128(i64, i64, i64) -> i64 {
+block0(v0: i64, v1: i64, v2: i64):
+    v3 = iconcat v1, v2
+    v4 = sshr.i64 v0, v3
+    return v4
+}
+; run: %sshr_i64_i128(0x80000000_80000000, 0, 0) == 0x80000000_80000000
+; run: %sshr_i64_i128(0x80000000_80000000, 1, 0) == 0xC0000000_40000000
+; run: %sshr_i64_i128(0xf0000000_f0000000, 0, 0) == 0xf0000000_f0000000
+; run: %sshr_i64_i128(0xf0000000_f0000000, 4, 0) == 0xff000000_0f000000
+; run: %sshr_i64_i128(0x40000000_40000000, 64, 0) == 0x40000000_40000000
+; run: %sshr_i64_i128(0x40000000_40000000, 65, 0) == 0x20000000_20000000
+; run: %sshr_i64_i128(0x40000000_40000000, 66, 0) == 0x10000000_10000000
+; run: %sshr_i64_i128(0x40000000_40000000, 66, 0xffffffff_ffffffff) == 0x10000000_10000000
+
+function %sshr_i32_i128(i32, i64, i64) -> i32 {
+block0(v0: i32, v1: i64, v2: i64):
+    v3 = iconcat v1, v2
+    v4 = sshr.i32 v0, v3
+    return v4
+}
+; run: %sshr_i32_i128(0x80000000, 0, 0) == 0x80000000
+; run: %sshr_i32_i128(0x80000000, 1, 0) == 0xC0000000
+; run: %sshr_i32_i128(0xf0000000, 0, 0) == 0xf0000000
+; run: %sshr_i32_i128(0xf0000000, 4, 0) == 0xff000000
+; run: %sshr_i32_i128(0x40000000, 32, 0) == 0x40000000
+; run: %sshr_i32_i128(0x40000000, 33, 0) == 0x20000000
+; run: %sshr_i32_i128(0x40000000, 34, 0) == 0x10000000
+; run: %sshr_i32_i128(0x40000000, 34, 0xffffffff_ffffffff) == 0x10000000
+
+function %sshr_i16_i128(i16, i64, i64) -> i16 {
+block0(v0: i16, v1: i64, v2: i64):
+    v3 = iconcat v1, v2
+    v4 = sshr.i16 v0, v3
+    return v4
+}
+; run: %sshr_i16_i128(0x8000, 0, 0) == 0x8000
+; run: %sshr_i16_i128(0x8000, 1, 0) == 0xC000
+; run: %sshr_i16_i128(0xf000, 0, 0) == 0xf000
+; run: %sshr_i16_i128(0xf000, 4, 0) == 0xff00
+; run: %sshr_i16_i128(0x4000, 16, 0) == 0x4000
+; run: %sshr_i16_i128(0x4000, 17, 0) == 0x2000
+; run: %sshr_i16_i128(0x4000, 18, 0) == 0x1000
+; run: %sshr_i16_i128(0x4000, 32, 0) == 0x4000
+; run: %sshr_i16_i128(0x4000, 33, 0) == 0x2000
+; run: %sshr_i16_i128(0x4000, 34, 0) == 0x1000
+; run: %sshr_i16_i128(0x4000, 34, 0xffffffff_ffffffff) == 0x1000
+
+function %sshr_i8_i128(i8, i64, i64) -> i8 {
+block0(v0: i8, v1: i64, v2: i64):
+    v3 = iconcat v1, v2
+    v4 = sshr.i8 v0, v3
+    return v4
+}
+; run: %sshr_i8_i128(0x80, 0, 0) == 0x80
+; run: %sshr_i8_i128(0x80, 1, 0) == 0xC0
+; run: %sshr_i8_i128(0xf0, 0, 0) == 0xf0
+; run: %sshr_i8_i128(0xf0, 4, 0) == 0xff
+; run: %sshr_i8_i128(0x40, 8, 0) == 0x40
+; run: %sshr_i8_i128(0x40, 9, 0) == 0x20
+; run: %sshr_i8_i128(0x40, 10, 0) == 0x10
+; run: %sshr_i8_i128(0x40, 32, 0) == 0x40
+; run: %sshr_i8_i128(0x40, 33, 0) == 0x20
+; run: %sshr_i8_i128(0x40, 34, 0) == 0x10
+; run: %sshr_i8_i128(0x40, 34, 0xffffffff_ffffffff) == 0x10
 
 function %ishl_i64_const(i64) -> i64 {
 block0(v0: i64):

--- a/cranelift/filetests/filetests/runtests/simd-ishl.clif
+++ b/cranelift/filetests/filetests/runtests/simd-ishl.clif
@@ -45,6 +45,45 @@ block0(v0: i64x2, v1: i32):
 ; run: %ishl_i64x2([1 2], 1) == [2 4]
 ; run: %ishl_i64x2([1 2], 65) == [2 4]
 
+function %ishl_i8x16_i128(i8x16, i64, i64) -> i8x16 {
+block0(v0: i8x16, v1: i64, v2: i64):
+    v3 = iconcat v1, v2
+    v4 = ishl v0, v3
+    return v4
+}
+; run: %ishl_i8x16_i128([0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15], 4, 0) == [0x00 0x10 0x20 0x30 0x40 0x50 0x60 0x70 0x80 0x90 0xa0 0xb0 0xc0 0xd0 0xe0 0xf0]
+; run: %ishl_i8x16_i128([0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15], 12, 0) == [0x00 0x10 0x20 0x30 0x40 0x50 0x60 0x70 0x80 0x90 0xa0 0xb0 0xc0 0xd0 0xe0 0xf0]
+; run: %ishl_i8x16_i128([0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15], 12, 0xffffffff_ffffffff) == [0x00 0x10 0x20 0x30 0x40 0x50 0x60 0x70 0x80 0x90 0xa0 0xb0 0xc0 0xd0 0xe0 0xf0]
+
+function %ishl_i16x8_i128(i16x8, i64, i64) -> i16x8 {
+block0(v0: i16x8, v1: i64, v2: i64):
+    v3 = iconcat v1, v2
+    v4 = ishl v0, v3
+    return v4
+}
+; run: %ishl_i16x8_i128([1 2 4 8 16 32 64 128], 1, 0) == [2 4 8 16 32 64 128 256]
+; run: %ishl_i16x8_i128([1 2 4 8 16 32 64 128], 17, 0) == [2 4 8 16 32 64 128 256]
+; run: %ishl_i16x8_i128([1 2 4 8 16 32 64 128], 17, 0xffffffff_ffffffff) == [2 4 8 16 32 64 128 256]
+
+function %ishl_i32x4_i128(i32x4, i64, i64) -> i32x4 {
+block0(v0: i32x4, v1: i64, v2: i64):
+    v3 = iconcat v1, v2
+    v4 = ishl v0, v3
+    return v4
+}
+; run: %ishl_i32x4_i128([1 2 4 8], 1, 0) == [2 4 8 16]
+; run: %ishl_i32x4_i128([1 2 4 8], 33, 0) == [2 4 8 16]
+; run: %ishl_i32x4_i128([1 2 4 8], 33, 0xffffffff_ffffffff) == [2 4 8 16]
+
+function %ishl_i64x2_i128(i64x2, i64, i64) -> i64x2 {
+block0(v0: i64x2, v1: i64, v2: i64):
+    v3 = iconcat v1, v2
+    v4 = ishl v0, v3
+    return v4
+}
+; run: %ishl_i64x2_i128([1 2], 1, 0) == [2 4]
+; run: %ishl_i64x2_i128([1 2], 65, 0) == [2 4]
+; run: %ishl_i64x2_i128([1 2], 65, 0xffffffff_ffffffff) == [2 4]
 
 function %ishl_imm_i64x2(i64x2) -> i64x2 {
 block0(v0: i64x2):

--- a/cranelift/filetests/filetests/runtests/simd-sshr.clif
+++ b/cranelift/filetests/filetests/runtests/simd-sshr.clif
@@ -54,7 +54,48 @@ block0(v0:i64x2, v1:i32):
 ; run: %sshr_i64x2([0x80000000_00000000 0x7FFFFFFF_FFFFFFFF], 63) == [0xFFFFFFFF_FFFFFFFF 0]
 ; run: %sshr_i64x2([2 -2], 65) == [1 -1]
 
+function %sshr_i8x16_i128(i8x16, i64, i64) -> i8x16 {
+block0(v0: i8x16, v1: i64, v2: i64):
+    v3 = iconcat v1, v2
+    v4 = sshr v0, v3
+    return v4
+}
+; run: %sshr_i8x16_i128([0 0xff 2 0xfd 4 0xfb 6 0xf9 8 0xf7 10 0xf5 12 0xf3 14 0xf1], 1, 0) == [0 0xff 1 0xfe 2 0xfd 3 0xfc 4 0xfb 5 0xfa 6 0xf9 7 0xf8]
+; run: %sshr_i8x16_i128([0 0xff 2 0xfd 4 0xfb 6 0xf9 8 0xf7 10 0xf5 12 0xf3 14 0xf1], 9, 0) == [0 0xff 1 0xfe 2 0xfd 3 0xfc 4 0xfb 5 0xfa 6 0xf9 7 0xf8]
+; run: %sshr_i8x16_i128([0 0xff 2 0xfd 4 0xfb 6 0xf9 8 0xf7 10 0xf5 12 0xf3 14 0xf1], 9, 0xffffffff_ffffffff) == [0 0xff 1 0xfe 2 0xfd 3 0xfc 4 0xfb 5 0xfa 6 0xf9 7 0xf8]
 
+function %sshr_i16x8_i128(i16x8, i64, i64) -> i16x8 {
+block0(v0: i16x8, v1: i64, v2: i64):
+    v3 = iconcat v1, v2
+    v4 = sshr v0, v3
+    return v4
+}
+; run: %sshr_i16x8_i128([-1 2 4 8 -16 32 64 128], 1, 0) == [-1 1 2 4 -8 16 32 64]
+; run: %sshr_i16x8_i128([-1 2 4 8 -16 32 64 128], 17, 0) == [-1 1 2 4 -8 16 32 64]
+; run: %sshr_i16x8_i128([-1 2 4 8 -16 32 64 128], 17, 0xffffffff_ffffffff) == [-1 1 2 4 -8 16 32 64]
+
+function %sshr_i32x4_i128(i32x4, i64, i64) -> i32x4 {
+block0(v0: i32x4, v1: i64, v2: i64):
+    v3 = iconcat v1, v2
+    v4 = sshr v0, v3
+    return v4
+}
+; run: %sshr_i32x4_i128([1 2 4 -8], 1, 0) == [0 1 2 -4]
+; run: %sshr_i32x4_i128([1 2 4 -8], 33, 0) == [0 1 2 -4]
+; run: %sshr_i32x4_i128([1 2 4 -8], 33, 0xffffffff_ffffffff) == [0 1 2 -4]
+
+function %sshr_i64x2_i128(i64x2, i64, i64) -> i64x2 {
+block0(v0: i64x2, v1: i64, v2: i64):
+    v3 = iconcat v1, v2
+    v4 = sshr v0, v3
+    return v4
+}
+; run: %sshr_i64x2_i128([1 -1], 0, 0) == [1 -1]
+; run: %sshr_i64x2_i128([1 -1], 1, 0) == [0 -1] ; note the -1 shift result
+; run: %sshr_i64x2_i128([2 -2], 1, 0) == [1 -1]
+; run: %sshr_i64x2_i128([0x80000000_00000000 0x7FFFFFFF_FFFFFFFF], 63, 0) == [0xFFFFFFFF_FFFFFFFF 0]
+; run: %sshr_i64x2_i128([2 -2], 65, 0) == [1 -1]
+; run: %sshr_i64x2_i128([2 -2], 65, 0xffffffff_ffffffff) == [1 -1]
 
 function %sshr_imm_i32x4(i32x4) -> i32x4 {
 block0(v0: i32x4):

--- a/cranelift/filetests/filetests/runtests/simd-ushr.clif
+++ b/cranelift/filetests/filetests/runtests/simd-ushr.clif
@@ -2,6 +2,7 @@ test interpret
 test run
 target aarch64
 target s390x
+target x86_64
 target x86_64 skylake
 set enable_multi_ret_implicit_sret
 target riscv64 has_v
@@ -45,6 +46,46 @@ block0(v0: i64x2, v1: i32):
 ; run: %ushr_i64x2([1 2], 1) == [0 1]
 ; run: %ushr_i64x2([1 2], 65) == [0 1]
 
+function %ushr_i8x16_i128(i8x16, i64, i64) -> i8x16 {
+block0(v0: i8x16, v1: i64, v2: i64):
+    v3 = iconcat v1, v2
+    v4 = ushr v0, v3
+    return v4
+}
+; run: %ushr_i8x16_i128([0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15], 1, 0) == [0 0 1 1 2 2 3 3 4 4 5 5 6 6 7 7]
+; run: %ushr_i8x16_i128([0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15], 9, 0) == [0 0 1 1 2 2 3 3 4 4 5 5 6 6 7 7]
+; run: %ushr_i8x16_i128([0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15], 9, 0xffffffff_ffffffff) == [0 0 1 1 2 2 3 3 4 4 5 5 6 6 7 7]
+
+function %ushr_i16x8_i128(i16x8, i64, i64) -> i16x8 {
+block0(v0: i16x8, v1: i64, v2: i64):
+    v3 = iconcat v1, v2
+    v4 = ushr v0, v3
+    return v4
+}
+; run: %ushr_i16x8_i128([0 1 2 3 4 5 6 7], 1, 0) == [0 0 1 1 2 2 3 3]
+; run: %ushr_i16x8_i128([0 1 2 3 4 5 6 7], 17, 0) == [0 0 1 1 2 2 3 3]
+; run: %ushr_i16x8_i128([1 2 4 -8 0 0 0 0], 1, 0) == [0 1 2 32764 0 0 0 0]
+; run: %ushr_i16x8_i128([1 2 4 -8 0 0 0 0], 1, 0xffffffff_ffffffff) == [0 1 2 32764 0 0 0 0]
+
+function %ushr_i32x4_i128(i32x4, i64, i64) -> i32x4 {
+block0(v0: i32x4, v1: i64, v2: i64):
+    v3 = iconcat v1, v2
+    v4 = ushr v0, v3
+    return v4
+}
+; run: %ushr_i32x4_i128([1 2 4 8], 1, 0) == [0 1 2 4]
+; run: %ushr_i32x4_i128([1 2 4 8], 33, 0) == [0 1 2 4]
+; run: %ushr_i32x4_i128([1 2 4 8], 33, 0xffffffff_ffffffff) == [0 1 2 4]
+
+function %ushr_i64x2_i128(i64x2, i64, i64) -> i64x2 {
+block0(v0: i64x2, v1: i64, v2: i64):
+    v3 = iconcat v1, v2
+    v4 = ushr v0, v3
+    return v4
+}
+; run: %ushr_i64x2_i128([1 2], 1, 0) == [0 1]
+; run: %ushr_i64x2_i128([1 2], 65, 0) == [0 1]
+; run: %ushr_i64x2_i128([1 2], 65, 0xffffffff_ffffffff) == [0 1]
 
 function %ushr_imm_i16x8() -> i16x8 {
 block0:


### PR DESCRIPTION
Many backends panicked on i128 shift amounts due to using `put_in_reg` which panics on i128 values. The x64 backend also panicked on i128 divisors in `srem` due to a missing constraint that the type needs to fit in 64-bits (otherwise dividing by i128 just isn't supported).

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
