### PR TITLE
Port `VM*Import` and `VMFuncRef` over to `for_each_vm_type!`

### DIFF
--- a/crates/cranelift/src/alias_region.rs
+++ b/crates/cranelift/src/alias_region.rs
@@ -540,11 +540,16 @@ impl<'a, Offsets> Field<'a, Offsets> {
 macro_rules! define_vm_type_alias_region_helpers {
     // Classify a field type to its Cranelift `ir::Type`, given `$pt` (the
     // target pointer type as an `ir::Type`).
-    (@field_ty $pt:expr, VmPtr < u8 >) => { $pt };
+    (@field_ty $pt:expr, VmPtr < $g:ty >) => { $pt };
+    (@field_ty $pt:expr, Option < $g:ty >) => { $pt };
     (@field_ty $pt:expr, AtomicUsize) => { $pt };
     (@field_ty $pt:expr, usize) => { $pt };
     (@field_ty $pt:expr, [u8; 16]) => { ir::types::I8X16 };
     (@field_ty $pt:expr, VMSharedTypeIndex) => { ir::types::I32 };
+    (@field_ty $pt:expr, DefinedTableIndex) => { ir::types::I32 };
+    (@field_ty $pt:expr, DefinedMemoryIndex) => { ir::types::I32 };
+    (@field_ty $pt:expr, DefinedTagIndex) => { ir::types::I32 };
+    (@field_ty $pt:expr, VMGlobalKind) => { ir::types::I64 };
 
     // Apply a field attribute to its access flags. The `#[readonly]` and
     // `#[can_move]` markers map to the corresponding `MemFlagsData` builder
@@ -563,7 +568,7 @@ macro_rules! define_vm_type_alias_region_helpers {
         $svis:vis struct $Name:ident {
             $(
                 $( # $fattr:tt )*
-                $fvis:vis $fname:ident : $fty:tt $(< $fgen:tt >)? ,
+                $fvis:vis $fname:ident : $fty:tt $(< $fgen:ty >)? ,
             )*
         }
     )* ) => {
@@ -892,7 +897,7 @@ impl AliasRegions<VMOffsets<u8>> {
             ir::MemFlagsData::trusted().with_readonly().with_can_move(),
             vmctx,
             self.offsets.vmctx_vmtag_import_vmctx(tag),
-            self.offsets.vmtag_import_vmctx().into(),
+            self.offsets.ptr.vm_tag_import().vmctx().into(),
             VmType::VMTagImport,
         )
     }
@@ -911,7 +916,7 @@ impl AliasRegions<VMOffsets<u8>> {
             ir::MemFlagsData::trusted().with_readonly().with_can_move(),
             vmctx,
             self.offsets.vmctx_vmtag_import_index(tag),
-            self.offsets.vmtag_import_index().into(),
+            self.offsets.ptr.vm_tag_import().index().into(),
             VmType::VMTagImport,
         )
     }
@@ -930,7 +935,7 @@ impl AliasRegions<VMOffsets<u8>> {
             ir::MemFlagsData::trusted().with_readonly().with_can_move(),
             vmctx,
             self.offsets.vmctx_vmtag_import_from(tag),
-            self.offsets.vmtag_import_from().into(),
+            self.offsets.ptr.vm_tag_import().from().into(),
             VmType::VMTagImport,
         )
     }
@@ -949,7 +954,7 @@ impl AliasRegions<VMOffsets<u8>> {
             ir::MemFlagsData::trusted().with_readonly().with_can_move(),
             vmctx,
             self.offsets.vmctx_vmfunction_import_vmctx(func),
-            self.offsets.vmfunction_import_vmctx().into(),
+            self.offsets.ptr.vm_function_import().vmctx().into(),
             VmType::VMFunctionImport,
         )
     }
@@ -968,7 +973,7 @@ impl AliasRegions<VMOffsets<u8>> {
             ir::MemFlagsData::trusted().with_readonly().with_can_move(),
             vmctx,
             self.offsets.vmctx_vmfunction_import_wasm_call(func),
-            self.offsets.vmfunction_import_wasm_call().into(),
+            self.offsets.ptr.vm_function_import().wasm_call().into(),
             VmType::VMFunctionImport,
         )
     }
@@ -982,14 +987,14 @@ impl AliasRegions<VMOffsets<u8>> {
         memory: MemoryIndex,
     ) -> ir::Value {
         let mem_offset = self.offsets.vmctx_vmmemory_import(memory);
-        let mem_vmctx_offset = mem_offset + u32::from(self.offsets.vmmemory_import_vmctx());
+        let mem_vmctx_offset = mem_offset + u32::from(self.offsets.ptr.vm_memory_import().vmctx());
         self.vmimport_load(
             cursor,
             self.pointer_type,
             ir::MemFlagsData::trusted().with_readonly().with_can_move(),
             vmctx,
             mem_vmctx_offset,
-            self.offsets.vmmemory_import_vmctx().into(),
+            self.offsets.ptr.vm_memory_import().vmctx().into(),
             VmType::VMMemoryImport,
         )
     }
@@ -1003,14 +1008,14 @@ impl AliasRegions<VMOffsets<u8>> {
         memory: MemoryIndex,
     ) -> ir::Value {
         let mem_offset = self.offsets.vmctx_vmmemory_import(memory);
-        let mem_index_offset = mem_offset + u32::from(self.offsets.vmmemory_import_index());
+        let mem_index_offset = mem_offset + u32::from(self.offsets.ptr.vm_memory_import().index());
         self.vmimport_load(
             cursor,
             ir::types::I32,
             ir::MemFlagsData::trusted().with_readonly().with_can_move(),
             vmctx,
             mem_index_offset,
-            self.offsets.vmmemory_import_index().into(),
+            self.offsets.ptr.vm_memory_import().index().into(),
             VmType::VMMemoryImport,
         )
     }
