### PR TITLE
Alias analysis: Make "observed" state per-instruction and flow insensitive

### DIFF
--- a/cranelift/codegen/src/alias_analysis.rs
+++ b/cranelift/codegen/src/alias_analysis.rs
@@ -60,12 +60,19 @@
 //! * If a store overwrites a key in the table, *and* if this
 //!   overwriting store always executes after the original store
 //!   (i.e. this store post-dominates the original), *and* if no other
-//!   instruction has "observed" the associated alias region in
-//!   between, then we can eliminate the original store. This is
-//!   called "dead-store elimination". Note that observing an alias
-//!   region is not just loading from it, all potentially-trapping
-//!   instructions must be treated as observing all regions because we
+//!   instruction has "observed" the original store, then we can
+//!   eliminate the original store. This is called "dead-store
+//!   elimination". Note that observing a store is not just loading
+//!   from the location it wrote, all potentially-trapping
+//!   instructions must be treated as observing every store because we
 //!   must preserve post-trap memory state.
+//!
+//! Which store is the "last store" to a region is flow-sensitive, but
+//! whether a store is ever observed is *not*: it is observed if there
+//! is *any* path on which some instruction can observe it. We
+//! therefore compute the set of observed stores for the whole function
+//! up front, in `AliasAnalysis::observed_stores`, rather than tracking
+//! it as part of the per-block `LastStores` state.
 
 use crate::cursor::CursorPosition;
 use crate::{FxHashMap, FxHashSet};
@@ -137,27 +144,16 @@ fn alias_regions_observed(func: &Function, inst: Inst, opcode: Opcode) -> AliasR
     }
 }
 
-/// The last-store state for a single named alias region: the last store to the
-/// region (if any) and whether that region has been observed since.
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-struct RegionState {
-    /// Last store to this region.
-    last_store: PackedOption<Inst>,
-
-    /// Whether this region has been observed since it was last stored to.
-    observed: bool,
-}
-
-/// For a given program point, the vector of last-store instruction
-/// indices for each disjoint category of abstract state.
+/// For a given program point, the last-store instruction for each disjoint
+/// category of abstract state.
 ///
 /// ### Instructions In `LastStores` Might Not Be In The Function's `Layout`
 ///
-/// The instructions named here (`regions[r].last_store`, `other`, `last_fence`)
-/// are *not* guaranteed to still be in the layout (unlike `mem_values`, this
-/// state does not maintain that invariant). A slot can name a store we already
-/// removed because, e.g., `block_input` snapshots are computed once up front
-/// (in `compute_block_input_states`) and can name a store a later-visited block
+/// The instructions named here (`regions[r]` and `last_fence`) are *not*
+/// guaranteed to still be in the layout (unlike `mem_values`, this state does
+/// not maintain that invariant). A slot can name a store we already removed
+/// because, e.g., `block_input` snapshots are computed once up front (in
+/// `compute_block_input_states`) and can name a store a later-visited block
 /// deletes.
 ///
 /// We tolerate this, rather than enforce the invariant, because enforcing it
@@ -167,41 +163,51 @@ struct RegionState {
 /// couple sites.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct LastStores {
-    /// Last store (and whether it has been observed) for each named alias
-    /// region.
-    regions: SecondaryMap<AliasRegion, RegionState>,
-
-    /// Last store for memory accesses with no alias region.
-    other: PackedOption<Inst>,
-
-    /// Whether the other/missing alias region has been observed since it was
-    /// last stored to.
-    observed_other: bool,
+    /// Last store to each named alias region.
+    regions: SecondaryMap<AliasRegion, PackedOption<Inst>>,
 
     /// Last instruction with fence semantics. This applies to ALL regions,
     /// including ones not yet in the `regions` map.
+    ///
+    /// This is also the last store for memory accesses that have no alias
+    /// region: such a store may alias any region, and so is treated as a
+    /// fence, which means the two are always the same instruction.
     last_fence: PackedOption<Inst>,
+}
 
