### PR TITLE
Fix loading fixed length lists from memory

### DIFF
--- a/crates/wasmtime/src/runtime/component/values.rs
+++ b/crates/wasmtime/src/runtime/component/values.rs
@@ -367,7 +367,7 @@ impl Val {
                 match number_elements.checked_mul(element_size) {
                     Some(total_size) if total_size <= bytes.len() => {
                         cx.consume_fuel_array(number_elements, size_of::<Val>())?;
-                        Val::Tuple(
+                        Val::FixedLengthList(
                             (0..number_elements)
                                 .map(|n| {
                                     // the match already checked that the whole array fits into usize


### PR DESCRIPTION
A copy/paste error meant that `Val::Tuple` was produced instead of `Val::FixedLengthList`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