@@ -1035,12 +1040,12 @@ impl AliasRegions<VMOffsets<u8>> {
         memory: MemoryIndex,
     ) -> Load {
         let mem_offset = self.offsets.vmctx_vmmemory_import(memory);
-        let offset = mem_offset + u32::from(self.offsets.vmmemory_import_from());
+        let offset = mem_offset + u32::from(self.offsets.ptr.vm_memory_import().from());
         let region = self.region(
             func,
             AliasRegionKey::Vm {
                 ty: VmType::VMMemoryImport,
-                offset: self.offsets.vmmemory_import_from().into(),
+                offset: self.offsets.ptr.vm_memory_import().from().into(),
             },
         );
         Load {
@@ -1062,14 +1067,15 @@ impl AliasRegions<VMOffsets<u8>> {
         table: TableIndex,
     ) -> ir::Value {
         let table_offset = self.offsets.vmctx_vmtable_import(table);
-        let table_vmctx_offset = table_offset + u32::from(self.offsets.vmtable_import_vmctx());
+        let table_vmctx_offset =
+            table_offset + u32::from(self.offsets.ptr.vm_table_import().vmctx());
         self.vmimport_load(
             cursor,
             self.pointer_type,
             ir::MemFlagsData::trusted().with_readonly().with_can_move(),
             vmctx,
             table_vmctx_offset,
-            self.offsets.vmtable_import_vmctx().into(),
+            self.offsets.ptr.vm_table_import().vmctx().into(),
             VmType::VMTableImport,
         )
     }
@@ -1083,14 +1089,15 @@ impl AliasRegions<VMOffsets<u8>> {
         table: TableIndex,
     ) -> ir::Value {
         let table_offset = self.offsets.vmctx_vmtable_import(table);
-        let table_index_offset = table_offset + u32::from(self.offsets.vmtable_import_index());
+        let table_index_offset =
+            table_offset + u32::from(self.offsets.ptr.vm_table_import().index());
         self.vmimport_load(
             cursor,
             ir::types::I32,
             ir::MemFlagsData::trusted().with_readonly().with_can_move(),
             vmctx,
             table_index_offset,
-            self.offsets.vmtable_import_index().into(),
+            self.offsets.ptr.vm_table_import().index().into(),
             VmType::VMTableImport,
         )
     }
@@ -1103,7 +1110,7 @@ impl AliasRegions<VMOffsets<u8>> {
             func,
             AliasRegionKey::Vm {
                 ty: VmType::VMTableImport,
-                offset: self.offsets.vmtable_import_from().into(),
+                offset: self.offsets.ptr.vm_table_import().from().into(),
             },
         );
         Load {
@@ -1131,7 +1138,7 @@ impl AliasRegions<VMOffsets<u8>> {
             ir::MemFlagsData::trusted().with_readonly().with_can_move(),
             vmctx,
             from_offset,
-            self.offsets.vmglobal_import_from().into(),
+            self.offsets.ptr.vm_global_import().from().into(),
             VmType::VMGlobalImport,
         )
     }
@@ -1902,7 +1909,7 @@ where
         base_flags: ir::MemFlagsData,
         funcref: ir::Value,
     ) -> ir::Value {
-        let offset = self.offsets.get_ptr_size().vm_func_ref_type_index();
+        let offset = self.offsets.get_ptr_size().vm_func_ref().type_index();
         let region = self.vmfuncref_region(cursor.func, offset.into());
         let ty = ir::Type::int_with_byte_size(
             self.offsets
@@ -1929,7 +1936,7 @@ where
         base_flags: ir::MemFlagsData,
         funcref: ir::Value,
     ) -> ir::Value {
-        let offset = self.offsets.get_ptr_size().vm_func_ref_wasm_call();
+        let offset = self.offsets.get_ptr_size().vm_func_ref().wasm_call();
         let region = self.vmfuncref_region(cursor.func, offset.into());
         cursor.ins().load(
             self.pointer_type,
@@ -1946,7 +1953,7 @@ where
         base_flags: ir::MemFlagsData,
         funcref: ir::Value,
     ) -> ir::Value {
-        let offset = self.offsets.get_ptr_size().vm_func_ref_vmctx();
+        let offset = self.offsets.get_ptr_size().vm_func_ref().vmctx();
         let region = self.vmfuncref_region(cursor.func, offset.into());
         cursor.ins().load(
             self.pointer_type,
@@ -1967,7 +1974,7 @@ where
             .offsets
             .get_ptr_size()
             .vmarray_call_host_func_context_func_ref();
-        let field = self.offsets.get_ptr_size().vm_func_ref_array_call();
+        let field = self.offsets.get_ptr_size().vm_func_ref().array_call();
         let region = self.vmfuncref_region(cursor.func, field.into());
         cursor.ins().load(
             self.pointer_type,

--- a/crates/cranelift/src/alias_region.rs
+++ b/crates/cranelift/src/alias_region.rs
@@ -541,7 +541,7 @@ macro_rules! define_vm_type_alias_region_helpers {
     // Classify a field type to its Cranelift `ir::Type`, given `$pt` (the
     // target pointer type as an `ir::Type`).
     (@field_ty $pt:expr, VmPtr < $g:ty >) => { $pt };
-    (@field_ty $pt:expr, Option < $g:ty >) => { $pt };
+    (@field_ty $pt:expr, Option < VmPtr < $g:ty >>) => { $pt };
     (@field_ty $pt:expr, AtomicUsize) => { $pt };
     (@field_ty $pt:expr, usize) => { $pt };
     (@field_ty $pt:expr, [u8; 16]) => { ir::types::I8X16 };
@@ -559,6 +559,100 @@ macro_rules! define_vm_type_alias_region_helpers {
     (@apply_attr $flags:expr, [can_move]) => { $flags.with_can_move() };
     (@apply_attr $flags:expr, [doc = $d:literal]) => { $flags };
 
+    // Emit the accessor `struct` and per-field methods for one `VM*` type.
+    //
+    // Fields arrive pre-split into `{ $fname [ $attrs... ] [ $fty... ] }` groups
+    // (see `@munch` below); the terminal arm consumes those groups once the
+    // struct body has been fully peeled apart.
+    (@emit $Name:ident $snake:ident {
+        $( { $fname:ident [ $($fattr:tt)* ] [ $($fty:tt)* ] } )*
+    }) => {
+        #[doc = concat!(
+            "An [`AliasRegions`] accessor for the fields of a `",
+            stringify!($Name), "`."
+        )]
+        #[allow(
+            dead_code,
+            reason = "generated uniformly for all VM types; not all accessors are used yet"
+        )]
+        pub struct $Name<'a, Offsets> {
+            regions: &'a mut AliasRegions<Offsets>,
+        }
+
+        #[allow(
+            dead_code,
+            reason = "generated uniformly for all VM types; not all accessors are used yet"
+        )]
+        impl<Offsets> AliasRegions<Offsets> {
+            #[doc = concat!(
+                "Get an accessor for the fields of a `", stringify!($Name), "`."
+            )]
+            pub fn $snake(&mut self) -> $Name<'_, Offsets> {
+                $Name { regions: self }
+            }
+        }
+
+        #[allow(
+            dead_code,
+            reason = "generated uniformly for all VM types; not all accessors are used yet"
+        )]
+        impl<'a, Offsets> $Name<'a, Offsets>
+        where
+            Offsets: GetPtrSize,
+        {
+            $(
+                #[doc = concat!(
+                    "Get the [`Field`] for the `", stringify!($fname),
+                    "` field of `", stringify!($Name), "`."
+                )]
+                pub fn $fname(self) -> Field<'a, Offsets> {
+                    let offset = u32::from(
+                        self.regions.offsets.get_ptr_size().$snake().$fname()
+                    );
+                    let flags = ir::MemFlagsData::trusted();
+                    $(
+                        let flags = define_vm_type_alias_region_helpers!(
+                            @apply_attr flags, $fattr
+                        );
+                    )*
+                    let ty = define_vm_type_alias_region_helpers!(
+                        @field_ty self.regions.pointer_type, $($fty)*
+                    );
+                    Field::new(self.regions, VmType::$Name, offset, flags, ty)
+                }
+            )*
+        }
+    };
+
+    // Peel fields off the raw struct body one at a time, accumulating completed
+    // `{ $fname [ $attrs... ] [ $fty... ] }` groups plus the pending attributes
+    // for the field currently being parsed.
+    //
+    // Splitting the body by hand (rather than matching `$fty:tt $(< $fgen:ty
+    // >)?` within a repetition) is what lets each field's type reach the
+    // `@field_ty` classifier as raw tokens, so it can require `Option`s to
+    // specifically be `Option<VmPtr<_>>`.
+    (@munch $Name:ident $snake:ident { $($groups:tt)* } [ $($pend:tt)* ]) => {
+        define_vm_type_alias_region_helpers!(@emit $Name $snake { $($groups)* });
+    };
+    // Stash a field attribute's bracket group (`[readonly]`, `[can_move]`,
+    // `[doc = ...]`) as pending for the next field.
+    (@munch $Name:ident $snake:ident { $($groups:tt)* } [ $($pend:tt)* ] # $fattr:tt $($rest:tt)*) => {
+        define_vm_type_alias_region_helpers!(@munch $Name $snake { $($groups)* } [ $($pend)* $fattr ] $($rest)*);
+    };
+    // Consume a field's visibility and name, then collect its type tokens.
+    (@munch $Name:ident $snake:ident { $($groups:tt)* } [ $($pend:tt)* ] $fvis:vis $fname:ident : $($rest:tt)*) => {
+        define_vm_type_alias_region_helpers!(@munch_ty $Name $snake { $($groups)* } $fname [ $($pend)* ] [] $($rest)*);
+    };
+    // Accumulate one field's type tokens up to its terminating comma, then
+    // append the completed group and reset the pending attributes.
+    (@munch_ty $Name:ident $snake:ident { $($groups:tt)* } $fname:ident [ $($pend:tt)* ] [ $($fty:tt)* ] , $($rest:tt)*) => {
+        define_vm_type_alias_region_helpers!(@munch $Name $snake { $($groups)* { $fname [ $($pend)* ] [ $($fty)* ] } } [] $($rest)*);
+    };
+    (@munch_ty $Name:ident $snake:ident { $($groups:tt)* } $fname:ident [ $($pend:tt)* ] [ $($fty:tt)* ] $tok:tt $($rest:tt)*) => {
+        define_vm_type_alias_region_helpers!(@munch_ty $Name $snake { $($groups)* } $fname [ $($pend)* ] [ $($fty)* $tok ] $($rest)*);
+    };
+
     // Top-level entry: the list of `VM*` type definitions.
     ( $(
         $(#[doc = $sdoc:literal])*
@@ -566,68 +660,11 @@ macro_rules! define_vm_type_alias_region_helpers {
         #[repr($($repr:tt)*)]
         #[snake_name = $snake:ident]
         $svis:vis struct $Name:ident {
-            $(
-                $( # $fattr:tt )*
-                $fvis:vis $fname:ident : $fty:tt $(< $fgen:ty >)? ,
-            )*
+            $($body:tt)*
         }
     )* ) => {
         $(
-            #[doc = concat!(
-                "An [`AliasRegions`] accessor for the fields of a `",
-                stringify!($Name), "`."
-            )]
-            #[allow(
-                dead_code,
-                reason = "generated uniformly for all VM types; not all accessors are used yet"
-            )]
-            pub struct $Name<'a, Offsets> {
-                regions: &'a mut AliasRegions<Offsets>,
-            }
-
-            #[allow(
-                dead_code,
-                reason = "generated uniformly for all VM types; not all accessors are used yet"
-            )]
-            impl<Offsets> AliasRegions<Offsets> {
-                #[doc = concat!(
-                    "Get an accessor for the fields of a `", stringify!($Name), "`."
-                )]
-                pub fn $snake(&mut self) -> $Name<'_, Offsets> {
-                    $Name { regions: self }
-                }
-            }
-
-            #[allow(
-                dead_code,
-                reason = "generated uniformly for all VM types; not all accessors are used yet"
-            )]
-            impl<'a, Offsets> $Name<'a, Offsets>
-            where
-                Offsets: GetPtrSize,
-            {
-                $(
-                    #[doc = concat!(
-                        "Get the [`Field`] for the `", stringify!($fname),
-                        "` field of `", stringify!($Name), "`."
-                    )]
-                    pub fn $fname(self) -> Field<'a, Offsets> {
-                        let offset = u32::from(
-                            self.regions.offsets.get_ptr_size().$snake().$fname()
-                        );
-                        let flags = ir::MemFlagsData::trusted();
-                        $(
-                            let flags = define_vm_type_alias_region_helpers!(
-                                @apply_attr flags, $fattr
-                            );
-                        )*
-                        let ty = define_vm_type_alias_region_helpers!(
-                            @field_ty self.regions.pointer_type, $fty $(< $fgen >)?
-                        );
-                        Field::new(self.regions, VmType::$Name, offset, flags, ty)
-                    }
-                )*
-            }
+            define_vm_type_alias_region_helpers!(@munch $Name $snake {} [] $($body)*);
         )*
     };
 }

