### PR TITLE
Fix processing of `assert_malformed`

### DIFF
--- a/crates/wasmtime/src/runtime/component/component.rs
+++ b/crates/wasmtime/src/runtime/component/component.rs
@@ -12,6 +12,7 @@ use crate::{
 };
 use crate::{FuncType, ValType};
 use alloc::sync::Arc;
+use core::fmt;
 use core::ops::Range;
 use core::ptr::NonNull;
 #[cfg(feature = "std")]
@@ -98,6 +99,12 @@ struct ComponentInner {
 
     /// The checksum of the source binary from which the module was compiled.
     checksum: WasmChecksum,
+}
+
+impl fmt::Debug for Component {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Component").finish_non_exhaustive()
+    }
 }
 
 pub(crate) struct AllCallFuncPointers {

--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -66,7 +66,7 @@ enum Results {
     Component(Vec<component::Val>),
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 enum ModuleKind {
     Core(Module),
     #[cfg(feature = "component-model")]
@@ -415,10 +415,7 @@ impl WastContext {
     /// This will not register the name within `self.modules`.
     fn module_definition(&mut self, file: &WasmFile) -> Result<ModuleKind> {
         let name = match file.module_type {
-            WasmFileType::Text => file
-                .binary_filename
-                .as_ref()
-                .ok_or_else(|| format_err!("cannot compile module that isn't a valid binary"))?,
+            WasmFileType::Text => file.binary_filename.as_ref().unwrap_or(&file.filename),
             WasmFileType::Binary => &file.filename,
         };
 
@@ -741,21 +738,17 @@ impl WastContext {
                 file,
                 text,
                 line: _,
+            }
+            | AssertMalformed {
+                file,
+                text,
+                line: _,
             } => {
                 let err = match self.module_definition(&file) {
                     Ok(_) => bail!("expected module to fail to build"),
                     Err(e) => e,
                 };
                 self.match_error_message(&text, err)?;
-            }
-            AssertMalformed {
-                file,
-                text: _,
-                line: _,
-            } => {
-                if let Ok(_) = self.module_definition(&file) {
-                    bail!("expected malformed module to fail to instantiate");
-                }
             }
             AssertUnlinkable {
                 file,

--- a/tests/misc_testsuite/no-panic-on-invalid.wast
+++ b/tests/misc_testsuite/no-panic-on-invalid.wast
@@ -32,4 +32,4 @@
     ;; pretend this is the actual function end
     "\0b"             ;; end
   )
-  "hello")
+  "operators remaining after end")


### PR DESCRIPTION
For tests specifically of a text parser they accidentally always passed due to the `binary_filename` field missing. This commit fixes this by falling back to parsing the text format in `wasmtime wast` which will report a test failure should the text format actually parse successfully.

Closes #13963

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