-    /// Whether all alias regions have been observed since they were last stored
-    /// to (e.g. via a memory fence or a call).
-    observed_all: bool,
+/// Mark the store, if any, in the given last-store slot as observed.
+fn observe(func: &Function, observed_stores: &mut FxHashSet<Inst>, last_store: PackedOption<Inst>) {
+    if let Some(inst) = last_store.expand() {
+        // NB: last-store slots do not always hold stores; they can also hold
+        // calls, fences, and the markers that `LastStores::meet_from` inserts
+        // where two control-flow paths disagree. Only actual stores can be DSE
+        // candidates, so don't bother recording other instructions as observed.
+        if func.dfg.insts[inst].opcode().can_store() {
+            observed_stores.insert(inst);
+        }
+    }
 }
 
 impl LastStores {
-    pub(crate) fn update(&mut self, func: &Function, inst: Inst) {
+    pub(crate) fn update(
+        &mut self,
+        func: &Function,
+        inst: Inst,
+        observed_stores: &mut FxHashSet<Inst>,
+    ) {
         let opcode = func.dfg.insts[inst].opcode();
 
         if has_memory_fence_semantics(opcode) {
-            self.fence(inst);
+            self.fence(func, inst, observed_stores);
         }
         // Explicitly trapping instructions (`trap`, `trapz`, `udiv`,
         // `uadd_overflow_trap`, etc... but not loads/stores that can implicitly
         // trap): allow store-to-load forwarding across these instructions, but
         // do not eliminate dead stores across them, as that would change the
-        // state of memory on trap. We do this by marking every region with a
-        // last-store as observed, but not clearing its last-store information.
+        // state of memory on trap. We do this by marking every last-store as
+        // observed, but not clearing our last-store information.
         else if opcode.can_trap() {
-            self.observe_others(None);
+            self.observe_others(func, observed_stores, None);
         }
         // Store instructions: update the last-store information for this
         // instruction's alias region, or, if it has no alias region, treat it
@@ -210,12 +216,33 @@ impl LastStores {
             if let Some(memflags) = func.dfg.insts[inst].memflags() {
                 match func.dfg.mem_flags[memflags].alias_region() {
                     Some(region) => {
-                        self.regions[region] = RegionState {
-                            last_store: inst.into(),
-                            observed: false,
-                        };
+                        // NB: The old last-store instruction is *not* observed
+                        // here, even though this new store instruction may not
+                        // fully overwrite it. First, a new store in a block
+                        // does not itself observe an old store in the same
+                        // block. Second, the old store will never be an
+                        // optimization candidate again from here on out:
+                        //
+                        // * We won't consider it again as we process the rest
+                        //   of this block, as it won't be in the last-store
+                        //   slot anymore.
+                        //
+                        // * What if we re-process this block in our initial
+                        //   fixed point loop? That implies this block is a
+                        //   member of a cycle in the CFG, but `meet_from` only
+                        //   propagates a store instruction when all
+                        //   predecessors agree on the same last-store
+                        //   instruction, but the predecessors already won't
+                        //   agree it is the old store since this block (which
+                        //   is on that path and therefore some kind of
+                        //   transitive predecessor) has already overridden it.
+                        //
+                        // Therefore, marking the old last-store as observed
+                        // here is unnecessary (and, in fact, doing so would
+                        // only inhibit optimization).
+                        self.regions[region] = inst.into();
 
-                        // And if this store can trap, then we need to observe
+                        // If this store can trap, then we need to observe
                         // all other alias regions, to ensure that their state
                         // is preserved in the case that this store traps
                         // (similar to the `can_trap()` handling above).
@@ -224,6 +251,11 @@ impl LastStores {
                         // following snippet, for example:
                         //
                         //     store notrap region0 v0, v3+8
+                        //     store user42 region1 v1, v4+16
+                        //     store notrap region0 v2, v3+8
+                        //
+                        //     ==/==>
+                        //
                         //     store user42 region1 v1, v4+16
                         //     store notrap region0 v2, v3+8
                         //
@@ -240,151 +272,174 @@ impl LastStores {
                         //     store notrap region1 v1, v4+16
                         //     store user42 region0 v2, v3+8
                         //
+                        //     ==/==>
+                        //
+                        //     store notrap region1 v1, v4+16
+                        //     store user42 region0 v2, v3+8
+                        //
                         // In this case, removing the first store would mean
                         // that when writing to `v3+8` traps, we would
                         // incorrectly store to `v4+16`, when we otherwise
                         // wouldn't have.
                         if func.dfg.mem_flags[memflags].trap_code().is_some() {
-                            self.observe_others(Some(region));
+                            self.observe_others(func, observed_stores, Some(region));
                         } else {
-                            self.observe_trapping_others(region, func);
+                            self.observe_trapping_others(func, observed_stores, region);
                         }
                     }
                     None => {
                         // A store with no alias region may alias any region, so
                         // treat it like a fence.
-                        self.fence(inst);
+                        self.fence(func, inst, observed_stores);
                     }
                 }
             } else {
                 // Store with no memflags (and therefore no region):
                 // treat it like a fence.
-                self.fence(inst);
+                self.fence(func, inst, observed_stores);
             }
         }
         // Everything else: determine which, if any, alias regions this
         // instruction observes.
         else {
             match alias_regions_observed(func, inst, opcode) {
-                AliasRegionsObserved::All => {
-                    self.observed_all = true;
-                }
+                AliasRegionsObserved::All => self.observe_others(func, observed_stores, None),
                 AliasRegionsObserved::Just(region) => {
-                    self.regions[region].observed = true;
+                    observe(func, observed_stores, self.last_store_for_region(region));
                     // NB: Because stores without regions may alias any other
-                    // region, we have also observed the last-store in
-                    // `self.other`.
-                    self.observed_other = true;
+                    // region, we have also observed the last such store, which
+                    // `self.last_fence` tracks.
+                    observe(func, observed_stores, self.last_fence);
                 }
-                AliasRegionsObserved::Other => {
-                    self.observed_other = true;
-                }
+                AliasRegionsObserved::Other => observe(func, observed_stores, self.last_fence),
                 AliasRegionsObserved::None => {}
             }
         }
     }
 
-    /// Mark all regions except for `excluding` (if given) as observed.
-    fn observe_others(&mut self, excluding: Option<AliasRegion>) {
-        for (region, state) in self.regions.iter_mut() {
-            if state.last_store.is_some() && excluding.is_none_or(|r| r != region) {
-                state.observed = true;
+    /// Mark the last store to every region except for `excluding` (if given), as
+    /// well as the last fence, as observed.
+    fn observe_others(
+        &self,
+        func: &Function,
+        observed_stores: &mut FxHashSet<Inst>,
+        excluding: Option<AliasRegion>,
+    ) {
+        for (region, last_store) in self.regions.iter() {
+            if excluding.is_none_or(|r| r != region) {
+                observe(func, observed_stores, *last_store);
             }
         }
-        self.observed_other = true;
+        observe(func, observed_stores, self.last_fence);
     }
 
-    /// Mark all regions whose last-store can trap as observed, except for
-    /// `excluding`.
-    fn observe_trapping_others(&mut self, excluding: AliasRegion, func: &Function) {
-        for (region, state) in self.regions.iter_mut() {
-            if region != excluding
-                && state
-                    .last_store
-                    .expand()
-                    .is_some_and(|s| func.dfg.insts[s].memflags_trap_code(&func.dfg).is_some())
-            {
-                state.observed = true;
+    /// Mark the last store to every region whose last store can trap, except for
+    /// `excluding`, as observed.
+    fn observe_trapping_others(
+        &self,
+        func: &Function,
+        observed_stores: &mut FxHashSet<Inst>,
+        excluding: AliasRegion,
+    ) {
+        let can_trap = |last_store: PackedOption<Inst>| {
+            last_store
+                .expand()
+                .is_some_and(|s| func.dfg.insts[s].memflags_trap_code(&func.dfg).is_some())
+        };
+
+        for (region, last_store) in self.regions.iter() {
+            if region != excluding && can_trap(*last_store) {
+                observe(func, observed_stores, *last_store);
             }
         }
 
-        self.observed_other |= self
-            .other
-            .expand()
-            .is_some_and(|s| func.dfg.insts[s].memflags_trap_code(&func.dfg).is_some());
+        if can_trap(self.last_fence) {
+            observe(func, observed_stores, self.last_fence);
+        }
     }
 
     /// Handle memory fence-like instructions by clearing all analysis data.
-    fn fence(&mut self, inst: Inst) {
+    fn fence(&mut self, func: &Function, inst: Inst, observed_stores: &mut FxHashSet<Inst>) {
+        // A fence can observe every region, so every store we are currently
+        // tracking for a region becomes observed.
+        for (_region, last_store) in self.regions.iter() {
+            observe(func, observed_stores, *last_store);
+        }
         self.regions.clear();
-        self.other = inst.into();
-        self.observed_other = false;
+
+        // NB: `self.last_fence` is *not* observed here. See the comment in
+        // `LastStores::update`. Marking it observed would, for example, prevent
+        // eliminating the first of two adjacent stores that have no alias
+        // region.
         self.last_fence = inst.into();
-        self.observed_all = false;
+    }
+
+    /// Get the last store affecting the given alias region.
+    fn last_store_for_region(&self, region: AliasRegion) -> PackedOption<Inst> {
+        if self.regions[region].is_some() {
+            self.regions[region]
+        } else {
+            self.last_fence
+        }
     }
 
     /// Get the last-store instruction for the given `inst`'s alias region, if
-    /// any, and whether that alias region has been observed or not.
-    fn get_last_store(&self, func: &Function, inst: Inst) -> (PackedOption<Inst>, bool) {
+    /// any.
+    fn get_last_store(&self, func: &Function, inst: Inst) -> PackedOption<Inst> {
         if let Some(memflags) = func.dfg.insts[inst].memflags() {
-            match func.dfg.mem_flags[memflags].alias_region() {
-                None => return (self.other, self.observed_all || self.observed_other),
-                Some(region) => {
-                    let region_state = self.regions[region];
-                    // If the region has never been explicitly stored to,
-                    // fall back to the last fence (which affects all regions).
-                    if region_state.last_store.is_none() {
-                        return (self.last_fence, self.observed_all);
-                    } else {
-                        return (
-                            region_state.last_store,
-                            self.observed_all || region_state.observed,
-                        );
-                    }
-                }
-            }
+            return match func.dfg.mem_flags[memflags].alias_region() {
+                None => self.last_fence,
+                Some(region) => self.last_store_for_region(region),
+            };
         }
 
         let opcode = func.dfg.insts[inst].opcode();
         if opcode.can_load() || opcode.can_store() {
-            (
-                inst.into(),
-                opcode.can_load() || self.observed_all || self.observed_other,
-            )
+            inst.into()
         } else {
-            (None.into(), true)
+            None.into()
         }
     }
 
     /// Meet `self` with `rhs`, placing the result in `self`.
     ///
     /// Returns `true` if `self` changed, `false` otherwise.
-    fn meet_from(&mut self, rhs: &LastStores, loc: Inst) -> bool {
+    fn meet_from(
+        &mut self,
+        func: &Function,
+        rhs: &LastStores,
+        loc: Inst,
+        observed_stores: &mut FxHashSet<Inst>,
+    ) -> bool {
         // NB: Destructure to make sure we don't accidentally forget a
         // field.
         let LastStores {
             regions,
-            other,
-            observed_other,
             last_fence,
-            observed_all,
         } = self;
 
-        let meet = |a: &mut PackedOption<Inst>, b: PackedOption<Inst>| -> bool {
+        let meet = |observed_stores: &mut FxHashSet<Inst>,
+                    a: &mut PackedOption<Inst>,
+                    b: PackedOption<Inst>|
+         -> bool {
             let old = a.expand();
             let new = match (old, b.expand()) {
                 (None, None) => None,
                 (Some(a), Some(b)) if a == b => Some(a),
-                _ => Some(loc),
+                (x, y) => {
+                    // The incoming paths disagree on the last store. Anything
+                    // after the merge that observes this slot observes `loc`,
+                    // not `x` or `y`, and, therefore, we must conservatively
+                    // mark them both observed here. This keeps the
+                    // observed-stores set sound in the presence of loops and
+                    // control-flow join points.
+                    observe(func, observed_stores, x.filter(|x| *x != loc).into());
+                    observe(func, observed_stores, y.filter(|y| *y != loc).into());
+                    Some(loc)
+                }
             };
             *a = new.into();
             old != new
-        };
-
-        let union_bool = |a: &mut bool, b: bool| -> bool {
-            let old = *a;
-            *a = *a || b;
-            *a != old
         };
 
         let mut changed = false;
@@ -392,19 +447,10 @@ impl LastStores {
         let max_len = core::cmp::max(regions.keys().len(), rhs.regions.keys().len());
         for i in 0..max_len {
             let region = AliasRegion::new(i);
-            let rhs_state = rhs.regions[region];
-            let state = &mut regions[region];
-            changed |= meet(&mut state.last_store, rhs_state.last_store);
-            // Union the observed bit: a region is observed after the meet if it
-            // was observed on either incoming path.
-            changed |= union_bool(&mut state.observed, rhs_state.observed);
+            changed |= meet(observed_stores, &mut regions[region], rhs.regions[region]);
         }
 
-        changed |= meet(other, rhs.other);
-        changed |= union_bool(observed_other, rhs.observed_other);
-
-        changed |= meet(last_fence, rhs.last_fence);
-        changed |= union_bool(observed_all, rhs.observed_all);
+        changed |= meet(observed_stores, last_fence, rhs.last_fence);
 
         changed
     }
@@ -475,6 +521,14 @@ pub struct AliasAnalysis<'a> {
     /// function is a waste.
     post_dom_tree: Option<PostDominatorTree>,
 
+    /// The set of store instructions that some other instruction can observe,
+    /// and which therefore cannot be eliminated as dead stores.
+    ///
+    /// Unlike the last-store state in `block_input`, this is *not* flow
+    /// sensitive: a store is either observable somewhere in the function or it
+    /// is not.
+    observed_stores: FxHashSet<Inst>,
+
     /// Input state to a basic block.
     block_input: FxHashMap<Block, LastStores>,
 
@@ -494,6 +548,7 @@ impl<'a> AliasAnalysis<'a> {
         let mut analysis = AliasAnalysis {
             domtree,
             post_dom_tree: None,
+            observed_stores: FxHashSet::default(),
             block_input: FxHashMap::default(),
             mem_values: FxHashMap::default(),
         };
@@ -556,14 +611,19 @@ impl<'a> AliasAnalysis<'a> {
             );
 
             for inst in func.layout.block_insts(block) {
-                state.update(func, inst);
+                state.update(func, inst, &mut self.observed_stores);
                 trace!("after inst{}: state is {:?}", inst.index(), state);
             }
 
             visit_block_succs(func, block, |_inst, succ, _from_table| {
                 let succ_first_inst = func.layout.block_insts(succ).next().unwrap();
                 let updated = match self.block_input.get_mut(&succ) {
-                    Some(succ_state) => succ_state.meet_from(&state, succ_first_inst),
+                    Some(succ_state) => succ_state.meet_from(
+                        func,
+                        &state,
+                        succ_first_inst,
+                        &mut self.observed_stores,
+                    ),
                     None => {
                         self.block_input.insert(succ, state.clone());
                         true
@@ -609,13 +669,12 @@ impl<'a> AliasAnalysis<'a> {
                 let store_data = inst_store_data(func, inst).unwrap();
                 let store_data = func.dfg.resolve_aliases(store_data);
 
-                let (last_store, observed_last_store) = state.get_last_store(func, inst);
+                let last_store = state.get_last_store(func, inst);
 
                 // Check whether this store makes the last store dead.
                 if let Some(last_store) = last_store.expand() {
-                    // A store can only be dead if we haven't observed
-                    // its alias region yet.
-                    if !observed_last_store
+                    // A store can only be dead when unobserved.
+                    if !self.observed_stores.contains(&last_store)
                         // This instruction doesn't make the last
                         // store dead if it itself is the last store.
                         && inst != last_store
@@ -679,6 +738,14 @@ impl<'a> AliasAnalysis<'a> {
                         && self.domtree.dominates(def_inst, inst, &func.layout)
                     {
                         trace!("  --> idempotent store of {store_data} to loc {check_loc:?}");
+
+                        // We are removing this idempotent store in favor of the
+                        // original, so if this idempotent store was observed,
+                        // then the original must now be observed as well.
+                        if self.observed_stores.contains(&inst) {
+                            observe(func, &mut self.observed_stores, last_store);
+                        }
+
                         return OptResult::IdempotentStore;
                     }
                 }
@@ -696,7 +763,7 @@ impl<'a> AliasAnalysis<'a> {
 
                 OptResult::None
             } else if opcode.can_load() {
-                let (last_store, _observed_last_store) = state.get_last_store(func, inst);
+                let last_store = state.get_last_store(func, inst);
                 let load_result = func.dfg.inst_results(inst)[0];
                 let mem_loc = MemoryLoc {
                     last_store,
@@ -757,7 +824,14 @@ impl<'a> AliasAnalysis<'a> {
             OptResult::None
         };
 
-        state.update(func, inst);
+        let observed_stores_len = self.observed_stores.len();
+        state.update(func, inst, &mut self.observed_stores);
+        debug_assert_eq!(
+            observed_stores_len,
+            self.observed_stores.len(),
+            "`compute_block_input_states` should have already found all observed stores, \
+             but processing {inst} found a new one",
+        );
 
         result
     }
@@ -792,6 +866,10 @@ impl<'a> AliasAnalysis<'a> {
                             !matches!(pos.position(), CursorPosition::At(other) if dead == other)
                         );
                         pos.func.layout.remove_inst(dead);
+                        // Step back so that we reprocess the overwriter. This
+                        // lets us unwind chains of dead stores, one link at a
+                        // time.
+                        pos.prev_inst();
                     }
                 }
             }

--- a/cranelift/filetests/filetests/alias/crossing-merges.clif
+++ b/cranelift/filetests/filetests/alias/crossing-merges.clif
@@ -1,0 +1,182 @@
+test optimize precise-output
+set opt_level=speed
+target aarch64
+
+;; With the following CFG:
+;;
+;;              block0
+;;             /      \
+;;         block1     block2
+;;          |   \     /   |
+;;          |    \   /    |
+;;          |     \ /     |
+;;          |      X      |
+;;          |     / \     |
+;;          |    /   \    |
+;;          |   /     \   |
+;;         block3     block4
+;;             \      /
+;;              block5
+;;
+;; Both `block1` and `block2` branch to both `block3` and `block4`, so a single
+;; pass over the blocks, in whatever order our worklist happens to pop them, can
+;; reach a merge block before it has seen all of that block's predecessors, and
+;; can reach a store's observers only after it has already processed the block
+;; that could otherwise have removed that store. Note that `block5`
+;; post-dominates every other block, so its store is a dead-store-elimination
+;; candidate for the stores in all of the blocks above it.
+;;
+;; The store in `block0` is observed by the load in `block3`, and so it is not
+;; dead, despite being fully overwritten by the store in `block5`.
+function %observed_after_crossing_merges(i64, i32, i32, i32) -> i32 {
+    region0 = 0 "R0"
+
+block0(v0: i64, v1: i32, v2: i32, v3: i32):
+    store notrap aligned region0 v1, v0
+    brif v1, block1, block2
+
+block1:
+    brif v2, block3, block4
+
+block2:
+    brif v3, block3, block4
+
+block3:
+    ;; (Different static offset to avoid being store-to-load forwarded away.)
+    v4 = load.i32 notrap aligned region0 v0+8
+    jump block5(v4)
+
+block4:
+    jump block5(v1)
+
+block5(v5: i32):
+    store notrap aligned region0 v2, v0
+    return v5
+}
+
+; function %observed_after_crossing_merges(i64, i32, i32, i32) -> i32 fast {
+;     region0 = 0 "R0"
+;
+; block0(v0: i64, v1: i32, v2: i32, v3: i32):
+;     store notrap aligned region0 v1, v0
+;     brif v1, block1, block2
+;
+; block1:
+;     brif.i32 v2, block3, block4
+;
+; block2:
+;     brif.i32 v3, block3, block4
+;
+; block3:
+;     v4 = load.i32 notrap aligned region0 v0+8
+;     jump block5(v4)
+;
+; block4:
+;     jump block5(v1)
+;
+; block5(v5: i32):
+;     store.i32 notrap aligned region0 v2, v0
+;     return v5
+; }
+
+;; Same as above, but without the load in `block3`. Nothing observes the store in
+;; `block0` now, so the store in `block5` does make it dead, even though the two
+;; stores are separated by these control-flow merges.
+function %dead_across_crossing_merges(i64, i32, i32, i32) {
+    region0 = 0 "R0"
+
+block0(v0: i64, v1: i32, v2: i32, v3: i32):
+    store notrap aligned region0 v1, v0
+    brif v1, block1, block2
+
+block1:
+    brif v2, block3, block4
+
+block2:
+    brif v3, block3, block4
+
+block3:
+    jump block5
+
+block4:
+    jump block5
+
+block5:
+    store notrap aligned region0 v2, v0
+    return
+}
+
+; function %dead_across_crossing_merges(i64, i32, i32, i32) fast {
+;     region0 = 0 "R0"
+;
+; block0(v0: i64, v1: i32, v2: i32, v3: i32):
+;     brif v1, block1, block2
+;
+; block1:
+;     brif.i32 v2, block3, block4
+;
+; block2:
+;     brif.i32 v3, block3, block4
+;
+; block3:
+;     jump block5
+;
+; block4:
+;     jump block5
+;
+; block5:
+;     store.i32 notrap aligned region0 v2, v0
+;     return
+; }
+
+;; The store is in `block2` this time, i.e. on only one of the two paths into
+;; `block3`, where the load that observes it lives. It is still not dead.
+function %store_in_one_predecessor(i64, i32, i32, i32) -> i32 {
+    region0 = 0 "R0"
+
+block0(v0: i64, v1: i32, v2: i32, v3: i32):
+    brif v1, block1, block2
+
+block1:
+    brif v2, block3, block4
+
+block2:
+    store notrap aligned region0 v1, v0
+    brif v3, block3, block4
+
+block3:
+    v4 = load.i32 notrap aligned region0 v0
+    jump block5(v4)
+
+block4:
+    jump block5(v1)
+
+block5(v5: i32):
+    store notrap aligned region0 v2, v0
+    return v5
+}
+
+; function %store_in_one_predecessor(i64, i32, i32, i32) -> i32 fast {
+;     region0 = 0 "R0"
+;
+; block0(v0: i64, v1: i32, v2: i32, v3: i32):
+;     brif v1, block1, block2
+;
+; block1:
+;     brif.i32 v2, block3, block4
+;
+; block2:
+;     store.i32 notrap aligned region0 v1, v0
+;     brif.i32 v3, block3, block4
+;
+; block3:
+;     v4 = load.i32 notrap aligned region0 v0
+;     jump block5(v4)
+;
+; block4:
+;     jump block5(v1)
+;
+; block5(v5: i32):
+;     store.i32 notrap aligned region0 v2, v0
+;     return v5
+; }

--- a/cranelift/filetests/filetests/alias/dead-store-pre-gvn-address.clif
+++ b/cranelift/filetests/filetests/alias/dead-store-pre-gvn-address.clif
@@ -1,0 +1,30 @@
+test optimize precise-output
+set opt_level=speed
+target aarch64
+
+;; The two stores below are to the same address, so the first one is
+;; dead. However, `v2` and `v3` are still distinct values when
+;; `AliasAnalysis::observed_stores` is computed, because that happens up front,
+;; before the egraph has GVN'd anything. We can nonetheless eliminate the first
+;; store because we never ask whether one store overwrites another while
+;; computing the set of observed stores; we only ask that at the point where we
+;; actually eliminate a dead store, by which time GVN has run.
+function %pre_gvn_address(i64, i64) {
+    region0 = 0 "R0"
+
+block0(v0: i64, v1: i64):
+    v2 = iconst.i64 0
+    v3 = iconst.i64 0
+    store notrap aligned region0 v1, v2
+    store notrap aligned region0 v0, v3
+    return
+}
+
+; function %pre_gvn_address(i64, i64) fast {
+;     region0 = 0 "R0"
+;
+; block0(v0: i64, v1: i64):
+;     v2 = iconst.i64 0
+;     store notrap aligned region0 v0, v2  ; v2 = 0
+;     return
+; }

--- a/cranelift/filetests/filetests/alias/not-dead-loop-carried.clif
+++ b/cranelift/filetests/filetests/alias/not-dead-loop-carried.clif
@@ -1,0 +1,43 @@
+test optimize precise-output
+set opt_level=speed
+target aarch64
+
+;; Regression test for issue #13990.
+;;
+;; A store inside a loop is read on the next iteration by the load at the top of
+;; the loop, across the back edge, so it is not dead.
+function %loop_carried(i64, i32) -> i32 {
+    region0 = 0 "R0"
+block0(v0: i64, v1: i32):
+    jump block1
+
+block1:
+    v2 = load.i32 notrap region0 v0
+    v3 = iconst.i32 7
+    store notrap region0 v3, v0
+    brif v1, block1, block2
+
+block2:
+    v4 = iconst.i32 0
+    store notrap region0 v4, v0
+    return v2
+}
+
+; function %loop_carried(i64, i32) -> i32 fast {
+;     region0 = 0 "R0"
+;
+; block0(v0: i64, v1: i32):
+;     v3 = iconst.i32 7
+;     jump block1
+;
+; block1:
+;     v2 = load.i32 notrap region0 v0
+;     v5 = iconst.i32 7
+;     store notrap region0 v5, v0  ; v5 = 7
+;     brif.i32 v1, block1, block2
+;
+; block2:
+;     v4 = iconst.i32 0
+;     store notrap region0 v4, v0  ; v4 = 0
+;     return v2
+; }

--- a/cranelift/filetests/filetests/alias/stale-last-store-after-dead-store.clif
+++ b/cranelift/filetests/filetests/alias/stale-last-store-after-dead-store.clif
@@ -1,0 +1,26 @@
+test alias-analysis
+set opt_level=speed
+target aarch64
+
+;; Removing a dead store must leave the last-store state pointing at the
+;; overwriter, not at the store we just removed. Without that, the last store
+;; for `region0` would still be the store we just removed when we reached the
+;; next store, so we could only ever unwind the first link of a chain of dead
+;; stores.
+function %stale_after_dead_store(i64, i32, i32, i32) {
+    region0 = 0 "R0"
+
+block0(v0: i64, v1: i32, v2: i32, v3: i32):
+    store notrap aligned region0 v1, v0
+    store notrap aligned region0 v2, v0
+    store notrap aligned region0 v3, v0
+    store notrap aligned region0 v3, v0+8
+    return
+}
+
+;; Every store to `v0` but the last is dead.
+; not: store notrap aligned region0 v1, v0
+; not: store notrap aligned region0 v2, v0
+; check: store notrap aligned region0 v3, v0
+; check: store notrap aligned region0 v3, v0+8
+; not: store

--- a/cranelift/filetests/filetests/alias/stale-last-store-after-idempotent-store.clif
+++ b/cranelift/filetests/filetests/alias/stale-last-store-after-idempotent-store.clif
@@ -1,0 +1,39 @@
+test optimize precise-output
+set opt_level=speed
+target aarch64
+
+;; Removing an idempotent store deliberately leaves the last store for its
+;; region as whatever it was before that store, since that is what the
+;; rewritten code's last store actually is.
+function %stale_after_idempotent_store(i64, i32, i32) -> i32 {
+    region0 = 0 "R0"
+
+block0(v0: i64, v1: i32, v2: i32):
+    store notrap aligned region0 v1, v0
+    brif v2, block1, block2
+
+block1:
+    store notrap aligned region0 v1, v0
+    v3 = load.i32 notrap aligned region0 v0+8
+    return v3
+
+block2:
+    store notrap aligned region0 v2, v0
+    return v2
+}
+
+; function %stale_after_idempotent_store(i64, i32, i32) -> i32 fast {
+;     region0 = 0 "R0"
+;
+; block0(v0: i64, v1: i32, v2: i32):
+;     store notrap aligned region0 v1, v0
+;     brif v2, block1, block2
+;
+; block1:
+;     v3 = load.i32 notrap aligned region0 v0+8
+;     return v3
+;
+; block2:
+;     store.i32 notrap aligned region0 v2, v0
+;     return v2
+; }

--- a/cranelift/filetests/filetests/alias/store-to-load-forwarding-from-dead-store.clif
+++ b/cranelift/filetests/filetests/alias/store-to-load-forwarding-from-dead-store.clif
@@ -2,6 +2,11 @@ test optimize precise-output
 set opt_level=speed
 target aarch64
 
+;; TODO: we cannot do both store-to-load forwarding and dead-store elimination
+;; for the same store yet. This would require multiple iterations of the
+;; analysis: whether a store is observed is computed up front, over the original
+;; code, so the load below counts as observing the first store even though
+;; store-to-load forwarding subsequently removes that load.
 function %f(i64, i64) -> i64 {
     region0 = 0 "R0"
 block0(v0: i64, v1: i64):
@@ -9,10 +14,9 @@ block0(v0: i64, v1: i64):
     v3 = iadd v1, v2
     store notrap aligned region0 v3, v0
 
-    ;; `v4` should be rewritten into an alias of `v3` via store-to-load
-    ;; forwarding, and should NOT mark `region0` as observed. Then, when we
-    ;; process the second store below, we should be able to eliminate the first
-    ;; store as dead.
+    ;; `v4` is rewritten into an alias of `v3` via store-to-load forwarding, but
+    ;; it has already marked the first store as observed, so we cannot eliminate
+    ;; that store as dead when we process the second store below.
     v4 = load.i64 notrap aligned region0 v0
 
     v5 = iadd v3, v2
@@ -25,16 +29,16 @@ block0(v0: i64, v1: i64):
 ;     region0 = 0 "R0"
 ;
 ; block0(v0: i64, v1: i64):
+;     v2 = iconst.i64 1
+;     v3 = iadd v1, v2  ; v2 = 1
+;     store notrap aligned region0 v3, v0
 ;     v7 = iconst.i64 2
 ;     v12 = iadd v1, v7  ; v7 = 2
 ;     store notrap aligned region0 v12, v0
-;     v2 = iconst.i64 1
-;     v3 = iadd v1, v2  ; v2 = 1
 ;     return v3
 ; }
 
-;; TODO: we cannot do both store-to-load forwarding and dead-store elimination
-;; across blocks yet. This would require multiple iterations of the analysis.
+;; Same as above, but with the load and stores spread across blocks.
 function %f(i64, i64) -> i64 {
     region0 = 0 "R0"
 block0(v0: i64, v1: i64):

--- a/cranelift/filetests/filetests/isa/riscv64/issue-12811.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/issue-12811.clif
@@ -3414,10 +3414,8 @@ block2:
 ;   mv fp,sp
 ;   ld t6,8(a0)
 ;   ld t6,16(t6)
-;   addi t6,t6,32
+;   addi t6,t6,16
 ;   trap_if stk_ovf##(sp ult t6)
-;   addi sp,sp,-16
-;   sd s7,8(sp)
 ; block0:
 ;   li a1,0
 ;   sd zero,0(a1)
@@ -3605,15 +3603,15 @@ block2:
 ;   j label1
 ; block1:
 ;   lui a1,435789
-;   addi a2,a1,3
-;   sext.w a1,a2
+;   addi a1,a1,3
+;   sext.w a1,a1
 ;   trap_if user11##(a1 ne zero)
 ;   j label2
 ; block2:
-;   lui a2,154029
-;   addi a4,a2,-1574
-;   sext.w a3,a4
-;   trap_if user11##(a3 ne zero)
+;   lui a1,154029
+;   addi a1,a1,-1574
+;   sext.w a1,a1
+;   trap_if user11##(a1 ne zero)
 ;   j label3
 ; block3:
 ;   j label4
@@ -3721,58 +3719,58 @@ block2:
 ; block39:
 ;   j label40
 ; block40:
-;   ld a2,[const(213)]
+;   ld a2,[const(144)]
 ;   li a1,0
 ;   sd a2,0(a1)
-;   ld a2,[const(212)]
+;   ld a2,[const(143)]
 ;   sd zero,0(a2)
-;   ld a2,[const(211)]
+;   ld a2,[const(142)]
 ;   sd a2,0(a1)
 ;   li a2,1
-;   ld a3,[const(210)]
+;   ld a3,[const(141)]
 ;   sd a2,0(a3)
-;   ld a3,[const(209)]
+;   ld a3,[const(140)]
 ;   sd a3,0(a1)
-;   ld a3,[const(208)]
+;   ld a3,[const(139)]
 ;   sd zero,0(a3)
-;   ld a3,[const(207)]
+;   ld a3,[const(138)]
 ;   sd a3,0(a1)
-;   ld a3,[const(206)]
+;   ld a3,[const(137)]
 ;   sd zero,0(a3)
-;   ld a3,[const(205)]
+;   ld a3,[const(136)]
 ;   sd zero,0(a3)
-;   ld a3,[const(204)]
+;   ld a3,[const(135)]
 ;   sd a3,0(a1)
-;   ld a3,[const(203)]
+;   ld a3,[const(134)]
 ;   sd a2,0(a3)
-;   ld a3,[const(202)]
+;   ld a3,[const(133)]
 ;   sd a3,0(a1)
-;   ld a3,[const(201)]
+;   ld a3,[const(132)]
 ;   sd zero,0(a3)
-;   ld a3,[const(200)]
+;   ld a3,[const(131)]
 ;   sd a3,0(a1)
-;   li a3,1
-;   ld a4,[const(199)]
-;   sw a3,0(a4)
-;   ld a4,[const(198)]
-;   sd a4,0(a1)
-;   ld a4,[const(197)]
-;   sd zero,0(a4)
+;   li a4,1
+;   ld a3,[const(130)]
+;   sw a4,0(a3)
+;   ld a3,[const(129)]
+;   sd a3,0(a1)
+;   ld a3,[const(128)]
+;   sd zero,0(a3)
 ;   sd zero,0(a1)
-;   li a5,0
+;   li a3,0
 ;   sw zero,0(a1)
-;   ld a4,[const(196)]
-;   sd a4,0(a1)
+;   ld a5,[const(127)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(195)]
-;   sd a4,0(a1)
+;   ld a5,[const(126)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   ld a4,[const(194)]
-;   ld s7,[const(193)]
-;   sd a4,0(s7)
+;   ld a5,[const(125)]
+;   ld a7,[const(124)]
+;   sd a5,0(a7)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
@@ -3780,30 +3778,30 @@ block2:
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(192)]
-;   sd a4,0(a1)
+;   ld a5,[const(123)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(191)]
-;   sd zero,0(a4)
+;   ld a5,[const(122)]
+;   sd zero,0(a5)
 ;   sw zero,0(a1)
-;   ld a4,[const(190)]
-;   sd a4,0(a1)
+;   ld a5,[const(121)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(189)]
-;   sd a4,0(a1)
+;   ld a5,[const(120)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(188)]
-;   sd zero,0(a4)
-;   ld a4,[const(187)]
-;   sd a4,0(a1)
+;   ld a5,[const(119)]
+;   sd zero,0(a5)
+;   ld a5,[const(118)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
@@ -3815,531 +3813,287 @@ block2:
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(186)]
-;   sd a4,0(a1)
+;   ld a5,[const(117)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(185)]
-;   sd a4,0(a1)
+;   ld a5,[const(116)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(184)]
-;   sd a4,0(a1)
+;   ld a5,[const(115)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(183)]
-;   sd a4,0(a1)
+;   ld a5,[const(114)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(182)]
-;   sd a4,0(a1)
-;   ld a4,[const(181)]
-;   ld a4,0(a4)
+;   ld a5,[const(113)]
+;   sd a5,0(a1)
+;   ld a5,[const(112)]
+;   ld a5,0(a5)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(180)]
-;   sd a4,0(a1)
-;   ld a4,[const(179)]
-;   sd a4,0(a1)
+;   ld a5,[const(111)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(178)]
-;   sd a4,0(a1)
-;   ld a4,[const(177)]
-;   sd a4,0(a1)
+;   ld a5,[const(110)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(176)]
-;   sd a4,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(175)]
-;   sd a4,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(174)]
-;   sd a4,0(a1)
 ;   sd zero,0(a1)
-;   ld a4,[const(173)]
-;   sd zero,0(a4)
+;   ld a5,[const(109)]
+;   sd zero,0(a5)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(172)]
-;   sd a4,0(a1)
+;   ld a5,[const(108)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(171)]
-;   sd a4,0(a1)
+;   ld a5,[const(107)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(170)]
-;   sd a4,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(169)]
-;   sd a4,0(a1)
+;   ld a5,[const(106)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(168)]
-;   sd a4,0(a1)
+;   ld a5,[const(105)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(167)]
-;   sd a4,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   ld a4,[const(166)]
-;   sd a4,0(a1)
-;   sw zero,0(a1)
-;   ld a4,[const(165)]
-;   sd a4,0(a1)
-;   sw zero,0(a1)
-;   ld a4,[const(164)]
-;   sd a4,0(a1)
-;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   ld a4,[const(163)]
-;   sd a4,0(a1)
-;   ld a4,[const(162)]
-;   sd a4,0(a1)
-;   sd zero,0(a1)
-;   ld a4,[const(161)]
-;   ld a4,0(a4)
-;   sw zero,0(a1)
-;   ld a4,[const(160)]
-;   sd a4,0(a1)
-;   ld a4,[const(159)]
-;   sd a4,0(a1)
-;   sw zero,0(a1)
-;   ld a4,[const(158)]
-;   sd a4,0(a1)
-;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   ld a4,[const(157)]
-;   sd a4,0(a1)
-;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   ld a4,[const(156)]
-;   sd a4,0(a1)
-;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   ld a4,[const(155)]
-;   sd a4,0(a1)
-;   sw zero,0(a1)
-;   ld a4,[const(154)]
-;   sd a4,0(a1)
-;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   ld a4,[const(153)]
-;   sd a4,0(a1)
-;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   ld a4,[const(152)]
-;   sd a4,0(a1)
-;   sw zero,0(a1)
-;   ld a4,[const(151)]
-;   sd a4,0(a1)
-;   ld a4,[const(150)]
-;   sd a4,0(a1)
-;   sw zero,0(a1)
-;   ld a4,[const(149)]
-;   sd a4,0(a1)
-;   ld a4,[const(148)]
-;   sd zero,0(a4)
+;   ld a5,[const(104)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(147)]
-;   sd a4,0(a1)
+;   ld a5,[const(103)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
+;   ld a5,[const(102)]
+;   ld a5,0(a5)
 ;   sw zero,0(a1)
-;   ld a4,[const(146)]
-;   sd a4,0(a1)
+;   ld a5,[const(101)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(145)]
-;   sd a4,0(a1)
-;   ld a4,[const(144)]
-;   sd a4,0(a1)
-;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   ld a4,[const(143)]
-;   sd a4,0(a1)
-;   sw zero,0(a1)
-;   ld a4,[const(142)]
-;   sd a4,0(a1)
-;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   ld a4,[const(141)]
-;   sd a4,0(a1)
-;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   ld a4,[const(140)]
-;   sd a4,0(a1)
-;   ld a4,[const(139)]
-;   sd a4,0(a1)
-;   sw zero,0(a1)
-;   ld a4,[const(138)]
-;   sd a4,0(a1)
-;   ld a4,[const(137)]
-;   sd a4,0(a1)
-;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   ld a4,[const(136)]
-;   sd a4,0(a1)
 ;   sw zero,0(a1)
-;   sd zero,0(a1)
+;   ld a5,[const(100)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(135)]
-;   sd a4,0(a1)
 ;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   ld a4,[const(134)]
-;   sd a4,0(a1)
-;   ld a4,[const(133)]
-;   sd a4,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(132)]
-;   sd a4,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(131)]
-;   sd a4,0(a1)
-;   ld a4,[const(130)]
-;   sd a4,0(a1)
-;   sw zero,0(a1)
-;   ld a4,[const(129)]
-;   sd a4,0(a1)
-;   ld a4,[const(128)]
-;   sd a4,0(a1)
-;   sw zero,0(a1)
-;   ld a4,[const(127)]
-;   sd a4,0(a1)
-;   ld a4,[const(126)]
-;   sd a4,0(a1)
-;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   ld a4,[const(125)]
-;   sd a4,0(a1)
+;   ld a5,[const(99)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(124)]
-;   sd a4,0(a1)
-;   ld a4,[const(123)]
-;   sd a4,0(a1)
-;   ld a4,[const(122)]
-;   sd a4,0(a1)
-;   ld a4,[const(121)]
-;   sd a4,0(a1)
+;   ld a5,[const(98)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   ld a4,[const(120)]
-;   sd a4,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(119)]
-;   sd a4,0(a1)
-;   ld a4,[const(118)]
-;   sd a4,0(a1)
+;   ld a5,[const(97)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(117)]
-;   sd a4,0(a1)
-;   ld a4,[const(116)]
-;   sd a4,0(a1)
+;   ld a5,[const(96)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
-;   sd zero,0(a1)
+;   ld a5,[const(95)]
+;   sd a5,0(a1)
+;   ld a5,[const(94)]
+;   sd zero,0(a5)
 ;   sw zero,0(a1)
-;   sd zero,0(a1)
+;   ld a5,[const(93)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(115)]
-;   sd a4,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   ld a4,[const(114)]
-;   sd a4,0(a1)
 ;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   ld a4,[const(113)]
-;   sd a4,0(a1)
+;   ld a5,[const(92)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(112)]
-;   sd a4,0(a1)
-;   ld a4,[const(111)]
-;   sd a4,0(a1)
+;   ld a5,[const(91)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(110)]
-;   sd a4,0(a1)
-;   ld a4,[const(109)]
-;   sd a4,0(a1)
-;   sw zero,0(a1)
-;   ld a4,[const(108)]
-;   sd a4,0(a1)
-;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   sd zero,0(a1)
+;   ld a5,[const(90)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   ld a4,[const(107)]
-;   sd a4,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(106)]
-;   sd a2,0(a4)
-;   sd zero,0(a1)
+;   ld a5,[const(89)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(105)]
-;   sd zero,0(a4)
-;   sd zero,0(a1)
+;   ld a5,[const(88)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
-;   sd zero,0(a1)
+;   ld a5,[const(87)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
-;   sd zero,0(a1)
+;   ld a5,[const(86)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   ld a4,[const(104)]
-;   sd a4,0(a1)
-;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   ld a4,[const(103)]
-;   sd a4,0(a1)
-;   sd zero,0(a1)
+;   ld a5,[const(85)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   ld a4,[const(102)]
-;   sd zero,0(a4)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(101)]
-;   sd a4,0(a1)
-;   ld a4,[const(100)]
-;   sd a4,0(a1)
-;   sd zero,0(a1)
+;   ld a5,[const(84)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(99)]
-;   sd a2,0(a4)
-;   ld a4,[const(98)]
-;   sd a4,0(a1)
+;   ld a5,[const(83)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   ld a4,[const(97)]
-;   sd a4,0(a1)
+;   ld a5,[const(82)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(96)]
-;   sd a4,0(a1)
-;   ld a4,[const(95)]
-;   sd a4,0(a1)
+;   ld a5,[const(81)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
-;   sd zero,0(a1)
+;   ld a5,[const(80)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   ld a4,[const(94)]
-;   sd a4,0(a1)
+;   ld a5,[const(79)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
-;   sd zero,0(a1)
+;   ld a5,[const(78)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(93)]
-;   sd a2,0(a4)
-;   ld a4,[const(92)]
-;   sd a4,0(a1)
-;   sd zero,0(a1)
+;   ld a5,[const(77)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(91)]
-;   sd a4,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   lui a4,309522
-;   addi a4,a4,-111
-;   ld t0,[const(90)]
-;   sw a4,0(t0)
+;   ld a5,[const(76)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(89)]
-;   sd a4,0(a1)
-;   ld a4,[const(88)]
-;   sd a4,0(a1)
+;   ld a5,[const(75)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(87)]
-;   sd a4,0(a1)
+;   ld a5,[const(74)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(86)]
-;   sd a4,0(a1)
-;   sd zero,0(a1)
+;   ld a5,[const(73)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(85)]
-;   sd a4,0(a1)
-;   ld a4,[const(84)]
-;   sd a4,0(a1)
+;   ld a5,[const(72)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(83)]
-;   sd a4,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   sd zero,0(a1)
+;   ld a5,[const(71)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
+;   ld a5,[const(70)]
+;   sd a2,0(a5)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
+;   ld a5,[const(69)]
+;   sd zero,0(a5)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   ld a4,[const(82)]
-;   sd a4,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   ld a4,[const(81)]
-;   sd a4,0(a1)
-;   ld a4,[const(80)]
-;   sd a4,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(79)]
-;   sd a4,0(a1)
 ;   sd zero,0(a1)
-;   ld a4,[const(78)]
-;   sd a4,0(a1)
-;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   ld a4,[const(77)]
-;   sd a4,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(76)]
-;   sd a4,0(a1)
-;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   ld a4,[const(75)]
-;   sd a4,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(74)]
-;   sd a4,0(a1)
-;   ld a4,[const(73)]
-;   sd a4,0(a1)
-;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   ld a4,[const(72)]
-;   sd a4,0(a1)
+;   ld a5,[const(68)]
+;   sd zero,0(a5)
 ;   sw zero,0(a1)
-;   ld a4,[const(71)]
-;   sd a4,0(a1)
-;   sw zero,0(a1)
-;   ld a4,[const(70)]
-;   sd a4,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   sd zero,0(a1)
+;   ld a5,[const(67)]
+;   sd a2,0(a5)
+;   ld a5,[const(66)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
-;   sd zero,0(a1)
+;   ld a5,[const(65)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
-;   sd zero,0(a1)
+;   ld a5,[const(64)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(69)]
-;   sd a4,0(a1)
 ;   sd zero,0(a1)
-;   ld a4,[const(68)]
-;   sd a4,0(a1)
-;   ld a4,[const(67)]
-;   lw a4,0(a4)
-;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   ld a4,[const(66)]
-;   sd a4,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   ld a4,[const(65)]
-;   sd a4,0(a1)
 ;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   ld a4,[const(64)]
-;   sd a4,0(a1)
+;   ld a5,[const(63)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(63)]
-;   sd a4,0(a1)
+;   ld a5,[const(62)]
+;   sd a2,0(a5)
 ;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   ld a4,[const(62)]
-;   sd a4,0(a1)
-;   sw zero,0(a1)
-;   ld a4,[const(61)]
-;   sd a4,0(a1)
-;   ld a4,[const(60)]
-;   sd a4,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(59)]
-;   sd a4,0(a1)
 ;   sd zero,0(a1)
-;   ld a4,[const(58)]
-;   sw zero,0(a4)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(57)]
-;   sd a4,0(a1)
+;   lui a5,309522
+;   addi a5,a5,-111
+;   ld t2,[const(61)]
+;   sw a5,0(t2)
 ;   sw zero,0(a1)
-;   ld a4,[const(56)]
-;   sd a4,0(a1)
-;   ld a4,[const(55)]
-;   sw a3,0(a4)
+;   ld a5,[const(60)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   ld a4,[const(54)]
-;   sd a4,0(a1)
-;   sw zero,0(a1)
-;   sd zero,0(a1)
+;   ld a5,[const(59)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   ld a4,[const(53)]
-;   sd a4,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   ld a4,[const(52)]
-;   sd a2,0(a4)
 ;   sw zero,0(a1)
-;   ld a4,[const(51)]
-;   sd a4,0(a1)
-;   ld a4,[const(50)]
-;   sd a4,0(a1)
+;   ld a5,[const(58)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(49)]
-;   sd a4,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
@@ -4347,189 +4101,265 @@ block2:
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   sb a5,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(48)]
-;   sd a4,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(47)]
-;   sd a4,0(a1)
-;   ld a4,[const(46)]
-;   sd a4,0(a1)
-;   sw zero,0(a1)
-;   ld a4,[const(45)]
-;   sd a4,0(a1)
-;   ld a4,[const(44)]
-;   sd a4,0(a1)
-;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   ld a4,[const(43)]
-;   sd a4,0(a1)
-;   ld a4,[const(42)]
-;   sd a2,0(a4)
 ;   sw zero,0(a1)
-;   ld a4,[const(41)]
-;   sd a4,0(a1)
+;   ld a5,[const(57)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(40)]
-;   sd a4,0(a1)
-;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   ld a4,[const(39)]
-;   sd a4,0(a1)
 ;   sd zero,0(a1)
-;   sb a5,0(a1)
-;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(38)]
-;   sd a4,0(a1)
+;   ld a5,[const(56)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(37)]
-;   sd a4,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(36)]
-;   sd a4,0(a1)
-;   ld a4,[const(35)]
-;   sd a2,0(a4)
+;   ld a5,[const(55)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   lw a4,0(a1)
+;   ld a5,[const(54)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   ld a4,[const(34)]
-;   sd a4,0(a1)
-;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(33)]
-;   sd a4,0(a1)
+;   ld a5,[const(53)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
-;   sd zero,0(a1)
+;   ld a5,[const(52)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(32)]
-;   sd a4,0(a1)
+;   ld a5,[const(51)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   ld a4,[const(31)]
-;   sd a4,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   ld a4,[const(30)]
-;   sd a2,0(a4)
-;   ld a4,[const(29)]
-;   sd zero,0(a4)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   sb a5,0(a1)
 ;   sw zero,0(a1)
+;   ld a5,[const(50)]
+;   sd a5,0(a1)
+;   ld a5,[const(49)]
+;   lw a5,0(a5)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(28)]
-;   sd a4,0(a1)
+;   ld a5,[const(48)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
-;   sd zero,0(a1)
+;   ld a5,[const(47)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(27)]
-;   sd a4,0(a1)
-;   sd zero,0(a1)
+;   ld a5,[const(46)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   sb a5,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   sd zero,0(a1)
+;   ld a5,[const(45)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
-;   sd zero,0(a1)
+;   ld a5,[const(44)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
+;   ld a5,[const(43)]
+;   sw zero,0(a5)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   sb a5,0(a1)
-;   sw zero,0(a1)
-;   ld a4,[const(26)]
-;   sd a4,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   ld a4,[const(25)]
-;   sd a4,0(a1)
-;   sd zero,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(24)]
-;   sd a4,0(a1)
+;   ld a5,[const(42)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
-;   sd zero,0(a1)
+;   ld a5,[const(41)]
+;   sd a5,0(a1)
+;   ld a5,[const(40)]
+;   sw a4,0(a5)
 ;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   sb a5,0(a1)
+;   ld a5,[const(39)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   ld a4,[const(23)]
-;   sd a4,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(22)]
-;   sd a4,0(a1)
-;   sw zero,0(a1)
-;   ld a4,[const(21)]
-;   sd a4,0(a1)
 ;   sd zero,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
+;   ld a5,[const(38)]
+;   sd a2,0(a5)
 ;   sw zero,0(a1)
-;   ld a4,[const(20)]
-;   sd a4,0(a1)
-;   ld a4,[const(19)]
-;   sd a4,0(a1)
+;   ld a5,[const(37)]
+;   sd a5,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   ld a4,[const(18)]
-;   sd a4,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   sw zero,0(a1)
-;   ld a4,[const(17)]
-;   sd zero,0(a4)
-;   sb a5,0(a1)
-;   sw zero,0(a1)
-;   ld a4,[const(16)]
-;   sd a4,0(a1)
-;   sw zero,0(a1)
-;   ld a4,[const(15)]
-;   sd a4,0(a1)
-;   ld a4,[const(14)]
-;   sd a4,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   ld a4,[const(13)]
-;   sd a4,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
 ;   sb a3,0(a1)
 ;   sw zero,0(a1)
-;   ld a4,[const(12)]
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(36)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(35)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(34)]
+;   sd a5,0(a1)
+;   ld a5,[const(33)]
+;   sd a2,0(a5)
+;   sw zero,0(a1)
+;   ld a5,[const(32)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(31)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sb a3,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(30)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(29)]
+;   sd a5,0(a1)
+;   ld a5,[const(28)]
+;   sd a2,0(a5)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   lw a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(27)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(26)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(25)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   ld a5,[const(24)]
+;   sd a2,0(a5)
+;   ld a5,[const(23)]
+;   sd zero,0(a5)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sb a3,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(22)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sb a3,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sb a3,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(21)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(20)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sb a3,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(19)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(18)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(17)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(16)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(15)]
+;   sd zero,0(a5)
+;   sb a3,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(14)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(13)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   ld a5,[const(12)]
+;   sd a5,0(a1)
+;   sw zero,0(a1)
+;   sd zero,0(a1)
+;   sb a4,0(a1)
+;   sw zero,0(a1)
+;   ld a4,[const(11)]
 ;   sd a4,0(a1)
-;   ld a3,[const(11)]
-;   sd a3,0(a1)
+;   sw zero,0(a1)
+;   ld a4,[const(10)]
+;   sd a4,0(a1)
+;   sw zero,0(a1)
+;   ld a4,[const(9)]
+;   sd a4,0(a1)
 ;   sw zero,0(a1)
 ;   sd zero,0(a1)
-;   ld a3,[const(10)]
-;   sd a3,0(a1)
-;   sw zero,0(a1)
-;   ld a3,[const(9)]
-;   sd a3,0(a1)
-;   sw zero,0(a1)
-;   sd zero,0(a1)
-;   sb a5,0(a1)
+;   sb a3,0(a1)
 ;   sw zero,0(a1)
 ;   ld a3,[const(8)]
 ;   sd a2,0(a3)
@@ -4594,12 +4424,10 @@ block2:
 ;   c.mv s0, sp
 ;   ld t6, 8(a0)
 ;   ld t6, 0x10(t6)
-;   addi t6, t6, 0x20
+;   c.addi t6, 0x10
 ;   bgeu sp, t6, 6
 ;   c.unimp ; trap: stk_ovf
-;   c.addi16sp sp, -0x10
-;   c.sdsp s7, 8(sp)
-; block1: ; offset 0x1e
+; block1: ; offset 0x18
 ;   c.li a1, 0
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
@@ -4783,139 +4611,139 @@ block2:
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   c.sd a2, 0(a1) ; trap: heap_oob
-; block2: ; offset 0x2ac
+; block2: ; offset 0x2a6
 ;   lui a1, 0x6a64d
-;   addi a2, a1, 3
-;   sext.w a1, a2
+;   c.addi a1, 3
+;   c.addiw a1, 0
 ;   beqz a1, 6
 ;   c.unimp ; trap: user11
-; block3: ; offset 0x2be
-;   lui a2, 0x259ad
-;   addi a4, a2, -0x626
-;   sext.w a3, a4
-;   beqz a3, 6
+; block3: ; offset 0x2b4
+;   lui a1, 0x259ad
+;   addi a1, a1, -0x626
+;   c.addiw a1, 0
+;   beqz a1, 6
 ;   c.unimp ; trap: user11
-; block4: ; offset 0x2d0
+; block4: ; offset 0x2c4
 ;   c.li a1, 1
 ;   c.addiw a1, 0
 ;   beqz a1, 6
 ;   c.unimp ; trap: user11
-; block5: ; offset 0x2da
+; block5: ; offset 0x2ce
 ;   lui a1, 0x7c7d9
 ;   addi a1, a1, -0xc1
 ;   c.addiw a1, 0
 ;   beqz a1, 6
 ;   c.unimp ; trap: user11
-; block6: ; offset 0x2ea
+; block6: ; offset 0x2de
 ;   lui a1, 0x5b1f2
 ;   addi a1, a1, 0x6e3
 ;   c.addiw a1, 0
 ;   beqz a1, 6
 ;   c.unimp ; trap: user11
-; block7: ; offset 0x2fa
+; block7: ; offset 0x2ee
 ;   lui a1, 0x6f8d1
 ;   addi a1, a1, -0x144
 ;   c.addiw a1, 0
 ;   beqz a1, 6
 ;   c.unimp ; trap: user11
-; block8: ; offset 0x30a
+; block8: ; offset 0x2fe
 ;   lui a1, 0x484e2
 ;   addi a1, a1, -0x478
 ;   c.addiw a1, 0
 ;   beqz a1, 6
 ;   c.unimp ; trap: user11
-; block9: ; offset 0x31a
+; block9: ; offset 0x30e
 ;   lui a1, 0x110e5
 ;   addi a1, a1, -0x662
 ;   c.addiw a1, 0
 ;   beqz a1, 6
 ;   c.unimp ; trap: user11
-; block10: ; offset 0x32a
+; block10: ; offset 0x31e
 ;   lui a1, 0x71fd2
 ;   addi a1, a1, 0x446
 ;   c.addiw a1, 0
 ;   beqz a1, 6
 ;   c.unimp ; trap: user11
-; block11: ; offset 0x33a
+; block11: ; offset 0x32e
 ;   lui a1, 0x8237d
 ;   addi a1, a1, 0x5b7
 ;   c.addiw a1, 0
 ;   beqz a1, 6
 ;   c.unimp ; trap: user11
-; block12: ; offset 0x34a
+; block12: ; offset 0x33e
 ;   auipc a2, 0
-;   ld a2, 0x276(a2)
+;   ld a2, 0x292(a2)
 ;   c.li a1, 0
 ;   c.sd a2, 0(a1) ; trap: heap_oob
 ;   auipc a2, 0
-;   ld a2, 0x272(a2)
+;   ld a2, 0x28e(a2)
 ;   sd zero, 0(a2) ; trap: heap_oob
 ;   auipc a2, 0
-;   ld a2, 0x26e(a2)
+;   ld a2, 0x28a(a2)
 ;   c.sd a2, 0(a1) ; trap: heap_oob
 ;   c.li a2, 1
 ;   auipc a3, 0
-;   ld a3, 0x26a(a3)
+;   ld a3, 0x286(a3)
 ;   c.sd a2, 0(a3) ; trap: heap_oob
 ;   auipc a3, 0
-;   ld a3, 0x268(a3)
+;   ld a3, 0x284(a3)
 ;   c.sd a3, 0(a1) ; trap: heap_oob
+;   auipc a3, 0
+;   ld a3, 0x282(a3)
+;   sd zero, 0(a3) ; trap: heap_oob
+;   auipc a3, 0
+;   ld a3, 0x27e(a3)
+;   c.sd a3, 0(a1) ; trap: heap_oob
+;   auipc a3, 0
+;   ld a3, 0x27c(a3)
+;   sd zero, 0(a3) ; trap: heap_oob
+;   auipc a3, 0
+;   ld a3, 0x278(a3)
+;   sd zero, 0(a3) ; trap: heap_oob
+;   auipc a3, 0
+;   ld a3, 0x274(a3)
+;   c.sd a3, 0(a1) ; trap: heap_oob
+;   auipc a3, 0
+;   ld a3, 0x272(a3)
+;   c.sd a2, 0(a3) ; trap: heap_oob
+;   auipc a3, 0
+;   ld a3, 0x270(a3)
+;   c.sd a3, 0(a1) ; trap: heap_oob
+;   auipc a3, 0
+;   ld a3, 0x26e(a3)
+;   sd zero, 0(a3) ; trap: heap_oob
+;   auipc a3, 0
+;   ld a3, 0x26a(a3)
+;   c.sd a3, 0(a1) ; trap: heap_oob
+;   c.li a4, 1
 ;   auipc a3, 0
 ;   ld a3, 0x266(a3)
-;   sd zero, 0(a3) ; trap: heap_oob
+;   c.sw a4, 0(a3) ; trap: heap_oob
+;   auipc a3, 0
+;   ld a3, 0x264(a3)
+;   c.sd a3, 0(a1) ; trap: heap_oob
 ;   auipc a3, 0
 ;   ld a3, 0x262(a3)
-;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 0
-;   ld a3, 0x260(a3)
 ;   sd zero, 0(a3) ; trap: heap_oob
-;   auipc a3, 0
-;   ld a3, 0x25c(a3)
-;   sd zero, 0(a3) ; trap: heap_oob
-;   auipc a3, 0
-;   ld a3, 0x258(a3)
-;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 0
-;   ld a3, 0x256(a3)
-;   c.sd a2, 0(a3) ; trap: heap_oob
-;   auipc a3, 0
-;   ld a3, 0x254(a3)
-;   c.sd a3, 0(a1) ; trap: heap_oob
-;   auipc a3, 0
-;   ld a3, 0x252(a3)
-;   sd zero, 0(a3) ; trap: heap_oob
-;   auipc a3, 0
-;   ld a3, 0x24e(a3)
-;   c.sd a3, 0(a1) ; trap: heap_oob
-;   c.li a3, 1
-;   auipc a4, 0
-;   ld a4, 0x24a(a4)
-;   c.sw a3, 0(a4) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x248(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x246(a4)
-;   sd zero, 0(a4) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
-;   c.li a5, 0
+;   c.li a3, 0
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x238(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x254(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x232(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x24e(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x220(a4)
-;   auipc s7, 0
-;   ld s7, 0x220(s7)
-;   sd a4, 0(s7) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x23c(a5)
+;   auipc a7, 0
+;   ld a7, 0x23c(a7)
+;   sd a5, 0(a7) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
@@ -4923,36 +4751,36 @@ block2:
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x200(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x21c(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x1ea(a4)
-;   sd zero, 0(a4) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x206(a5)
+;   sd zero, 0(a5) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x1e2(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x1fe(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x1cc(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x1c6(a4)
-;   sd zero, 0(a4) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x1c2(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x1e8(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x1e2(a5)
+;   sd zero, 0(a5) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x1de(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
@@ -4964,60 +4792,66 @@ block2:
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x194(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x1b0(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x18e(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x1aa(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x180(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x19c(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x17a(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x196(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x174(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x172(a4)
-;   c.ld a4, 0(a4) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x190(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x18e(a5)
+;   c.ld a5, 0(a5) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x168(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x166(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x184(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x160(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x15e(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x17e(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x158(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x14e(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x144(a4)
-;   c.j 0x144
-;   c.unimp
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x164(a5)
+;   sd zero, 0(a5) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x150(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x14a(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x13c(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   c.j 0x13a
 ;   c.lw a2, 0xc(a4)
 ;   c.sd s0, 0x70(s0)
 ;   c.slli a7, 1
@@ -5143,97 +4977,14 @@ block2:
 ;   .byte 0x23, 0xc2
 ;   c.unimp
 ;   c.unimp
-;   c.mv a4, t3
-;   .byte 0x0f, 0x41
-;   c.addi4spn a0, sp, 0x210
-;   c.slli t1, 0x1b
 ;   c.swsp s11, 0x44(sp)
 ;   c.fsdsp fs0, 0x38(sp)
 ;   c.fsdsp ft7, 0x88(sp)
 ;   c.beqz s1, 0x5a
-;   c.beqz s0, -0x100
-;   .byte 0xdf, 0xec
-;   c.lwsp t0, 0x70(sp)
-;   c.lui t6, 0xfffe6
 ;   c.fld fa1, 0x58(a0)
 ;   c.lw a1, 0x24(a5)
 ;   c.fldsp fa2, 0x60(sp)
 ;   c.beqz a2, -0x36
-;   c.fsd fs0, 0xf8(s1)
-;   c.sd s1, 0x40(s0)
-;   c.sub a5, a4
-;   c.swsp a5, 0x78(sp)
-;   c.fsd fa4, 0x70(a1)
-;   c.ld a2, 0x60(s0)
-;   .byte 0xf0, 0x96
-;   c.fsdsp fa0, 0x180(sp)
-;   c.fld fa4, 0x70(a0)
-;   c.swsp t0, 0x60(sp)
-;   c.j 0x44c
-;   c.addi4spn s1, sp, 0x3ac
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0xda(a4)
-;   sd zero, 0(a4) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0xc6(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0xc0(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0xba(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0xb0(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0xaa(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0xa4(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x96(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x90(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x8a(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x80(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x7e(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x78(a4)
-;   c.ld a4, 0(a4) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x72(a4)
-;   c.j 0x72
 ;   c.j -0x648
 ;   .byte 0x73, 0xca
 ;   c.unimp
@@ -5243,20 +4994,89 @@ block2:
 ;   fmsub.s ft4, fs5, fa0, fa6, rdn
 ;   c.ld a1, 0x78(a4)
 ;   c.beqz a1, 0x5c
-;   csrrw s0, 3434, s3
-;   fnmsub.s ft4, ft9, ft5, ft8
 ;   c.beqz a1, 0xb6
 ;   .byte 0xbf, 0x7f
 ;   c.fsdsp ft7, 0x180(sp)
 ;   c.bnez a1, 0x3c
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x10c(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0xfe(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0xf8(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0xe6(a5)
+;   c.ld a5, 0(a5) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0xe0(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0xd2(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0xb4(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0xae(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x98(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x92(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x8c(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x8a(a5)
+;   sd zero, 0(a5) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x82(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.j 0x6c
+;   c.unimp
 ;   c.slli s10, 0x39
 ;   c.fldsp ft8, 0x80(sp)
 ;   c.slli t1, 0x3d
 ;   c.bnez a0, -0xb4
-;   c.ld s0, 0xb8(s0)
-;   c.addi4spn a5, sp, 0x3bc
-;   .byte 0x5f, 0x95
-;   c.fldsp ft8, 0x1c8(sp)
 ;   .byte 0x07, 0x00
 ;   c.unimp
 ;   c.unimp
@@ -5265,94 +5085,18 @@ block2:
 ;   c.addiw s5, -0xf
 ;   .byte 0xe7, 0xd9
 ;   c.sdsp t0, 0xc8(sp)
-;   c.fldsp fa7, 0x1d8(sp)
-;   c.fld fs1, 0x90(s0)
-;   csrrs s10, 3729, a1
-;   c.lui t3, 0x11
-;   c.li tp, 0x16
-;   c.sw a4, 0x40(a3)
-;   c.bnez a3, -0x4a
-;   c.sw a0, 0x48(a5)
-;   c.lui t5, 0x1d
-;   c.lwsp s11, 0x58(sp)
-;   c.sdsp t0, 0x110(sp)
 ;   c.addi t5, 9
 ;   c.andi s0, -0x16
-;   c.unimp
-;   c.unimp
-;   c.lui a0, 0xffff3
-;   c.beqz a2, 0x9a
-;   c.sd a5, 0x50(a1)
-;   c.fsdsp fa3, 0x1d8(sp)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0xb6(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0xb0(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0xa2(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x94(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x7e(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x78(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x6a(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x60(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x5a(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x58(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   c.j 0x56
 ;   c.unimp
 ;   c.unimp
 ;   .byte 0x33, 0x10
 ;   c.mv s1, s3
 ;   c.addiw a7, -0xa
 ;   c.j -0x71e
-;   c.fld fs1, 0x60(a0)
-;   c.swsp ra, 0x40(sp)
-;   .byte 0xab, 0x8f
-;   c.sd a3, 0x20(s1)
 ;   .byte 0x0f, 0x5a
 ;   c.addiw a1, -0x1b
 ;   .byte 0x69, 0x40
 ;   c.fld fa3, 0x98(a1)
-;   .byte 0x6c, 0x84
-;   c.addi s11, -2
-;   c.beqz s1, 0xb8
-;   c.addi4spn a5, sp, 0x3bc
 ;   c.fsd fa4, 0xc8(s0)
 ;   .byte 0xcb, 0xd8
 ;   c.ldsp s2, 0x68(sp)
@@ -5360,47 +5104,14 @@ block2:
 ;   c.ld a2, 0xb8(s0)
 ;   .byte 0xff, 0xb4
 ;   c.beqz s0, 0xa0
-;   fnmadd.d fs9, fa4, fs10, fa3, rne
-;   fsw ft9, -0x5f3(t6)
-;   c.addi a6, -0x17
+;   .byte 0xcf, 0x0c
 ;   c.ld a2, 0xd8(a1)
 ;   c.li s11, -0x19
 ;   sb gp, 0x3d1(a7)
-;   .byte 0xfb, 0xc2
-;   c.lui s10, 0x1a
-;   .byte 0x67, 0x2a
-;   .byte 0x7f, 0xd8
 ;   c.sd s0, 0x88(a3)
 ;   c.fld fa5, 0x40(a5)
 ;   c.sw a4, 0x3c(s0)
 ;   c.fld fa1, 0x30(a1)
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x5c(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x5a(a4)
-;   sd zero, 0(a4) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x52(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x3c(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x36(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x34(a4)
-;   c.j 0x34
-;   c.unimp
 ;   c.fld fa2, 0xf0(a0)
 ;   c.fsdsp ft3, 0x1f0(sp)
 ;   c.mv s4, a6
@@ -5411,505 +5122,549 @@ block2:
 ;   c.add t4, s9
 ;   c.sw a5, 0(s1)
 ;   c.fld fa4, 0x60(a2)
+;   auipc a5, 0
+;   ld a5, 0xd8(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0xd2(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0xbc(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0xae(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0xa0(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x9a(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x94(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x7e(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x68(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x62(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x5c(a5)
+;   c.j 0x5c
+;   c.unimp
 ;   .byte 0xac, 0x88
 ;   c.mv a7, a0
 ;   c.addiw a1, 0x1c
 ;   c.addi t4, -0x1d
-;   c.beqz s1, -0xf4
-;   c.slli gp, 0x29
-;   c.fldsp fa6, 0x190(sp)
-;   c.addi t4, -0x18
 ;   .byte 0xd3, 0xbf
 ;   .byte 0x8f, 0xc1
 ;   c.lui s6, 0xfffe5
-;   jal s2, -0x701e8 ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x1e(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x18(a4)
-;   c.j 0x18
-;   c.unimp
-;   c.unimp
-;   c.unimp
-;   c.j 0xba
+;   jal s2, -0x20d7a
 ;   fnmsub.d fs2, fs11, fs7, fa3, rmm
 ;   c.swsp a7, 0x3c(sp)
-;   c.sd a1, 0x60(a4)
-;   .byte 0xc7, 0x21
-;   c.swsp ra, 0x6c(sp)
-;   c.sd a4, 0x20(a5)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x26(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x18(a4)
-;   c.j 0x18
-;   c.unimp
-;   c.unimp
-;   c.unimp
 ;   .byte 0xbf, 0x97
 ;   .byte 0x67, 0x98
 ;   .byte 0x55, 0x9e
-;   fnmsub.d ft10, fs11, fa4, fs0, rmm
-;   c.lwsp s3, 0x40(sp)
-;   c.fsdsp ft5, 0x38(sp)
-;   .byte 0xc7, 0xd9
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0xe(a4)
-;   c.j 0xe
-;   c.unimp
-;   c.unimp
+;   .byte 0x4b, 0xcf
 ;   c.lui a2, 0xfffe5
 ;   c.ld s0, 0x80(s0)
 ;   c.addiw s1, -6
 ;   c.sd a0, 0xd0(a2)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0xa(a4)
-;   c.j 0xa
-;   c.lw a5, 0x44(a2)
-;   c.addi a1, -0x19
-;   .byte 0x7f, 0xda
-;   c.addiw t5, 3
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   c.j 2
-;   auipc a4, 0
-;   ld a4, 0xc(a4)
-;   c.j 0xc
-;   c.unimp
 ;   c.li ra, 1
 ;   c.add a1, s7
 ;   .byte 0xeb, 0x32
 ;   c.addi4spn a0, sp, 0x3a0
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   c.j 2
-;   sw zero, 0(a1) ; trap: heap_oob
-;   c.j 2
-;   sd zero, 0(a1) ; trap: heap_oob
-;   c.j 2
-;   auipc a4, 0
-;   ld a4, 0x10(a4)
-;   c.j 0x10
-;   c.unimp
-;   c.unimp
-;   c.unimp
 ;   c.sd s1, 0x48(a0)
 ;   c.slli a6, 0x1d
 ;   c.srai a2, 0x19
 ;   c.addi s6, 0x16
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   c.j 2
-;   sw zero, 0(a1) ; trap: heap_oob
-;   c.j 2
-;   sd zero, 0(a1) ; trap: heap_oob
-;   c.j 2
-;   sw zero, 0(a1) ; trap: heap_oob
-;   c.j 2
-;   auipc a4, 0
-;   ld a4, 0xa(a4)
-;   c.j 0xa
-;   c.addi a3, -0x14
-;   c.lwsp a2, 0x4c(sp)
-;   c.fsdsp ft6, 0x18(sp)
-;   .byte 0x7b, 0x1f
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   c.j 2
-;   sd zero, 0(a1) ; trap: heap_oob
-;   c.j 2
-;   sw zero, 0(a1) ; trap: heap_oob
-;   c.j 2
-;   auipc a4, 0
-;   ld a4, 0x10(a4)
-;   c.j 0x10
-;   c.unimp
-;   c.unimp
-;   c.unimp
-;   c.mv s9, a4
-;   .byte 0x3f, 0x74
-;   c.lui t1, 0xfffea
-;   c.beqz s1, 0xdc
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   c.j 2
-;   auipc a4, 0
-;   ld a4, 0xc(a4)
-;   c.j 0xc
-;   c.unimp
 ;   c.li tp, -6
 ;   c.addi4spn a3, sp, 0x1f8
 ;   c.sdsp s6, 0x90(sp)
 ;   c.addi gp, 0x1b
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   c.j 2
-;   sw zero, 0(a1) ; trap: heap_oob
-;   c.j 2
-;   auipc a4, 0
-;   ld a4, 0xe(a4)
-;   c.j 0xe
-;   c.unimp
-;   c.unimp
-;   c.li a4, 0x1b
-;   c.sd a2, 8(a5)
-;   c.ld s0, 0x20(a3)
-;   c.addi t4, -0x10
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   c.j 2
-;   sd zero, 0(a1) ; trap: heap_oob
-;   c.j 2
-;   sw zero, 0(a1) ; trap: heap_oob
-;   c.j 2
-;   sd zero, 0(a1) ; trap: heap_oob
-;   c.j 2
-;   sw zero, 0(a1) ; trap: heap_oob
-;   c.j 2
-;   auipc a4, 0
-;   ld a4, 0xc(a4)
-;   c.j 0xc
-;   c.unimp
-;   c.ld s1, 0x30(a5)
-;   c.li s3, -0x10
-;   c.add s8, a0
-;   c.fld fa0, 0x38(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   c.j 2
-;   auipc a4, 0
-;   ld a4, 0xc(a4)
-;   c.j 0xc
-;   c.unimp
 ;   c.fld fs0, 0x30(a4)
 ;   .byte 0xd7, 0x5e
 ;   .byte 0xd7, 0x7b
 ;   c.bnez a3, 0x52
-;   c.sd a4, 0(a1) ; trap: heap_oob
+;   .byte 0x12, 0x90
+;   c.fldsp fa4, 0x1a0(sp)
+;   c.lw a1, 0x58(a2)
+;   c.mv s10, a2
+;   c.swsp s0, 0x1c(sp)
+;   .byte 0xd7, 0x0b
+;   c.fldsp fs5, 0x120(sp)
+;   c.li s8, 0x1d
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x6a(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x64(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x56(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x50(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x4a(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.j 0x30
+;   c.unimp
+;   c.unimp
+;   c.unimp
+;   c.fsd fa1, 0xb0(a4)
+;   c.mv s9, s0
+;   c.beqz s1, 0x44
+;   csrrw s3, 1696, t5
+;   xori t0, t6, 0x273
+;   c.fsdsp fa7, 0x1a0(sp)
+;   c.sw s1, 0x28(a3)
+;   c.bnez a3, -0xce
+;   c.li s7, 0xb
+;   c.fld fa1, 0xa0(a5)
+;   c.sw s0, 0x4c(a1)
+;   c.ldsp t6, 0x28(sp)
+;   .byte 0x1f, 0xdb
+;   c.fld fa0, 0xf0(a0)
+;   c.xor a5, a3
+;   c.lwsp t4, 0xd0(sp)
+;   .byte 0x4b, 0x75
+;   c.beqz s0, 0xce
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x3c(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x36(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x30(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x22(a5)
+;   c.j 0x22
+;   c.sdsp t2, 0xe8(sp)
+;   c.lui t0, 0xfffea
+;   c.xor a3, s0
+;   c.sd a2, 0x58(a4)
+;   lui a1, 0xe0c6
+;   c.sd s1, 0x48(a3)
+;   c.ld a4, 0x58(a0)
+;   c.sub a1, a5
+;   c.li tp, -9
+;   slti t3, a7, 0x57c
+;   c.ld s1, 0x58(a2)
+;   c.sw a4, 0x34(s0)
+;   c.or a5, s0
+;   c.sd a4, 0xc8(a1)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x2a(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.j 0xc
+;   c.unimp
+;   c.beqz a2, -0xe0
+;   fnmadd.d fa1, fs5, fs3, ft2
+;   .byte 0x23, 0xf3
+;   auipc a5, 0
+;   ld a5, 0x18(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x12(a5)
+;   c.j 0x12
+;   c.sw s0, 8(a0)
+;   c.lwsp tp, 0xe8(sp)
+;   c.j -0x662
+;   c.li s0, -0x15
+;   c.beqz a1, -0x82
+;   c.beqz a5, 4
+;   c.unimp
+;   c.unimp
+;   c.sd a2, 0(a5) ; trap: heap_oob
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sd zero, 0(a1) ; trap: heap_oob
+;   sw zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0xc(a5)
+;   c.j 0xc
+;   c.unimp
+;   c.addiw a0, -0x14
+;   c.fsdsp fa6, 0x150(sp)
+;   c.unimp
+;   c.unimp
+;   sd zero, 0(a5) ; trap: heap_oob
+;   c.j 2
+;   sd zero, 0(a1) ; trap: heap_oob
 ;   c.j 2
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   c.j 2
-;   auipc a4, 0
-;   ld a4, 0x16(a4)
+;   sd zero, 0(a1) ; trap: heap_oob
 ;   c.j 2
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   auipc a5, 0
+;   ld a5, 0xc(a5)
+;   c.j 0xc
+;   c.unimp
+;   c.beqz s0, 0x5e
+;   c.sd a3, 0xb8(a2)
+;   c.unimp
+;   c.unimp
+;   sd zero, 0(a5) ; trap: heap_oob
+;   c.j 2
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   auipc a5, 0
+;   ld a5, 0xc(a5)
+;   c.j 0xc
+;   c.unimp
+;   .byte 0x0b, 0xc8
+;   fnmadd.s ft2, ft1, ft0, ft0, rtz
+;   c.unimp
+;   c.sd a2, 0(a5) ; trap: heap_oob
+;   c.j 2
+;   auipc a5, 0
+;   ld a5, 0xc(a5)
+;   c.j 0xc
+;   c.unimp
+;   .byte 0x3b, 0x78
+;   fnmadd.d ft10, fs2, ft11, fa7, rup
+;   c.sd a0, 0x90(a2)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   auipc a5, 0
+;   ld a5, 0xe(a5)
+;   c.j 0xe
+;   c.unimp
+;   c.unimp
+;   c.swsp s4, 0xe8(sp)
+;   c.lw a5, 0x68(s0)
+;   .byte 0x23, 0x40
+;   c.lw a4, 0x48(s0)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   auipc a5, 0
+;   ld a5, 0xe(a5)
+;   c.j 0xe
+;   c.unimp
+;   c.unimp
+;   c.addi tp, 7
+;   c.beqz a1, 0x58
+;   c.j -0x608
+;   c.fsd fa5, 0x80(a3)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   auipc a5, 0
+;   ld a5, 0xe(a5)
+;   c.j 0xe
+;   c.unimp
+;   c.unimp
+;   .byte 0xab, 0x89
+;   .byte 0x9b, 0x53
+;   sw zero, 0x42(s6)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   auipc a5, 0
+;   ld a5, 0xa(a5)
+;   c.j 0xa
+;   fmadd.d ft10, fs11, ft10, fs8
+;   c.unimp
+;   c.unimp
+;   c.sd a2, 0(a5) ; trap: heap_oob
+;   c.j 2
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sd zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   lui a5, 0x4b912
+;   c.j 2
+;   addi a5, a5, -0x6f
+;   c.j 2
+;   auipc t2, 0
+;   ld t2, 0x10(t2)
+;   c.j 0x10
+;   c.unimp
+;   c.unimp
+;   c.unimp
+;   .byte 0xdf, 0xbd
+;   c.beqz s1, -0x54
+;   c.unimp
+;   c.unimp
+;   sw a5, 0(t2) ; trap: heap_oob
+;   c.j 2
+;   sw zero, 0(a1) ; trap: heap_oob
+;   c.j 2
+;   auipc a5, 0
+;   ld a5, 0x14(a5)
+;   c.j 4
+;   c.unimp
 ;   auipc t6, 0
-;   jalr zero, t6, 0x14
-;   c.unimp
-;   c.unimp
-;   c.sdsp s3, 0x190(sp)
-;   c.j 0x622
-;   c.andi a1, 0xa
-;   flw fa7, -0x1e7(a6) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x62a(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x630(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x632(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x63c(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x642(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x644(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x646(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x648(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x65a(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x660(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x662(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x668(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x66a(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x680(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x68e(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x698(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
+;   jalr zero, t6, 0x10
+;   c.bnez s1, 0x40
+;   c.add t6, s10
+;   .byte 0x77, 0x2f
+;   c.lwsp t1, 0xe8(sp)
+;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x69e(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x6a0(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x59a(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x6ae(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x6b0(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x6b6(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x584(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x6d4(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x6da(a4)
-;   c.sd a2, 0(a4) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x6ec(a4)
-;   sd zero, 0(a4) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x70c(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x722(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x53e(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x730(a4)
-;   sd zero, 0(a4) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x530(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x740(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x742(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x74c(a4)
-;   c.sd a2, 0(a4) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x74e(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x758(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x522(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x75e(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x760(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x51c(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x50e(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x77a(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x508(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x502(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x788(a4)
-;   c.sd a2, 0(a4) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x78a(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x79c(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   lui a4, 0x4b912
-;   addi a4, a4, -0x6f
-;   auipc t0, 1
-;   ld t0, -0x7b6(t0)
-;   sw a4, 0(t0) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x7be(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x7c0(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x7c6(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x7d4(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x4d4(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x4d2(a5)
+;   c.lw a5, 0(a5) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x7de(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x7e0(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x4c8(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x4c2(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 1
-;   ld a4, -0x7f6(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x4bc(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x4a6(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x4a0(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x496(a5)
+;   sw zero, 0(a5) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x7d4(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x7c6(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x7c4(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x7be(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x7b8(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x47e(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x7ae(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x478(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x476(a5)
+;   c.sw a4, 0(a5) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x7a8(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x470(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x79e(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x794(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x792(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x788(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x782(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x77c(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x456(a5)
+;   c.sd a2, 0(a5) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x450(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
@@ -5917,344 +5672,199 @@ block2:
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x752(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x74c(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x74a(a4)
-;   c.lw a4, 0(a4) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x740(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sb a3, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x736(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x72c(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x41e(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x418(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x71e(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x714(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x70e(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x70c(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x706(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x700(a4)
-;   sw zero, 0(a4) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x3fa(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x3f8(a5)
+;   c.sd a2, 0(a5) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x6e8(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x3f2(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x6e2(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x6e0(a4)
-;   c.sw a3, 0(a4) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x3ec(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x6d6(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
+;   sb a3, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x6c4(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x3d6(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x6b6(a4)
-;   c.sd a2, 0(a4) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x6b0(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x6ae(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x6a8(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x3c8(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x3c6(a5)
+;   c.sd a2, 0(a5) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
+;   c.lw a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sb a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x3ae(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x682(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x678(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x676(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x3a0(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x670(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x66e(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x39a(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x650(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x64e(a4)
-;   c.sd a2, 0(a4) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x648(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x642(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x380(a5)
+;   c.sd a2, 0(a5) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x37e(a5)
+;   sd zero, 0(a5) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x638(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sb a5, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
+;   sb a3, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x626(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x620(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x616(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x614(a4)
-;   c.sd a2, 0(a4) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   c.lw a4, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x362(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x600(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x5f6(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x5e8(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x5de(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sb a3, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x5c4(a4)
-;   c.sd a2, 0(a4) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x5c2(a4)
-;   sd zero, 0(a4) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
-;   sb a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x5a6(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
+;   sb a3, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x314(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x598(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sb a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x306(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
+;   sb a3, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x2ec(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x2e6(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
-;   sb a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x556(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x54c(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x542(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x2d0(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sb a5, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x2ca(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x524(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x51e(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x518(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x2bc(a5)
+;   sd zero, 0(a5) ; trap: heap_oob
+;   sb a3, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x2b0(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x506(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x504(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x2aa(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x4fa(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
+;   auipc a5, 0
+;   ld a5, 0x2a4(a5)
+;   c.sd a5, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x4ec(a4)
-;   sd zero, 0(a4) ; trap: heap_oob
-;   sb a5, 0(a1) ; trap: heap_oob
+;   sb a4, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a4, 0
-;   ld a4, 0x4e0(a4)
+;   ld a4, 0x292(a4)
 ;   c.sd a4, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x4da(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
 ;   auipc a4, 0
-;   ld a4, 0x4d8(a4)
+;   ld a4, 0x28c(a4)
 ;   c.sd a4, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
 ;   auipc a4, 0
-;   ld a4, 0x4ce(a4)
+;   ld a4, 0x286(a4)
 ;   c.sd a4, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sb a3, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a4, 0
-;   ld a4, 0x4bc(a4)
-;   c.sd a4, 0(a1) ; trap: heap_oob
 ;   auipc a3, 0
-;   ld a3, 0x4ba(a3)
-;   c.sd a3, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   auipc a3, 0
-;   ld a3, 0x4b0(a3)
-;   c.sd a3, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a3, 0
-;   ld a3, 0x4aa(a3)
-;   c.sd a3, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   sd zero, 0(a1) ; trap: heap_oob
-;   sb a5, 0(a1) ; trap: heap_oob
-;   sw zero, 0(a1) ; trap: heap_oob
-;   auipc a3, 0
-;   ld a3, 0x498(a3)
+;   ld a3, 0x274(a3)
 ;   c.sd a2, 0(a3) ; trap: heap_oob
 ;   auipc a2, 0
-;   ld a2, 0x496(a2)
+;   ld a2, 0x272(a2)
 ;   c.sd a2, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a2, 0
-;   ld a2, 0x490(a2)
+;   ld a2, 0x26c(a2)
 ;   c.sd a2, 0(a1) ; trap: heap_oob
 ;   auipc a2, 0
-;   ld a2, 0x48e(a2)
+;   ld a2, 0x26a(a2)
 ;   c.lui a3, 4
 ;   addi a3, a3, -0x720
 ;   c.sd a2, 0(a3) ; trap: heap_oob
@@ -6263,7 +5873,7 @@ block2:
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   auipc a2, 0
-;   ld a2, 0x476(a2)
+;   ld a2, 0x252(a2)
 ;   c.lui a3, 4
 ;   addi a3, a3, -0x6a4
 ;   c.sd a2, 0(a3) ; trap: heap_oob
@@ -6272,7 +5882,7 @@ block2:
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a2, 0
-;   ld a2, 0x45e(a2)
+;   ld a2, 0x23a(a2)
 ;   c.lui a3, 4
 ;   addi a3, a3, -0x5f0
 ;   c.sd a2, 0(a3) ; trap: heap_oob
@@ -6280,19 +5890,19 @@ block2:
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   auipc a2, 0
-;   ld a2, 0x44a(a2)
+;   ld a2, 0x226(a2)
 ;   c.lui a3, 4
 ;   addi a3, a3, -0x638
 ;   c.sd a2, 0(a3) ; trap: heap_oob
 ;   auipc a2, 0
-;   ld a2, 0x442(a2)
+;   ld a2, 0x21e(a2)
 ;   c.lui a3, 4
 ;   addi a3, a3, -0x640
 ;   c.sd a2, 0(a3) ; trap: heap_oob
 ;   sw zero, 0(a1) ; trap: heap_oob
 ;   sd zero, 0(a1) ; trap: heap_oob
 ;   auipc a2, 0
-;   ld a2, 0x432(a2)
+;   ld a2, 0x20e(a2)
 ;   c.lui a3, 4
 ;   addi a3, a3, -0x59c
 ;   c.sd a2, 0(a3) ; trap: heap_oob
@@ -6303,195 +5913,26 @@ block2:
 ;   c.j 0xc
 ;   c.unimp
 ;   auipc t6, 0
-;   jalr zero, t6, 0x418
+;   jalr zero, t6, 0x1f4
 ;   auipc t6, 0
-;   jalr zero, t6, 0x410
-;   .byte 0x12, 0x90
-;   c.fldsp fa4, 0x1a0(sp)
-;   c.lw a1, 0x58(a2)
-;   c.mv s10, a2
-;   c.ld s0, 0x18(a0)
-;   bge s4, s0, 0x6ca
-;   .byte 0x4f, 0x3b
-;   c.swsp s0, 0x1c(sp)
-;   .byte 0xd7, 0x0b
-;   c.fldsp fs5, 0x120(sp)
-;   c.li s8, 0x1d
-;   c.fsd fa1, 0xb0(a4)
-;   c.mv s9, s0
-;   c.beqz s1, 0x44
-;   csrrw s3, 1036, t3
-;   c.sd a2, 0x88(a2)
-;   .byte 0x4f, 0xdc
-;   c.fld fs0, 0x18(s0)
-;   c.bnez a4, -0xa8
-;   sh sp, 0xc8(a5)
-;   c.li s7, 3
-;   c.ldsp s7, 0x48(sp)
-;   c.fsdsp fs9, 0xe0(sp)
-;   .byte 0x8b, 0x5a
-;   .byte 0x83, 0xf8
-;   .byte 0x0f, 0x6a
-;   xori t0, t6, 0x273
-;   c.fsdsp fa7, 0x1a0(sp)
-;   c.sw s1, 0x28(a3)
-;   c.bnez a3, -0xce
-;   c.li s7, 0xb
-;   c.fld fa1, 0xa0(a5)
-;   c.lwsp s5, 0x98(sp)
-;   fmin.d fs7, ft6, ft0
-;   .byte 0xeb, 0x2f
-;   c.sw s0, 0x4c(a1)
-;   c.ldsp t6, 0x28(sp)
-;   .byte 0x1f, 0xdb
-;   c.fld fa0, 0xf0(a0)
-;   .byte 0x5f, 0x0e
-;   .byte 0xd7, 0x00
-;   c.fld fa0, 0xa0(a1)
-;   c.fldsp ft2, 0xe8(sp)
-;   c.xor a5, a3
-;   c.lwsp t4, 0xd0(sp)
-;   .byte 0x4b, 0x75
-;   c.beqz s0, 0xce
-;   c.lui t1, 0x1b
-;   c.bnez a3, 0x72
-;   c.addi s3, -0xf
-;   .byte 0xe5, 0x9c
-;   c.sdsp t2, 0xe8(sp)
-;   c.lui t0, 0xfffea
-;   c.xor a3, s0
-;   c.sd a2, 0x58(a4)
-;   lui a1, 0xe0c6
-;   c.sd s1, 0x48(a3)
-;   c.ld a4, 0x58(a0)
-;   .byte 0xcb, 0xc5
-;   c.ld a4, 0x38(a2)
-;   .byte 0x93, 0xd5
-;   csrrs t1, 2265, s10
-;   c.li tp, -9
-;   slti t3, a7, 0x57c
-;   .byte 0x13, 0x1d
-;   c.fsdsp ft0, 0x1d8(sp)
-;   c.fsdsp fs11, 0xe0(sp)
-;   csrrw s0, 1762, s0
-;   c.sw a4, 0x34(s0)
-;   c.or a5, s0
-;   c.sd a4, 0xc8(a1)
-;   c.beqz a2, -0xe0
-;   fnmadd.d fa1, fs5, fs3, ft2
-;   .byte 0x23, 0xf3
-;   c.sw s0, 8(a0)
-;   c.lwsp tp, 0xe8(sp)
-;   c.j -0x662
-;   c.li s0, -0x15
-;   c.beqz a1, -0x82
-;   c.beqz a5, 4
+;   jalr zero, t6, 0x1ec
 ;   c.unimp
 ;   c.unimp
-;   c.addiw a0, -0x14
-;   c.fsdsp fa6, 0x150(sp)
-;   c.unimp
-;   c.unimp
-;   .byte 0x10, 0x00
-;   c.unimp
-;   c.unimp
-;   .byte 0x00, 0x80
-;   c.ld s0, 0x28(a3)
-;   c.j -0x7de
-;   c.sw a2, 0x78(a5)
-;   .byte 0x19, 0x10
-;   c.beqz s0, 0x5e
-;   c.sd a3, 0xb8(a2)
-;   c.unimp
-;   c.unimp
-;   .byte 0xf7, 0x1a
-;   .byte 0x3b, 0xf0
-;   .byte 0xcb, 0x27
-;   c.slli s1, 0x3f
-;   blt t4, t1, -0x9a6
-;   c.addi a2, 0x19
-;   c.addiw a3, -0xe
-;   .byte 0x0b, 0xc8
-;   fnmadd.s ft2, ft1, ft0, ft0, rtz
-;   c.unimp
-;   .byte 0x3b, 0x78
-;   fnmadd.d ft10, fs2, ft11, fa7, rup
-;   c.sd a0, 0x90(a2)
-;   c.swsp s4, 0xe8(sp)
-;   c.lw a5, 0x68(s0)
-;   .byte 0x23, 0x40
-;   c.lw a4, 0x48(s0)
-;   csrrs ra, 2022, s1
-;   .byte 0x0d, 0x20
-;   c.sd a4, 0x28(s1)
-;   c.addi tp, 7
-;   c.beqz a1, 0x58
-;   c.j -0x608
-;   c.fsd fa5, 0x80(a3)
-;   .byte 0xab, 0x89
-;   .byte 0x9b, 0x53
-;   sw zero, 0x42(s6)
-;   fmadd.d ft10, fs11, ft10, fs8
-;   c.unimp
-;   c.unimp
-;   c.ld s1, 0x50(s0)
-;   c.sw a5, 0x5c(a3)
-;   .byte 0x90, 0x87
-;   c.lw s0, 0(a1)
-;   .byte 0x54, 0x84
-;   c.sdsp s8, 0x150(sp)
-;   c.lw a4, 0x24(s1)
-;   c.sd a1, 0xa0(s1)
-;   .byte 0xdf, 0xbd
-;   c.beqz s1, -0x54
-;   c.unimp
-;   c.unimp
-;   c.lui ra, 0xb
-;   c.lw a0, 0x3c(a2)
-;   c.beqz s1, -0x86
-;   c.fldsp ft11, 0x160(sp)
-;   c.bnez s1, 0x40
-;   c.add t6, s10
-;   .byte 0x77, 0x2f
-;   c.lwsp t1, 0xe8(sp)
 ;   c.sw a4, 0x38(a5)
 ;   .byte 0xb4, 0x92
 ;   .byte 0xb3, 0x4d
-;   lh zero, -0x6dd(s6)
-;   c.sw a1, 0x58(s1)
-;   c.addi4spn a5, sp, 0x328
-;   c.lwsp sp, 0xd4(sp)
-;   .byte 0xcf, 0x0e
-;   .byte 0x41, 0x9e
-;   c.lwsp s9, 0xdc(sp)
-;   c.swsp gp, 0xcc(sp)
-;   .byte 0x4f, 0x33
+;   lh zero, 0x334(t5)
 ;   c.sd a2, 0x28(a3)
 ;   c.slli a7, 0x3c
 ;   c.slli s6, 8
-;   c.lwsp s11, 0x28(sp)
-;   c.sd a2, 0xf8(a5)
-;   .byte 0x5b, 0xfd
-;   .byte 0x7f, 0x29
 ;   c.sd a1, 0xc0(a1)
 ;   .byte 0x5b, 0xf9
 ;   c.ldsp ra, 0x118(sp)
 ;   c.sdsp t3, 0x78(sp)
-;   c.addiw t5, -0xd
-;   c.addi4spn a1, sp, 0x33c
-;   c.addi4spn a1, sp, 0x3ac
-;   c.sd a3, 0x38(s0)
 ;   .byte 0x3b, 0x56
 ;   c.li s8, 6
 ;   c.li s6, -3
 ;   .byte 0x2b, 0x21
-;   c.addi s9, 1
-;   jal s2, -0x9c9e8
-;   c.addi4spn a1, sp, 4
-;   c.j -0x322
-;   c.beqz a1, -0xd6
-;   c.addi s7, -0x12
-;   .byte 0x58, 0x8f
 ;   c.fsdsp fa1, 0xd0(sp)
 ;   .byte 0xeb, 0x83
 ;   c.addi t0, 7
@@ -6500,14 +5941,6 @@ block2:
 ;   .byte 0x90, 0x99
 ;   c.lw s1, 0x40(a2)
 ;   .byte 0x43, 0xef
-;   c.ldsp s9, 0x1e8(sp)
-;   c.sw s0, 0x44(a2)
-;   c.fld fa4, 0x58(a5)
-;   c.addiw s2, 0x15
-;   c.swsp s0, 0x44(sp)
-;   c.sdsp t1, 0x120(sp)
-;   c.sdsp a3, 0xb0(sp)
-;   c.lw a3, 0x1c(a2)
 ;   c.ldsp t4, 0x150(sp)
 ;   c.sd a2, 8(s1)
 ;   .byte 0x8f, 0x13
@@ -6519,14 +5952,6 @@ block2:
 ;   c.sub a3, a5
 ;   c.fsdsp fa1, 0x158(sp)
 ;   csrrs s7, 1905, a3
-;   c.fld fa2, 0x10(a0)
-;   c.fsdsp fs8, 0x98(sp)
-;   c.ld a0, 0x60(a1)
-;   c.ld a5, 0x88(a5)
-;   c.j -0x38c
-;   .byte 0xcb, 0xe8
-;   c.andi a1, 0x16
-;   c.ld a4, 0x90(a0)
 ;   c.sw a1, 0x68(a3)
 ;   .byte 0xff, 0x35
 ;   .byte 0x27, 0xc3
@@ -6544,25 +5969,14 @@ block2:
 ;   c.lw a1, 0x2c(a5)
 ;   c.or s0, a0
 ;   c.addi4spn s1, sp, 0x240
-;   c.li a5, 0x1a
-;   c.fldsp fs11, 0x80(sp)
-;   c.sw s0, 0x20(s1)
-;   beq s2, a4, 0xde0
+;   c.li t4, -6
 ;   .byte 0x2b, 0xb5
 ;   c.lw a4, 0x7c(s0)
 ;   c.mv a7, a1
-;   c.sd s0, 0xc0(s1)
-;   c.ld a4, 0x20(a3)
-;   c.bnez a1, 0xa4
-;   c.slli a2, 0x39
 ;   c.li sp, -0xb
 ;   c.mv sp, a0
 ;   c.fld fa0, 0xb8(a3)
 ;   .byte 0xab, 0x2b
-;   .byte 0xf3, 0x0f
-;   .byte 0x0b, 0x03
-;   c.addi4spn s1, sp, 0x8c
-;   .byte 0xe3, 0x31
 ;   c.addiw t1, 0xc
 ;   c.sd a2, 0xf8(a0)
 ;   c.unimp
@@ -6582,42 +5996,18 @@ block2:
 ;   .byte 0xc5, 0x9c
 ;   c.lui t4, 0xffffa
 ;   c.li a4, -0xc
-;   c.fsd fa0, 0x80(a0)
-;   c.lwsp a3, 0x24(sp)
-;   .byte 0xab, 0x2d
-;   jal s3, 0x76714
-;   c.beqz s1, -0x4a
+;   fmsub.s ft2, fs10, fa3, fs11
 ;   c.unimp
 ;   c.unimp
-;   .byte 0x2f, 0x49
-;   c.slli ra, 0x3f
-;   c.slli gp, 0x3a
-;   .byte 0xaf, 0x39
 ;   c.fsd fa3, 0xf0(a0)
 ;   .byte 0x45, 0x70
 ;   .byte 0xbb, 0x20
 ;   .byte 0x7b, 0xdf
-;   c.sw a4, 0x3c(s0)
-;   .byte 0xff, 0xae
-;   c.addi s10, 1
-;   c.lw a1, 0x2c(a0)
-;   c.ld s1, 0x90(s0)
-;   c.sd a0, 0(a5)
-;   c.sd a0, 0xd0(a4)
-;   .byte 0x27, 0x8e
-;   c.sd a1, 0xe0(s1)
-;   .byte 0x87, 0x61
-;   c.ld a5, 0x50(a3)
-;   .byte 0xa7, 0xf9
 ;   c.fsd fa1, 0xa8(a0)
 ;   c.addi t1, 0x11
 ;   c.fsdsp fs0, 0x58(sp)
 ;   .byte 0x4f, 0xc0
-;   .byte 0x0f, 0x1f
-;   c.lw a1, 0x74(s0)
-;   c.bnez a4, 0xd2
-;   auipc a5, 0xa597c
-;   c.beqz a2, -0xf0
+;   auipc a1, 0xda01a
 ;   c.lwsp s9, 0x80(sp)
 ;   csrrw gp, 4044, t1
 ;   .byte 0x0f, 0x8a
@@ -6635,18 +6025,10 @@ block2:
 ;   .byte 0xab, 0x35
 ;   c.sdsp a4, 0x168(sp)
 ;   .byte 0x67, 0xdf
-;   c.fsd fa2, 0x70(s0)
-;   c.li t6, 3
-;   c.fld fs0, 0x38(a5)
-;   c.beqz s0, -0xd4
 ;   c.fsd fs0, 0xe0(a3)
 ;   c.sdsp t3, 0x128(sp)
 ;   c.sd s0, 0xd8(a2)
 ;   c.swsp a6, 0x90(sp)
-;   c.bnez a0, -0xfc
-;   c.srli a4, 0x3c
-;   c.srai a5, 0x19
-;   c.slli t4, 0x2d
 ;   c.fsdsp fa3, 0x20(sp)
 ;   c.li t4, -0xd
 ;   c.sd a1, 0xb0(a4)
@@ -6655,9 +6037,6 @@ block2:
 ;   .byte 0x90, 0x86
 ;   c.unimp
 ;   c.unimp
-;   auipc tp, 0x22bce
-;   c.fsd fa4, 0(s1)
-;   c.lwsp a0, 0x40(sp)
 ;   c.addi t1, -0x1e
 ;   c.lwsp a3, 0x1c(sp)
 ;   c.srli s1, 0x1b
@@ -6682,17 +6061,10 @@ block2:
 ;   c.sdsp t5, 0x1e0(sp)
 ;   c.fldsp fa1, 0(sp)
 ;   c.sdsp t4, 8(sp)
-;   lui s10, 0xe1bf6
-;   c.fld fa2, 0x50(a4)
-;   c.swsp s9, 0(sp)
 ;   c.sdsp a7, 0x168(sp)
 ;   c.fsd fs0, 0xd0(a5)
 ;   c.lui t3, 0x11
 ;   c.lui s4, 0xfffeb
-;   c.sdsp a2, 0x80(sp)
-;   c.ldsp gp, 0xc8(sp)
-;   c.lw a5, 0x40(a2)
-;   c.slli s8, 0x25
 ;   jal a5, 0x1ceba
 ;   .byte 0x67, 0x18
 ;   c.bnez a5, -0x74
@@ -6703,14 +6075,6 @@ block2:
 ;   c.ld a0, 0x58(a4)
 ;   .byte 0x6b, 0x07
 ;   csrrci t0, 565, 0x10
-;   .byte 0x5f, 0x70
-;   c.sw a5, 0x2c(a5)
-;   c.fld fs0, 0x10(a0)
-;   c.sd a5, 0x30(a3)
-;   c.addiw s6, 0x1f
-;   c.sdsp s2, 0x158(sp)
-;   c.ldsp t6, 0x180(sp)
-;   c.addiw tp, 0x1a
 ;   auipc t6, 0xb2974
 ;   c.fld fa4, 0x98(a0)
 ;   .byte 0x9f, 0xea
@@ -6726,10 +6090,6 @@ block2:
 ;   c.ldsp s1, 0x160(sp)
 ;   c.addi4spn s0, sp, 0x1dc
 ;   c.addi4spn a5, sp, 0x358
-;   c.sd a1, 8(a3)
-;   c.fld fa3, 0x68(a1)
-;   c.mv a1, t0
-;   .byte 0x8f, 0x49
 ;   c.beqz a4, -0x8e
 ;   c.lw s1, 0x10(a5)
 ;   c.ldsp a7, 0x198(sp)
@@ -6737,10 +6097,7 @@ block2:
 ;   .byte 0x07, 0x7c
 ;   .byte 0xec, 0x85
 ;   .byte 0x2f, 0xb6
-;   fdiv.s fs3, ft3, ft4
-;   c.fsd fa5, 0xe8(s0)
-;   c.j -0x730
-;   c.swsp a1, 0x8c(sp)
+;   .byte 0xd3, 0xf9
 ;   c.fldsp fs7, 0x1f0(sp)
 ;   c.bnez a5, -0x84
 ;   c.li t0, -0xe
@@ -6785,7 +6142,7 @@ block2:
 ;   c.addi4spn s0, sp, 0x84
 ;   andi a7, s11, -0x6ab
 ;   c.swsp t5, 0xb4(sp)
-; block13: ; offset 0x19b8
+; block13: ; offset 0x1488
 ;   c.li a2, 1
 ;   c.li a3, 2
 ;   c.mv a1, a0


### PR DESCRIPTION
We were previously computing "observed" state per-region, and doing this in a
flow-sensitive manner. Observation flows *backwards* from observers to the
observed memory state's last mutator, however our `LastStores` is a *forwards*
flow-sensitive analysis, so its results for observation were not sound.

This commit switches observation from being per-region and flow sensitive, to
being per-store instruction and flow insensitive. The set of observed store
instructions is computed up front in the existing fixed point that initializes
each block's initial `LastStores`. Dead-store elimination guards on its
candidate store not being in the observed-stores set. `LastStores::meet_from`
adds the last store instruction from each CFG predecessor to the observed-stores
set, which is what fixes the incorrect DSE of a store inside a loop from outside
that loop in #13990.

Fixes #13990
