### PR TITLE
Fix mid-end ISLE spec causing verification timeout

### DIFF
--- a/cranelift/codegen/src/spec/opt.isle
+++ b/cranelift/codegen/src/spec/opt.isle
@@ -546,7 +546,7 @@
     (match (and (bvsge result (int2bv 64 0))
                 (not (bv_is_zero! result))
                 (bv_is_zero! (bvand result (bvsub result (int2bv 64 1))))))
-    (provide (= x (clz (rev result)))))
+    (provide (= result (bvshl (int2bv 64 1) (zero_ext 64 x)))))
 
 ;;;; Condition-code helpers ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; `IntCC::complement` (negate) / `IntCC::swap_args` (swap operands), per


### PR DESCRIPTION
This commit fixes a recently upstreamed VeriISLE follow-up work to verify many mid-end ISLE rules in #13935. Currently, the verification times out for this specific rule:

```
(rule (simplify (imul ty x (iconst _ (imm64_power_of_two c))))
      (ishl ty x (iconst ty (imm64 c))))
```

This is because the `imm64_power_of_two` extractor contains a buggy `provides` block. This commit changes the specification to a more intuitive one that successfully verifies.

Before fix:

```
============================= Verification summary ============================
Total expansions:    1331
In scope expansions: 1054
Type instantiations: 5148
Applicable:          5134
Verification passed: 5133
Verification failed: 0
Verification unknown: 1
===============================================================================
```

After fix:

```
============================= Verification summary ============================
Total expansions:    1331
In scope expansions: 1054
Type instantiations: 5148
Applicable:          5134
Verification passed: 5134
Verification failed: 0
Verification unknown: 0
===============================================================================
```