--- a/crates/cranelift/src/debug.rs
+++ b/crates/cranelift/src/debug.rs
@@ -103,7 +103,7 @@ impl<'a> Compilation<'a> {
                 let index = MemoryIndex::new(0);
                 ModuleMemoryOffset::Imported {
                     offset_to_vm_memory_definition: ofs.vmctx_vmmemory_import(index)
-                        + u32::from(ofs.vmmemory_import_from()),
+                        + u32::from(ofs.ptr.vm_memory_import().from()),
                     offset_to_memory_base: ofs.ptr.vm_memory_definition().base().into(),
                 }
             } else if ofs.num_owned_memories > 0 {

--- a/crates/environ/src/component/vmcomponent_offsets.rs
+++ b/crates/environ/src/component/vmcomponent_offsets.rs
@@ -175,11 +175,11 @@ impl<P: PtrSize> VMComponentOffsets<P> {
             size(may_leave) = cmul(ret.num_runtime_component_instances, ret.ptr.vm_global_definition().size()),
             size(task_may_block) = ret.ptr.vm_global_definition().size(),
             align(u32::from(ret.ptr.size())),
-            size(trampoline_func_refs) = cmul(ret.num_trampolines, ret.ptr.size_of_vm_func_ref()),
-            size(intrinsic_func_refs) = cmul(ret.num_unsafe_intrinsics, ret.ptr.size_of_vm_func_ref()),
+            size(trampoline_func_refs) = cmul(ret.num_trampolines, ret.ptr.vm_func_ref().size()),
+            size(intrinsic_func_refs) = cmul(ret.num_unsafe_intrinsics, ret.ptr.vm_func_ref().size()),
             size(lowerings) = cmul(ret.num_lowerings, ret.ptr.size() * 2),
             size(memories) = cmul(ret.num_runtime_memories, ret.ptr.size()),
-            size(tables) = cmul(ret.num_runtime_tables, ret.size_of_vmtable_import()),
+            size(tables) = cmul(ret.num_runtime_tables, ret.ptr.vm_table_import().size()),
             size(reallocs) = cmul(ret.num_runtime_reallocs, ret.ptr.size()),
             size(callbacks) = cmul(ret.num_runtime_callbacks, ret.ptr.size()),
             size(post_returns) = cmul(ret.num_runtime_post_returns, ret.ptr.size()),
@@ -242,7 +242,7 @@ impl<P: PtrSize> VMComponentOffsets<P> {
     #[inline]
     pub fn trampoline_func_ref(&self, index: TrampolineIndex) -> u32 {
         assert!(index.as_u32() < self.num_trampolines);
-        self.trampoline_func_refs() + index.as_u32() * u32::from(self.ptr.size_of_vm_func_ref())
+        self.trampoline_func_refs() + index.as_u32() * u32::from(self.ptr.vm_func_ref().size())
     }
 
     /// The offset of the `unsafe_intrinsic_func_refs` field.
@@ -256,7 +256,7 @@ impl<P: PtrSize> VMComponentOffsets<P> {
     pub fn unsafe_intrinsic_func_ref(&self, intrinsic: UnsafeIntrinsic) -> u32 {
         assert!(intrinsic.index() < self.num_unsafe_intrinsics);
         self.unsafe_intrinsic_func_refs()
-            + intrinsic.index() * u32::from(self.ptr.size_of_vm_func_ref())
+            + intrinsic.index() * u32::from(self.ptr.vm_func_ref().size())
     }
 
     /// The offset of the `lowerings` field.
@@ -326,14 +326,7 @@ impl<P: PtrSize> VMComponentOffsets<P> {
     #[inline]
     pub fn runtime_table(&self, index: RuntimeTableIndex) -> u32 {
         assert!(index.as_u32() < self.num_runtime_tables);
-        self.runtime_tables() + index.as_u32() * u32::from(self.size_of_vmtable_import())
-    }
-
-    /// Return the size of `VMTableImport`, used here to hold the pointers to
-    /// the `VMTableDefinition` and `VMContext`.
-    #[inline]
-    pub fn size_of_vmtable_import(&self) -> u8 {
-        3 * self.pointer_size()
+        self.runtime_tables() + index.as_u32() * u32::from(self.ptr.vm_table_import().size())
     }
 
     /// The offset of the base of the `runtime_reallocs` field

--- a/crates/environ/src/vmoffsets.rs
+++ b/crates/environ/src/vmoffsets.rs
@@ -72,7 +72,7 @@ macro_rules! define_vm_type_offsets {
     // references; and `VMGlobalKind` is a `repr(C, u32)` enum with a `u32`
     // payload.
     (@size ($p:expr) VmPtr < $g:ty >) => { u32::from($p) };
-    (@size ($p:expr) Option < $g:ty >) => { u32::from($p) };
+    (@size ($p:expr) Option < VmPtr < $g:ty >>) => { u32::from($p) };
     (@size ($p:expr) AtomicUsize) => { u32::from($p) };
     (@size ($p:expr) usize) => { u32::from($p) };
     (@size ($p:expr) [u8; 16]) => { 16u32 };
@@ -85,7 +85,7 @@ macro_rules! define_vm_type_offsets {
     // Classify a field type to its alignment in bytes as a `u32`, given `$p`
     // (the target pointer size as a `u8`).
     (@align ($p:expr) VmPtr < $g:ty >) => { u32::from($p) };
-    (@align ($p:expr) Option < $g:ty >) => { u32::from($p) };
+    (@align ($p:expr) Option < VmPtr < $g:ty >>) => { u32::from($p) };
     (@align ($p:expr) AtomicUsize) => { u32::from($p) };
     (@align ($p:expr) usize) => { u32::from($p) };
     (@align ($p:expr) [u8; 16]) => { 16u32 };
@@ -104,9 +104,13 @@ macro_rules! define_vm_type_offsets {
     // caller-minted identifiers (for the pointer size and running offset) that
     // are threaded through the recursion so their hygiene stays consistent
     // across the emitted `let` bindings.
+    //
+    // Fields arrive pre-split into `[ $fname : $fty... ]` groups (see `@impl`
+    // below), so each field's type is a raw token sequence that the `@size`
+    // and `@align` classifiers can match against structurally.
     (@fields $Name:ident ($p:ident, $o:ident) prefix( $($prefix:tt)* )) => {};
     (@fields $Name:ident ($p:ident, $o:ident) prefix( $($prefix:tt)* )
-        [ $fname:ident : $fty:tt $(< $fgen:ty >)? ]
+        [ $fname:ident : $($fty:tt)* ]
         $($rest:tt)*
     ) => {
         #[doc = concat!(
@@ -118,18 +122,80 @@ macro_rules! define_vm_type_offsets {
             let $p = self.0.size();
             let $o: u32 = 0;
             $($prefix)*
-            let $o = align($o, define_vm_type_offsets!(@align ($p) $fty $(< $fgen >)?));
+            let $o = align($o, define_vm_type_offsets!(@align ($p) $($fty)*));
             let _ = $p;
             u8::try_from($o).unwrap()
         }
         define_vm_type_offsets!(@fields $Name ($p, $o)
             prefix(
                 $($prefix)*
-                let $o = align($o, define_vm_type_offsets!(@align ($p) $fty $(< $fgen >)?));
-                let $o = $o + define_vm_type_offsets!(@size ($p) $fty $(< $fgen >)?);
+                let $o = align($o, define_vm_type_offsets!(@align ($p) $($fty)*));
+                let $o = $o + define_vm_type_offsets!(@size ($p) $($fty)*);
             )
             $($rest)*
         );
+    };
+
+    // Emit an `offsets::VMFoo` type's inherent `impl`. Fields are peeled off
+    // the raw struct body one at a time into `[ $fname : $fty... ]` groups
+    // accumulated in the `{ ... }` list; once the body is exhausted, the
+    // terminal arm emits the per-field offset methods plus `align`/`size`.
+    //
+    // Splitting the body by hand (rather than matching `$fty:tt $(< $fgen:ty
+    // >)?` within a repetition) is what lets each field's type reach the
+    // `@size`/`@align` classifiers as raw tokens, so those classifiers can
+    // require `Option`s to specifically be `Option<VmPtr<_>>`.
+    (@impl $Name:ident [$($repr:tt)*] { $( [ $fname:ident : $($fty:tt)* ] )* }) => {
+        impl<P: PtrSize> $Name<P> {
+            define_vm_type_offsets!(@fields $Name (p, o) prefix()
+                $( [ $fname : $($fty)* ] )*
+            );
+
+            #[doc = concat!("The alignment of the `", stringify!($Name), "` type.")]
+            #[inline]
+            pub fn align(&self) -> u8 {
+                let p = self.0.size();
+                let a: u32 = define_vm_type_offsets!(@repr_align $($repr)*);
+                $(
+                    let a = core::cmp::max(
+                        a,
+                        define_vm_type_offsets!(@align (p) $($fty)*),
+                    );
+                )*
+                let _ = p;
+                u8::try_from(a).unwrap()
+            }
+
+            #[doc = concat!("The size of the `", stringify!($Name), "` type.")]
+            #[inline]
+            pub fn size(&self) -> u8 {
+                let p = self.0.size();
+                let o: u32 = 0;
+                $(
+                    let o = align(o, define_vm_type_offsets!(@align (p) $($fty)*));
+                    let o = o + define_vm_type_offsets!(@size (p) $($fty)*);
+                )*
+                let o = align(o, u32::from(self.align()));
+                let _ = p;
+                u8::try_from(o).unwrap()
+            }
+        }
+    };
+    // Skip a field attribute (`#[doc = ...]`, `#[readonly]`, `#[can_move]`).
+    (@impl $Name:ident $repr:tt { $($groups:tt)* } #[$($attr:tt)*] $($rest:tt)*) => {
+        define_vm_type_offsets!(@impl $Name $repr { $($groups)* } $($rest)*);
+    };
+    // Consume a field's visibility and name, then collect its type tokens.
+    (@impl $Name:ident $repr:tt { $($groups:tt)* } $fvis:vis $fname:ident : $($rest:tt)*) => {
+        define_vm_type_offsets!(@impl_ty $Name $repr { $($groups)* } $fname [] $($rest)*);
+    };
+    // Accumulate one field's type tokens up to its terminating comma, then
+    // append the completed `[ $fname : $fty... ]` group and resume `@impl`.
+    (@impl_ty $Name:ident $repr:tt { $($groups:tt)* } $fname:ident [ $($fty:tt)* ] , $($rest:tt)*) => {
+        define_vm_type_offsets!(@impl $Name $repr { $($groups)* [ $fname : $($fty)* ] } $($rest)*);
+    };
+    (@impl_ty $Name:ident $repr:tt { $($groups:tt)* } $fname:ident [ $($fty:tt)* ] $tok:tt $($rest:tt)*) => {
+        define_vm_type_offsets!(@impl_ty $Name $repr { $($groups)* } $fname [ $($fty)* $tok ] $($rest)*);
     };
 
     // Top-level entry: the list of `VM*` type definitions.
@@ -139,12 +205,7 @@ macro_rules! define_vm_type_offsets {
         #[repr($($repr:tt)*)]
         #[snake_name = $snake:ident]
         $svis:vis struct $Name:ident {
-            $(
-                $(#[doc = $fdoc:literal])*
-                $(#[readonly])?
-                $(#[can_move])?
-                $fvis:vis $fname:ident : $fty:tt $(< $fgen:ty >)? ,
-            )*
+            $($body:tt)*
         }
     )* ) => {
         /// Offsets of fields within the various `VM*` types, parameterized over
@@ -160,40 +221,7 @@ macro_rules! define_vm_type_offsets {
                 #[doc = concat!("Offsets of fields within the `", stringify!($Name), "` type.")]
                 pub struct $Name<P: PtrSize>(pub P);
 
-                impl<P: PtrSize> $Name<P> {
-                    define_vm_type_offsets!(@fields $Name (p, o) prefix()
-                        $( [ $fname : $fty $(< $fgen >)? ] )*
-                    );
-
-                    #[doc = concat!("The alignment of the `", stringify!($Name), "` type.")]
-                    #[inline]
-                    pub fn align(&self) -> u8 {
-                        let p = self.0.size();
-                        let a: u32 = define_vm_type_offsets!(@repr_align $($repr)*);
-                        $(
-                            let a = core::cmp::max(
-                                a,
-                                define_vm_type_offsets!(@align (p) $fty $(< $fgen >)?),
-                            );
-                        )*
-                        let _ = p;
-                        u8::try_from(a).unwrap()
-                    }
-
-                    #[doc = concat!("The size of the `", stringify!($Name), "` type.")]
-                    #[inline]
-                    pub fn size(&self) -> u8 {
-                        let p = self.0.size();
-                        let o: u32 = 0;
-                        $(
-                            let o = align(o, define_vm_type_offsets!(@align (p) $fty $(< $fgen >)?));
-                            let o = o + define_vm_type_offsets!(@size (p) $fty $(< $fgen >)?);
-                        )*
-                        let o = align(o, u32::from(self.align()));
-                        let _ = p;
-                        u8::try_from(o).unwrap()
-                    }
-                }
+                define_vm_type_offsets!(@impl $Name [$($repr)*] {} $($body)*);
             )*
         }
     };

--- a/crates/environ/src/vmoffsets.rs
+++ b/crates/environ/src/vmoffsets.rs
@@ -67,20 +67,33 @@ fn align(offset: u32, width: u32) -> u32 {
 /// `size` and `align` methods.
 macro_rules! define_vm_type_offsets {
     // Classify a field type to its size in bytes as a `u32`, given `$p` (the
-    // target pointer size as a `u8`).
-    (@size ($p:expr) VmPtr < u8 >) => { u32::from($p) };
+    // target pointer size as a `u8`). All `VmPtr<_>` and `Option<VmPtr<_>>`
+    // fields are pointer-sized; the `Defined*Index` types are `u32` entity
+    // references; and `VMGlobalKind` is a `repr(C, u32)` enum with a `u32`
+    // payload.
+    (@size ($p:expr) VmPtr < $g:ty >) => { u32::from($p) };
+    (@size ($p:expr) Option < $g:ty >) => { u32::from($p) };
     (@size ($p:expr) AtomicUsize) => { u32::from($p) };
     (@size ($p:expr) usize) => { u32::from($p) };
     (@size ($p:expr) [u8; 16]) => { 16u32 };
     (@size ($p:expr) VMSharedTypeIndex) => { u32::from(($p).size_of_vmshared_type_index()) };
+    (@size ($p:expr) DefinedTableIndex) => { 4u32 };
+    (@size ($p:expr) DefinedMemoryIndex) => { 4u32 };
+    (@size ($p:expr) DefinedTagIndex) => { 4u32 };
+    (@size ($p:expr) VMGlobalKind) => { 8u32 };
 
     // Classify a field type to its alignment in bytes as a `u32`, given `$p`
     // (the target pointer size as a `u8`).
-    (@align ($p:expr) VmPtr < u8 >) => { u32::from($p) };
+    (@align ($p:expr) VmPtr < $g:ty >) => { u32::from($p) };
+    (@align ($p:expr) Option < $g:ty >) => { u32::from($p) };
     (@align ($p:expr) AtomicUsize) => { u32::from($p) };
     (@align ($p:expr) usize) => { u32::from($p) };
     (@align ($p:expr) [u8; 16]) => { 16u32 };
     (@align ($p:expr) VMSharedTypeIndex) => { u32::from(($p).align_of_vmshared_type_index()) };
+    (@align ($p:expr) DefinedTableIndex) => { 4u32 };
+    (@align ($p:expr) DefinedMemoryIndex) => { 4u32 };
+    (@align ($p:expr) DefinedTagIndex) => { 4u32 };
+    (@align ($p:expr) VMGlobalKind) => { 4u32 };
 
     // Classify a `#[repr(...)]` to the minimum alignment it forces, as a `u32`.
     (@repr_align C) => { 1u32 };
@@ -93,7 +106,7 @@ macro_rules! define_vm_type_offsets {
     // across the emitted `let` bindings.
     (@fields $Name:ident ($p:ident, $o:ident) prefix( $($prefix:tt)* )) => {};
     (@fields $Name:ident ($p:ident, $o:ident) prefix( $($prefix:tt)* )
-        [ $fname:ident : $fty:tt $(< $fgen:tt >)? ]
+        [ $fname:ident : $fty:tt $(< $fgen:ty >)? ]
         $($rest:tt)*
     ) => {
         #[doc = concat!(
@@ -130,7 +143,7 @@ macro_rules! define_vm_type_offsets {
                 $(#[doc = $fdoc:literal])*
                 $(#[readonly])?
                 $(#[can_move])?
-                $fvis:vis $fname:ident : $fty:tt $(< $fgen:tt >)? ,
+                $fvis:vis $fname:ident : $fty:tt $(< $fgen:ty >)? ,
             )*
         }
     )* ) => {
@@ -201,7 +214,7 @@ macro_rules! define_ptr_size_vm_type_accessors {
                 $(#[doc = $fdoc:literal])*
                 $(#[readonly])?
                 $(#[can_move])?
-                $fvis:vis $fname:ident : $fty:tt $(< $fgen:tt >)? ,
+                $fvis:vis $fname:ident : $fty:tt $(< $fgen:ty >)? ,
             )*
         }
     )* ) => {
@@ -289,36 +302,6 @@ pub trait PtrSize {
     /// The offset of the `VMContext::builtin_functions` field
     fn vmcontext_builtin_functions(&self) -> u8 {
         self.vmcontext_store_context() + self.size()
-    }
-
-    /// The offset of the `array_call` field.
-    #[inline]
-    fn vm_func_ref_array_call(&self) -> u8 {
-        0 * self.size()
-    }
-
-    /// The offset of the `wasm_call` field.
-    #[inline]
-    fn vm_func_ref_wasm_call(&self) -> u8 {
-        1 * self.size()
-    }
-
-    /// The offset of the `type_index` field.
-    #[inline]
-    fn vm_func_ref_type_index(&self) -> u8 {
-        2 * self.size()
-    }
-
-    /// The offset of the `vmctx` field.
-    #[inline]
-    fn vm_func_ref_vmctx(&self) -> u8 {
-        3 * self.size()
-    }
-
-    /// Return the size of `VMFuncRef`.
-    #[inline]
-    fn size_of_vm_func_ref(&self) -> u8 {
-        4 * self.size()
     }
 
     /// Return the size of `VMSharedTypeIndex`.
@@ -1004,19 +987,19 @@ impl<P: PtrSize> From<VMOffsetsFields<P>> for VMOffsets<P> {
 
         fields! {
             size(imported_memories)
-                = cmul(ret.num_imported_memories, ret.size_of_vmmemory_import()),
+                = cmul(ret.num_imported_memories, ret.ptr.vm_memory_import().size()),
             size(defined_memories)
                 = cmul(ret.num_defined_memories, ret.ptr.size_of_vmmemory_pointer()),
             size(owned_memories)
                 = cmul(ret.num_owned_memories, ret.ptr.vm_memory_definition().size()),
             size(imported_functions)
-                = cmul(ret.num_imported_functions, ret.size_of_vmfunction_import()),
+                = cmul(ret.num_imported_functions, ret.ptr.vm_function_import().size()),
             size(imported_tables)
-                = cmul(ret.num_imported_tables, ret.size_of_vmtable_import()),
+                = cmul(ret.num_imported_tables, ret.ptr.vm_table_import().size()),
             size(imported_globals)
-                = cmul(ret.num_imported_globals, ret.size_of_vmglobal_import()),
+                = cmul(ret.num_imported_globals, ret.ptr.vm_global_import().size()),
             size(imported_tags)
-                = cmul(ret.num_imported_tags, ret.size_of_vmtag_import()),
+                = cmul(ret.num_imported_tags, ret.ptr.vm_tag_import().size()),
             size(defined_tables)
                 = cmul(ret.num_defined_tables, ret.ptr.vm_table_definition().size()),
             align(16),
@@ -1026,10 +1009,10 @@ impl<P: PtrSize> From<VMOffsetsFields<P>> for VMOffsets<P> {
                 = cmul(ret.num_defined_tags, ret.ptr.vm_tag_definition().size()),
             size(defined_func_refs) = cmul(
                 ret.num_escaped_funcs,
-                ret.ptr.size_of_vm_func_ref(),
+                ret.ptr.vm_func_ref().size(),
             ),
             size(startup_func_ref) = if ret.has_startup_func {
-                ret.ptr.size_of_vm_func_ref()
+                ret.ptr.vm_func_ref().size()
             } else {
                 0
             },
@@ -1043,70 +1026,11 @@ impl<P: PtrSize> From<VMOffsetsFields<P>> for VMOffsets<P> {
     }
 }
 
-impl<P: PtrSize> VMOffsets<P> {
-    /// The offset of the `VMFunctionImport::array_call` field.
-    #[inline]
-    pub fn vmfunction_import_array_call(&self) -> u8 {
-        0 * self.pointer_size()
-    }
-
-    /// The offset of the `VMFunctionImport::wasm_call` field.
-    #[inline]
-    pub fn vmfunction_import_wasm_call(&self) -> u8 {
-        1 * self.pointer_size()
-    }
-
-    /// The offset of the `VMFunctionImport::type_index` field.
-    #[inline]
-    pub fn vmfunction_import_type_index(&self) -> u8 {
-        2 * self.pointer_size()
-    }
-
-    /// The offset of the `VMFunctionImport::vmctx` field.
-    #[inline]
-    pub fn vmfunction_import_vmctx(&self) -> u8 {
-        3 * self.pointer_size()
-    }
-
-    /// Return the size of `VMFunctionImport`.
-    #[inline]
-    pub fn size_of_vmfunction_import(&self) -> u8 {
-        4 * self.pointer_size()
-    }
-}
-
 /// Offsets for `*const VMFunctionBody`.
 impl<P: PtrSize> VMOffsets<P> {
     /// The size of the `current_elements` field.
     pub fn size_of_vmfunction_body_ptr(&self) -> u8 {
         1 * self.pointer_size()
-    }
-}
-
-/// Offsets for `VMTableImport`.
-impl<P: PtrSize> VMOffsets<P> {
-    /// The offset of the `from` field.
-    #[inline]
-    pub fn vmtable_import_from(&self) -> u8 {
-        0 * self.pointer_size()
-    }
-
-    /// The offset of the `vmctx` field.
-    #[inline]
-    pub fn vmtable_import_vmctx(&self) -> u8 {
-        1 * self.pointer_size()
-    }
-
-    /// The offset of the `index` field.
-    #[inline]
-    pub fn vmtable_import_index(&self) -> u8 {
-        2 * self.pointer_size()
-    }
-
-    /// Return the size of `VMTableImport`.
-    #[inline]
-    pub fn size_of_vmtable_import(&self) -> u8 {
-        3 * self.pointer_size()
     }
 }
 
@@ -1119,82 +1043,12 @@ impl<P: PtrSize> VMOffsets<P> {
     }
 }
 
-/// Offsets for `VMMemoryImport`.
-impl<P: PtrSize> VMOffsets<P> {
-    /// The offset of the `from` field.
-    #[inline]
-    pub fn vmmemory_import_from(&self) -> u8 {
-        0 * self.pointer_size()
-    }
-
-    /// The offset of the `vmctx` field.
-    #[inline]
-    pub fn vmmemory_import_vmctx(&self) -> u8 {
-        1 * self.pointer_size()
-    }
-
-    /// The offset of the `index` field.
-    #[inline]
-    pub fn vmmemory_import_index(&self) -> u8 {
-        2 * self.pointer_size()
-    }
-
-    /// Return the size of `VMMemoryImport`.
-    #[inline]
-    pub fn size_of_vmmemory_import(&self) -> u8 {
-        3 * self.pointer_size()
-    }
-}
-
-/// Offsets for `VMGlobalImport`.
-impl<P: PtrSize> VMOffsets<P> {
-    /// The offset of the `from` field.
-    #[inline]
-    pub fn vmglobal_import_from(&self) -> u8 {
-        0 * self.pointer_size()
-    }
-
-    /// Return the size of `VMGlobalImport`.
-    #[inline]
-    pub fn size_of_vmglobal_import(&self) -> u8 {
-        // `VMGlobalImport` has two pointers plus 8 bytes for `VMGlobalKind`
-        2 * self.pointer_size() + 8
-    }
-}
-
 /// Offsets for `VMSharedTypeIndex`.
 impl<P: PtrSize> VMOffsets<P> {
     /// Return the size of `VMSharedTypeIndex`.
     #[inline]
     pub fn size_of_vmshared_type_index(&self) -> u8 {
         self.ptr.size_of_vmshared_type_index()
-    }
-}
-
-/// Offsets for `VMTagImport`.
-impl<P: PtrSize> VMOffsets<P> {
-    /// The offset of the `from` field.
-    #[inline]
-    pub fn vmtag_import_from(&self) -> u8 {
-        0 * self.pointer_size()
-    }
-
-    /// The offset of the `vmctx` field.
-    #[inline]
-    pub fn vmtag_import_vmctx(&self) -> u8 {
-        1 * self.pointer_size()
-    }
-
-    /// The offset of the `index` field.
-    #[inline]
-    pub fn vmtag_import_index(&self) -> u8 {
-        2 * self.pointer_size()
-    }
-
-    /// Return the size of `VMTagImport`.
-    #[inline]
-    pub fn size_of_vmtag_import(&self) -> u8 {
-        3 * self.pointer_size()
     }
 }
 
@@ -1289,7 +1143,7 @@ impl<P: PtrSize> VMOffsets<P> {
     pub fn vmctx_vmfunction_import(&self, index: FuncIndex) -> u32 {
         assert!(index.as_u32() < self.num_imported_functions);
         self.vmctx_imported_functions_begin()
-            + index.as_u32() * u32::from(self.size_of_vmfunction_import())
+            + index.as_u32() * u32::from(self.ptr.vm_function_import().size())
     }
 
     /// Return the offset to `VMTable` index `index`.
@@ -1297,7 +1151,7 @@ impl<P: PtrSize> VMOffsets<P> {
     pub fn vmctx_vmtable_import(&self, index: TableIndex) -> u32 {
         assert!(index.as_u32() < self.num_imported_tables);
         self.vmctx_imported_tables_begin()
-            + index.as_u32() * u32::from(self.size_of_vmtable_import())
+            + index.as_u32() * u32::from(self.ptr.vm_table_import().size())
     }
 
     /// Return the offset to `VMMemoryImport` index `index`.
@@ -1305,7 +1159,7 @@ impl<P: PtrSize> VMOffsets<P> {
     pub fn vmctx_vmmemory_import(&self, index: MemoryIndex) -> u32 {
         assert!(index.as_u32() < self.num_imported_memories);
         self.vmctx_imported_memories_begin()
-            + index.as_u32() * u32::from(self.size_of_vmmemory_import())
+            + index.as_u32() * u32::from(self.ptr.vm_memory_import().size())
     }
 
     /// Return the offset to `VMGlobalImport` index `index`.
@@ -1313,14 +1167,15 @@ impl<P: PtrSize> VMOffsets<P> {
     pub fn vmctx_vmglobal_import(&self, index: GlobalIndex) -> u32 {
         assert!(index.as_u32() < self.num_imported_globals);
         self.vmctx_imported_globals_begin()
-            + index.as_u32() * u32::from(self.size_of_vmglobal_import())
+            + index.as_u32() * u32::from(self.ptr.vm_global_import().size())
     }
 
     /// Return the offset to `VMTagImport` index `index`.
     #[inline]
     pub fn vmctx_vmtag_import(&self, index: TagIndex) -> u32 {
         assert!(index.as_u32() < self.num_imported_tags);
-        self.vmctx_imported_tags_begin() + index.as_u32() * u32::from(self.size_of_vmtag_import())
+        self.vmctx_imported_tags_begin()
+            + index.as_u32() * u32::from(self.ptr.vm_tag_import().size())
     }
 
     /// Return the offset to `VMTableDefinition` index `index`.
@@ -1368,7 +1223,7 @@ impl<P: PtrSize> VMOffsets<P> {
     pub fn vmctx_func_ref(&self, index: FuncRefIndex) -> u32 {
         assert!(!index.is_reserved_value());
         assert!(index.as_u32() < self.num_escaped_funcs);
-        self.vmctx_func_refs_begin() + index.as_u32() * u32::from(self.ptr.size_of_vm_func_ref())
+        self.vmctx_func_refs_begin() + index.as_u32() * u32::from(self.ptr.vm_func_ref().size())
     }
 
     /// Returns the offset to the `VMFuncRef` for the module startup function.
@@ -1399,26 +1254,26 @@ impl<P: PtrSize> VMOffsets<P> {
     /// Return the offset to the `wasm_call` field in `*const VMFunctionBody` index `index`.
     #[inline]
     pub fn vmctx_vmfunction_import_wasm_call(&self, index: FuncIndex) -> u32 {
-        self.vmctx_vmfunction_import(index) + u32::from(self.vmfunction_import_wasm_call())
+        self.vmctx_vmfunction_import(index) + u32::from(self.ptr.vm_function_import().wasm_call())
     }
 
     /// Return the offset to the `array_call` field in `*const VMFunctionBody` index `index`.
     #[inline]
     pub fn vmctx_vmfunction_import_array_call(&self, index: FuncIndex) -> u32 {
-        self.vmctx_vmfunction_import(index) + u32::from(self.vmfunction_import_array_call())
+        self.vmctx_vmfunction_import(index) + u32::from(self.ptr.vm_function_import().array_call())
     }
 
     /// Return the offset to the `vmctx` field in `*const VMFunctionBody` index `index`.
     #[inline]
     pub fn vmctx_vmfunction_import_vmctx(&self, index: FuncIndex) -> u32 {
-        self.vmctx_vmfunction_import(index) + u32::from(self.vmfunction_import_vmctx())
+        self.vmctx_vmfunction_import(index) + u32::from(self.ptr.vm_function_import().vmctx())
     }
 
     /// Return the offset to the `from` field in the imported `VMTable` at index
     /// `index`.
     #[inline]
     pub fn vmctx_vmtable_from(&self, index: TableIndex) -> u32 {
-        self.vmctx_vmtable_import(index) + u32::from(self.vmtable_import_from())
+        self.vmctx_vmtable_import(index) + u32::from(self.ptr.vm_table_import().from())
     }
 
     /// Return the offset to the `base` field in `VMTableDefinition` index `index`.
@@ -1437,7 +1292,7 @@ impl<P: PtrSize> VMOffsets<P> {
     /// Return the offset to the `from` field in `VMMemoryImport` index `index`.
     #[inline]
     pub fn vmctx_vmmemory_import_from(&self, index: MemoryIndex) -> u32 {
-        self.vmctx_vmmemory_import(index) + u32::from(self.vmmemory_import_from())
+        self.vmctx_vmmemory_import(index) + u32::from(self.ptr.vm_memory_import().from())
     }
 
     /// Return the offset to the `base` field in `VMMemoryDefinition` index `index`.
@@ -1456,25 +1311,25 @@ impl<P: PtrSize> VMOffsets<P> {
     /// Return the offset to the `from` field in `VMGlobalImport` index `index`.
     #[inline]
     pub fn vmctx_vmglobal_import_from(&self, index: GlobalIndex) -> u32 {
-        self.vmctx_vmglobal_import(index) + u32::from(self.vmglobal_import_from())
+        self.vmctx_vmglobal_import(index) + u32::from(self.ptr.vm_global_import().from())
     }
 
     /// Return the offset to the `from` field in `VMTagImport` index `index`.
     #[inline]
     pub fn vmctx_vmtag_import_from(&self, index: TagIndex) -> u32 {
-        self.vmctx_vmtag_import(index) + u32::from(self.vmtag_import_from())
+        self.vmctx_vmtag_import(index) + u32::from(self.ptr.vm_tag_import().from())
     }
 
     /// Return the offset to the `vmctx` field in `VMTagImport` index `index`.
     #[inline]
     pub fn vmctx_vmtag_import_vmctx(&self, index: TagIndex) -> u32 {
-        self.vmctx_vmtag_import(index) + u32::from(self.vmtag_import_vmctx())
+        self.vmctx_vmtag_import(index) + u32::from(self.ptr.vm_tag_import().vmctx())
     }
 
     /// Return the offset to the `index` field in `VMTagImport` index `index`.
     #[inline]
     pub fn vmctx_vmtag_import_index(&self, index: TagIndex) -> u32 {
-        self.vmctx_vmtag_import(index) + u32::from(self.vmtag_import_index())
+        self.vmctx_vmtag_import(index) + u32::from(self.ptr.vm_tag_import().index())
     }
 }
 

--- a/crates/environ/src/vmtypes.rs
+++ b/crates/environ/src/vmtypes.rs
@@ -85,6 +85,149 @@ macro_rules! for_each_vm_type {
                 /// Function signature's type id.
                 pub type_index: VMSharedTypeIndex,
             }
+
+            /// The VM caller-checked "funcref" record, for caller-side signature checking.
+            ///
+            /// It consists of function pointer(s), a type id to be checked by the
+            /// caller, and the vmctx closure associated with this function.
+            #[derive(Debug, Clone)]
+            #[repr(C)]
+            #[snake_name = vm_func_ref]
+            pub struct VMFuncRef {
+                /// Function pointer for this funcref if being called via the "array"
+                /// calling convention that `Func::new` et al use.
+                pub array_call: VmPtr<VMArrayCallFunction>,
+
+                /// Function pointer for this funcref if being called via the calling
+                /// convention we use when compiling Wasm.
+                ///
+                /// Most functions come with a function pointer that we can use when they
+                /// are called from Wasm. The notable exception is when we `Func::wrap` a
+                /// host function, and we don't have a Wasm compiler on hand to compile a
+                /// Wasm-to-native trampoline for the function. In this case, we leave
+                /// `wasm_call` empty until the function is passed as an import to Wasm (or
+                /// otherwise exposed to Wasm via tables/globals). At this point, we look up
+                /// a Wasm-to-native trampoline for the function in the Wasm's compiled
+                /// module and use that fill in `VMFunctionImport::wasm_call`. **However**
+                /// there is no guarantee that the Wasm module has a trampoline for this
+                /// function's signature. The Wasm module only has trampolines for its
+                /// types, and if this function isn't of one of those types, then the Wasm
+                /// module will not have a trampoline for it. This is actually okay, because
+                /// it means that the Wasm cannot actually call this function. But it does
+                /// mean that this field needs to be an `Option` even though it is non-null
+                /// the vast vast vast majority of the time.
+                pub wasm_call: Option<VmPtr<VMWasmCallFunction>>,
+
+                /// Function signature's type id.
+                pub type_index: VMSharedTypeIndex,
+
+                /// The VM state associated with this function.
+                ///
+                /// The actual definition of what this pointer points to depends on the
+                /// function being referenced: for core Wasm functions, this is a `*mut
+                /// VMContext`, for host functions it is a `*mut VMHostFuncContext`, and for
+                /// component functions it is a `*mut VMComponentContext`.
+                pub vmctx: VmPtr<VMOpaqueContext>,
+            }
+
+            /// An imported function.
+            ///
+            /// Basically the same as `VMFuncRef`, except that `wasm_call` is not optional.
+            #[derive(Debug, Clone)]
+            #[repr(C)]
+            #[snake_name = vm_function_import]
+            pub struct VMFunctionImport {
+                /// Same as `VMFuncRef::array_call`.
+                pub array_call: VmPtr<VMArrayCallFunction>,
+
+                /// Same as `VMFuncRef::wasm_call`, except always non-null. Must be filled
+                /// in by the time Wasm is importing this function!
+                pub wasm_call: VmPtr<VMWasmCallFunction>,
+
+                /// Function signature's _actual_ type id.
+                ///
+                /// This is the type that the function was defined with, not the type that
+                /// it was imported as. These two can be different in the face of subtyping
+                /// and we need the former for to correctly implement dynamic downcasts.
+                pub type_index: VMSharedTypeIndex,
+
+                /// Same as `VMFuncRef::vmctx`.
+                pub vmctx: VmPtr<VMOpaqueContext>,
+            }
+
+            /// The fields compiled code needs to access to utilize a WebAssembly table
+            /// imported from another instance.
+            #[derive(Debug, Copy, Clone)]
+            #[repr(C)]
+            #[snake_name = vm_table_import]
+            pub struct VMTableImport {
+                /// A pointer to the imported table description.
+                pub from: VmPtr<VMTableDefinition>,
+
+                /// A pointer to the `VMContext` that owns the table description.
+                pub vmctx: VmPtr<VMContext>,
+
+                /// The table index, within `vmctx`, this definition resides at.
+                pub index: DefinedTableIndex,
+            }
+
+            /// The fields compiled code needs to access to utilize a WebAssembly linear
+            /// memory imported from another instance.
+            #[derive(Debug, Copy, Clone)]
+            #[repr(C)]
+            #[snake_name = vm_memory_import]
+            pub struct VMMemoryImport {
+                /// A pointer to the imported memory description.
+                pub from: VmPtr<VMMemoryDefinition>,
+
+                /// A pointer to the `VMContext` that owns the memory description.
+                pub vmctx: VmPtr<VMContext>,
+
+                /// The index of the memory in the containing `vmctx`.
+                pub index: DefinedMemoryIndex,
+            }
+
+            /// The fields compiled code needs to access to utilize a WebAssembly global
+            /// variable imported from another instance.
+            ///
+            /// Note that unlike with functions, tables, and memories, `VMGlobalImport`
+            /// doesn't include a `vmctx` pointer. Globals are never resized, and don't
+            /// require a `vmctx` pointer to access.
+            #[derive(Debug, Copy, Clone)]
+            #[repr(C)]
+            #[snake_name = vm_global_import]
+            pub struct VMGlobalImport {
+                /// A pointer to the imported global variable description.
+                pub from: VmPtr<VMGlobalDefinition>,
+
+                /// A pointer to the context that owns the global.
+                ///
+                /// Exactly what's stored here is dictated by `kind` below. This is `None`
+                /// for `VMGlobalKind::Host`, it's a `VMContext` for
+                /// `VMGlobalKind::Instance`, and it's `VMComponentContext` for
+                /// `VMGlobalKind::ComponentFlags`.
+                pub vmctx: Option<VmPtr<VMOpaqueContext>>,
+
+                /// The kind of global, and extra location information in addition to
+                /// `vmctx` above.
+                pub kind: VMGlobalKind,
+            }
+
+            /// The fields compiled code needs to access to utilize a WebAssembly
+            /// tag imported from another instance.
+            #[derive(Debug, Copy, Clone)]
+            #[repr(C)]
+            #[snake_name = vm_tag_import]
+            pub struct VMTagImport {
+                /// A pointer to the imported tag description.
+                pub from: VmPtr<VMTagDefinition>,
+
+                /// The instance that owns this tag.
+                pub vmctx: VmPtr<VMContext>,
+
+                /// The index of the tag in the containing `vmctx`.
+                pub index: DefinedTagIndex,
+            }
         }
     };
 }

--- a/crates/wasmtime/src/runtime/vm/vmcontext.rs
+++ b/crates/wasmtime/src/runtime/vm/vmcontext.rs
@@ -67,32 +67,8 @@ pub struct VMArrayCallFunction(VMFunctionBody);
 #[repr(transparent)]
 pub struct VMWasmCallFunction(VMFunctionBody);
 
-/// An imported function.
-///
-/// Basically the same as `VMFuncRef`, except that `wasm_call` is not optional.
-#[derive(Debug, Clone)]
-#[repr(C)]
-pub struct VMFunctionImport {
-    /// Same as `VMFuncRef::array_call`.
-    pub array_call: VmPtr<VMArrayCallFunction>,
-
-    /// Same as `VMFuncRef::wasm_call`, except always non-null. Must be filled
-    /// in by the time Wasm is importing this function!
-    pub wasm_call: VmPtr<VMWasmCallFunction>,
-
-    /// Function signature's _actual_ type id.
-    ///
-    /// This is the type that the function was defined with, not the type that
-    /// it was imported as. These two can be different in the face of subtyping
-    /// and we need the former for to correctly implement dynamic downcasts.
-    pub type_index: VMSharedTypeIndex,
-
-    /// Same as `VMFuncRef::vmctx`.
-    pub vmctx: VmPtr<VMOpaqueContext>,
-    // If more elements are added here, remember to add offset_of tests below!
-}
-
-// SAFETY: the above structure is repr(C) and only contains `VmSafe` fields.
+// SAFETY: `VMFunctionImport` is generated with `#[repr(C)]` and only contains
+// `VmSafe` fields.
 unsafe impl VmSafe for VMFunctionImport {}
 
 impl VMFunctionImport {
@@ -119,33 +95,6 @@ mod test_vmfunction_import {
     use super::{VMFuncRef, VMFunctionImport};
     use core::mem::offset_of;
     use std::mem::size_of;
-    use wasmtime_environ::{HostPtr, Module, StaticModuleIndex, VMOffsets};
-
-    #[test]
-    fn check_vmfunction_import_offsets() {
-        let module = Module::new(StaticModuleIndex::from_u32(0));
-        let offsets = VMOffsets::new(HostPtr, &module);
-        assert_eq!(
-            size_of::<VMFunctionImport>(),
-            usize::from(offsets.size_of_vmfunction_import())
-        );
-        assert_eq!(
-            offset_of!(VMFunctionImport, array_call),
-            usize::from(offsets.vmfunction_import_array_call())
-        );
-        assert_eq!(
-            offset_of!(VMFunctionImport, wasm_call),
-            usize::from(offsets.vmfunction_import_wasm_call())
-        );
-        assert_eq!(
-            offset_of!(VMFunctionImport, type_index),
-            usize::from(offsets.vmfunction_import_type_index())
-        );
-        assert_eq!(
-            offset_of!(VMFunctionImport, vmctx),
-            usize::from(offsets.vmfunction_import_vmctx())
-        );
-    }
 
     #[test]
     fn vmfunction_import_and_vmfunc_ref_have_same_layout() {
@@ -190,53 +139,14 @@ mod test_vmfunction_body {
     }
 }
 
-/// The fields compiled code needs to access to utilize a WebAssembly table
-/// imported from another instance.
-#[derive(Debug, Copy, Clone)]
-#[repr(C)]
-pub struct VMTableImport {
-    /// A pointer to the imported table description.
-    pub from: VmPtr<VMTableDefinition>,
-
-    /// A pointer to the `VMContext` that owns the table description.
-    pub vmctx: VmPtr<VMContext>,
-
-    /// The table index, within `vmctx`, this definition resides at.
-    pub index: DefinedTableIndex,
-}
-
-// SAFETY: the above structure is repr(C) and only contains `VmSafe` fields.
+// SAFETY: `VMTableImport` is generated with `#[repr(C)]` and only contains
+// `VmSafe` fields.
 unsafe impl VmSafe for VMTableImport {}
 
 #[cfg(test)]
 mod test_vmtable {
-    use super::VMTableImport;
-    use core::mem::offset_of;
-    use std::mem::size_of;
     use wasmtime_environ::component::{Component, VMComponentOffsets};
-    use wasmtime_environ::{HostPtr, Module, StaticModuleIndex, VMOffsets};
-
-    #[test]
-    fn check_vmtable_offsets() {
-        let module = Module::new(StaticModuleIndex::from_u32(0));
-        let offsets = VMOffsets::new(HostPtr, &module);
-        assert_eq!(
-            size_of::<VMTableImport>(),
-            usize::from(offsets.size_of_vmtable_import())
-        );
-        assert_eq!(
-            offset_of!(VMTableImport, from),
-            usize::from(offsets.vmtable_import_from())
-        );
-        assert_eq!(
-            offset_of!(VMTableImport, vmctx),
-            usize::from(offsets.vmtable_import_vmctx())
-        );
-        assert_eq!(
-            offset_of!(VMTableImport, index),
-            usize::from(offsets.vmtable_import_index())
-        );
-    }
+    use wasmtime_environ::{HostPtr, Module, PtrSize, StaticModuleIndex, VMOffsets};
 
     #[test]
     fn ensure_sizes_match() {
@@ -248,86 +158,18 @@ mod test_vmtable {
         let component = Component::default();
         let vm_component_offsets = VMComponentOffsets::new(HostPtr, &component);
         assert_eq!(
-            vm_offsets.size_of_vmtable_import(),
-            vm_component_offsets.size_of_vmtable_import()
+            vm_offsets.ptr.vm_table_import().size(),
+            vm_component_offsets.ptr.vm_table_import().size()
         );
     }
 }
 
-/// The fields compiled code needs to access to utilize a WebAssembly linear
-/// memory imported from another instance.
-#[derive(Debug, Copy, Clone)]
-#[repr(C)]
-pub struct VMMemoryImport {
-    /// A pointer to the imported memory description.
-    pub from: VmPtr<VMMemoryDefinition>,
-
-    /// A pointer to the `VMContext` that owns the memory description.
-    pub vmctx: VmPtr<VMContext>,
-
-    /// The index of the memory in the containing `vmctx`.
-    pub index: DefinedMemoryIndex,
-}
-
-// SAFETY: the above structure is repr(C) and only contains `VmSafe` fields.
+// SAFETY: `VMMemoryImport` is generated with `#[repr(C)]` and only contains
+// `VmSafe` fields.
 unsafe impl VmSafe for VMMemoryImport {}
 
-#[cfg(test)]
-mod test_vmmemory_import {
-    use super::VMMemoryImport;
-    use core::mem::offset_of;
-    use std::mem::size_of;
-    use wasmtime_environ::{HostPtr, Module, StaticModuleIndex, VMOffsets};
-
-    #[test]
-    fn check_vmmemory_import_offsets() {
-        let module = Module::new(StaticModuleIndex::from_u32(0));
-        let offsets = VMOffsets::new(HostPtr, &module);
-        assert_eq!(
-            size_of::<VMMemoryImport>(),
-            usize::from(offsets.size_of_vmmemory_import())
-        );
-        assert_eq!(
-            offset_of!(VMMemoryImport, from),
-            usize::from(offsets.vmmemory_import_from())
-        );
-        assert_eq!(
-            offset_of!(VMMemoryImport, vmctx),
-            usize::from(offsets.vmmemory_import_vmctx())
-        );
-        assert_eq!(
-            offset_of!(VMMemoryImport, index),
-            usize::from(offsets.vmmemory_import_index())
-        );
-    }
-}
-
-/// The fields compiled code needs to access to utilize a WebAssembly global
-/// variable imported from another instance.
-///
-/// Note that unlike with functions, tables, and memories, `VMGlobalImport`
-/// doesn't include a `vmctx` pointer. Globals are never resized, and don't
-/// require a `vmctx` pointer to access.
-#[derive(Debug, Copy, Clone)]
-#[repr(C)]
-pub struct VMGlobalImport {
-    /// A pointer to the imported global variable description.
-    pub from: VmPtr<VMGlobalDefinition>,
-
-    /// A pointer to the context that owns the global.
-    ///
-    /// Exactly what's stored here is dictated by `kind` below. This is `None`
-    /// for `VMGlobalKind::Host`, it's a `VMContext` for
-    /// `VMGlobalKind::Instance`, and it's `VMComponentContext` for
-    /// `VMGlobalKind::ComponentFlags`.
-    pub vmctx: Option<VmPtr<VMOpaqueContext>>,
-
-    /// The kind of global, and extra location information in addition to
-    /// `vmctx` above.
-    pub kind: VMGlobalKind,
-}
-
-// SAFETY: the above structure is repr(C) and only contains `VmSafe` fields.
+// SAFETY: `VMGlobalImport` is generated with `#[repr(C)]` and only contains
+// `VmSafe` fields.
 unsafe impl VmSafe for VMGlobalImport {}
 
 /// The kinds of globals that Wasmtime has.
@@ -348,74 +190,9 @@ pub enum VMGlobalKind {
 // SAFETY: the above enum is repr(C) and stores nothing else
 unsafe impl VmSafe for VMGlobalKind {}
 
-#[cfg(test)]
-mod test_vmglobal_import {
-    use super::VMGlobalImport;
-    use core::mem::offset_of;
-    use std::mem::size_of;
-    use wasmtime_environ::{HostPtr, Module, StaticModuleIndex, VMOffsets};
-
-    #[test]
-    fn check_vmglobal_import_offsets() {
-        let module = Module::new(StaticModuleIndex::from_u32(0));
-        let offsets = VMOffsets::new(HostPtr, &module);
-        assert_eq!(
-            size_of::<VMGlobalImport>(),
-            usize::from(offsets.size_of_vmglobal_import())
-        );
-        assert_eq!(
-            offset_of!(VMGlobalImport, from),
-            usize::from(offsets.vmglobal_import_from())
-        );
-    }
-}
-
-/// The fields compiled code needs to access to utilize a WebAssembly
-/// tag imported from another instance.
-#[derive(Debug, Copy, Clone)]
-#[repr(C)]
-pub struct VMTagImport {
-    /// A pointer to the imported tag description.
-    pub from: VmPtr<VMTagDefinition>,
-
-    /// The instance that owns this tag.
-    pub vmctx: VmPtr<VMContext>,
-
-    /// The index of the tag in the containing `vmctx`.
-    pub index: DefinedTagIndex,
-}
-
-// SAFETY: the above structure is repr(C) and only contains `VmSafe` fields.
+// SAFETY: `VMTagImport` is generated with `#[repr(C)]` and only contains
+// `VmSafe` fields.
 unsafe impl VmSafe for VMTagImport {}
-
-#[cfg(test)]
-mod test_vmtag_import {
-    use super::VMTagImport;
-    use core::mem::{offset_of, size_of};
-    use wasmtime_environ::{HostPtr, Module, StaticModuleIndex, VMOffsets};
-
-    #[test]
-    fn check_vmtag_import_offsets() {
-        let module = Module::new(StaticModuleIndex::from_u32(0));
-        let offsets = VMOffsets::new(HostPtr, &module);
-        assert_eq!(
-            size_of::<VMTagImport>(),
-            usize::from(offsets.size_of_vmtag_import())
-        );
-        assert_eq!(
-            offset_of!(VMTagImport, from),
-            usize::from(offsets.vmtag_import_from())
-        );
-        assert_eq!(
-            offset_of!(VMTagImport, vmctx),
-            usize::from(offsets.vmtag_import_vmctx())
-        );
-        assert_eq!(
-            offset_of!(VMTagImport, index),
-            usize::from(offsets.vmtag_import_index())
-        );
-    }
-}
 
 /// Define the runtime definitions of the shared `VM*` types.
 macro_rules! define_vm_types {
@@ -429,7 +206,7 @@ macro_rules! define_vm_types {
                 $(#[doc = $fdoc:literal])*
                 $(#[readonly])?
                 $(#[can_move])?
-                $fvis:vis $fname:ident : $fty:tt $(< $fgen:tt >)? ,
+                $fvis:vis $fname:ident : $fty:tt $(< $fgen:ty >)? ,
             )*
         }
     )* ) => {
@@ -770,51 +547,8 @@ mod test_vmtag_definition {
     }
 }
 
-/// The VM caller-checked "funcref" record, for caller-side signature checking.
-///
-/// It consists of function pointer(s), a type id to be checked by the
-/// caller, and the vmctx closure associated with this function.
-#[derive(Debug, Clone)]
-#[repr(C)]
-pub struct VMFuncRef {
-    /// Function pointer for this funcref if being called via the "array"
-    /// calling convention that `Func::new` et al use.
-    pub array_call: VmPtr<VMArrayCallFunction>,
-
-    /// Function pointer for this funcref if being called via the calling
-    /// convention we use when compiling Wasm.
-    ///
-    /// Most functions come with a function pointer that we can use when they
-    /// are called from Wasm. The notable exception is when we `Func::wrap` a
-    /// host function, and we don't have a Wasm compiler on hand to compile a
-    /// Wasm-to-native trampoline for the function. In this case, we leave
-    /// `wasm_call` empty until the function is passed as an import to Wasm (or
-    /// otherwise exposed to Wasm via tables/globals). At this point, we look up
-    /// a Wasm-to-native trampoline for the function in the Wasm's compiled
-    /// module and use that fill in `VMFunctionImport::wasm_call`. **However**
-    /// there is no guarantee that the Wasm module has a trampoline for this
-    /// function's signature. The Wasm module only has trampolines for its
-    /// types, and if this function isn't of one of those types, then the Wasm
-    /// module will not have a trampoline for it. This is actually okay, because
-    /// it means that the Wasm cannot actually call this function. But it does
-    /// mean that this field needs to be an `Option` even though it is non-null
-    /// the vast vast vast majority of the time.
-    pub wasm_call: Option<VmPtr<VMWasmCallFunction>>,
-
-    /// Function signature's type id.
-    pub type_index: VMSharedTypeIndex,
-
-    /// The VM state associated with this function.
-    ///
-    /// The actual definition of what this pointer points to depends on the
-    /// function being referenced: for core Wasm functions, this is a `*mut
-    /// VMContext`, for host functions it is a `*mut VMHostFuncContext`, and for
-    /// component functions it is a `*mut VMComponentContext`.
-    pub vmctx: VmPtr<VMOpaqueContext>,
-    // If more elements are added here, remember to add offset_of tests below!
-}
-
-// SAFETY: the above structure is repr(C) and only contains `VmSafe` fields.
+// SAFETY: `VMFuncRef` is generated with `#[repr(C)]` and only contains
+// `VmSafe` fields.
 unsafe impl VmSafe for VMFuncRef {}
 
 impl VMFuncRef {
@@ -912,40 +646,6 @@ impl VMFuncRef {
         } else {
             None
         }
-    }
-}
-
-#[cfg(test)]
-mod test_vm_func_ref {
-    use super::VMFuncRef;
-    use core::mem::offset_of;
-    use std::mem::size_of;
-    use wasmtime_environ::{HostPtr, Module, PtrSize, StaticModuleIndex, VMOffsets};
-
-    #[test]
-    fn check_vm_func_ref_offsets() {
-        let module = Module::new(StaticModuleIndex::from_u32(0));
-        let offsets = VMOffsets::new(HostPtr, &module);
-        assert_eq!(
-            size_of::<VMFuncRef>(),
-            usize::from(offsets.ptr.size_of_vm_func_ref())
-        );
-        assert_eq!(
-            offset_of!(VMFuncRef, array_call),
-            usize::from(offsets.ptr.vm_func_ref_array_call())
-        );
-        assert_eq!(
-            offset_of!(VMFuncRef, wasm_call),
-            usize::from(offsets.ptr.vm_func_ref_wasm_call())
-        );
-        assert_eq!(
-            offset_of!(VMFuncRef, type_index),
-            usize::from(offsets.ptr.vm_func_ref_type_index())
-        );
-        assert_eq!(
-            offset_of!(VMFuncRef, vmctx),
-            usize::from(offsets.ptr.vm_func_ref_vmctx())
-        );
     }
 }
 

--- a/winch/codegen/src/codegen/call.rs
+++ b/winch/codegen/src/codegen/call.rs
@@ -240,13 +240,13 @@ impl FnCall {
         // Load the callee VMContext, that will be passed as first argument to
         // the function call.
         masm.load_ptr(
-            masm.address_at_reg(funcref_ptr, ptr.vm_func_ref_vmctx().into())?,
+            masm.address_at_reg(funcref_ptr, ptr.vm_func_ref().vmctx().into())?,
             writable!(callee_vmctx),
         )?;
 
         // Load the function pointer to be called.
         masm.load_ptr(
-            masm.address_at_reg(funcref_ptr, ptr.vm_func_ref_wasm_call().into())?,
+            masm.address_at_reg(funcref_ptr, ptr.vm_func_ref().wasm_call().into())?,
             writable!(funcref),
         )?;
         context.free_reg(funcref_ptr);

--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -467,7 +467,7 @@ where
             .checked_mul(sig_index_bytes.into())
             .unwrap();
         let signatures_base_offset = self.env.vmoffsets.ptr.vmctx_type_ids_array();
-        let funcref_sig_offset = self.env.vmoffsets.ptr.vm_func_ref_type_index();
+        let funcref_sig_offset = self.env.vmoffsets.ptr.vm_func_ref().type_index();
         // Get the caller id.
         let caller_id = self.context.any_gpr(self.masm)?;
 
@@ -2508,8 +2508,10 @@ where
             // the vmctx itself.
             None => {
                 let vmimport = self.env.vmoffsets.vmctx_vmmemory_import(mem);
-                let vmctx_offset = vmimport + u32::from(self.env.vmoffsets.vmmemory_import_vmctx());
-                let index_offset = vmimport + u32::from(self.env.vmoffsets.vmmemory_import_index());
+                let vmctx_offset =
+                    vmimport + u32::from(self.env.vmoffsets.ptr.vm_memory_import().vmctx());
+                let index_offset =
+                    vmimport + u32::from(self.env.vmoffsets.ptr.vm_memory_import().index());
                 let index_addr = self.masm.address_at_vmctx(index_offset)?;
                 let index_dst = self.context.reg_for_class(RegClass::Int, self.masm)?;
                 self.masm
@@ -2538,8 +2540,10 @@ where
             }
             None => {
                 let vmimport = self.env.vmoffsets.vmctx_vmtable_import(table);
-                let vmctx_offset = vmimport + u32::from(self.env.vmoffsets.vmtable_import_vmctx());
-                let index_offset = vmimport + u32::from(self.env.vmoffsets.vmtable_import_index());
+                let vmctx_offset =
+                    vmimport + u32::from(self.env.vmoffsets.ptr.vm_table_import().vmctx());
+                let index_offset =
+                    vmimport + u32::from(self.env.vmoffsets.ptr.vm_table_import().index());
                 let index_addr = self.masm.address_at_vmctx(index_offset)?;
                 let index_dst = self.context.reg_for_class(RegClass::Int, self.masm)?;
                 self.masm


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
