### PR TITLE
Exceptions: remove unrooted exception-type index in Tag.

### DIFF
--- a/crates/wasmtime/src/runtime/trampoline/table.rs
+++ b/crates/wasmtime/src/runtime/trampoline/table.rs
@@ -40,7 +40,7 @@ pub async fn create_table(
                 AllocateInstanceKind::Dummy {
                     allocator: &allocator,
                 },
-                &ModuleRuntimeInfo::bare_with_registered_type(
+                &ModuleRuntimeInfo::bare_with_registered_types(
                     module,
                     table.element().clone().into_registered_type(),
                 )?,

--- a/crates/wasmtime/src/runtime/trampoline/tag.rs
+++ b/crates/wasmtime/src/runtime/trampoline/tag.rs
@@ -42,12 +42,19 @@ pub fn create_tag(store: &mut StoreOpaque, ty: &TagType) -> Result<InstanceId> {
         // doesn't allocate tables or memories meaning it shouldn't need a
         // resource limiter so `None` is passed. As a result no `await` points
         // should ever be hit.
+        //
+        // Both the tag's signature type and its exception type are
+        // referred to by engine-level type index from the dummy
+        // module's `Tag`, so both `RegisteredType`s must be handed to
+        // the instance's runtime info to keep those indices rooted in
+        // the engine's type registry for as long as the instance (and
+        // thus the store) is alive.
         vm::assert_ready(store.allocate_instance(
             None,
             AllocateInstanceKind::Dummy {
                 allocator: &allocator,
             },
-            &ModuleRuntimeInfo::bare_with_registered_type(module, Some(func_ty))?,
+            &ModuleRuntimeInfo::bare_with_registered_types(module, [func_ty, exn_ty])?,
             imports,
         ))
     }

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -297,26 +297,25 @@ pub enum ModuleRuntimeInfo {
 /// cases where a purpose-built environ::Module is used and a full
 /// CompiledModule does not exist (for example, for tests or for the
 /// default-callee instance).
-#[derive(Clone)]
 pub struct BareModuleInfo {
     module: Arc<wasmtime_environ::Module>,
     offsets: VMOffsets<HostPtr>,
-    _registered_type: Option<RegisteredType>,
+    _registered_types: TryVec<RegisteredType>,
 }
 
 impl ModuleRuntimeInfo {
     pub(crate) fn bare(module: Arc<wasmtime_environ::Module>) -> Result<Self, OutOfMemory> {
-        ModuleRuntimeInfo::bare_with_registered_type(module, None)
+        ModuleRuntimeInfo::bare_with_registered_types(module, None)
     }
 
-    pub(crate) fn bare_with_registered_type(
+    pub(crate) fn bare_with_registered_types(
         module: Arc<wasmtime_environ::Module>,
-        registered_type: Option<RegisteredType>,
+        registered_types: impl IntoIterator<Item = RegisteredType>,
     ) -> Result<Self, OutOfMemory> {
         let info = try_new(BareModuleInfo {
             offsets: VMOffsets::new(HostPtr, &module),
             module,
-            _registered_type: registered_type,
+            _registered_types: registered_types.into_iter().try_collect()?,
         })?;
         Ok(ModuleRuntimeInfo::Bare(info))
     }


### PR DESCRIPTION
We previously kept two interned types in a `Tag`: one corresponding to the function signature type, and one corresponding to the exception type. (These are distinct and need to be distinct: we need a home for the exn object layout that is not the function type.)

However, when a `Tag` was created via the host API, the outer object would root the tag itself with a `RegisteredType`, but the corresponding exception type was left unrooted, and hence the index could be reused.

This PR removes the `exception` field from `Tag` completely, avoiding the rooting issue. Instead, a side-table records the tag -> exception type mapping during compilation, where it is actually needed.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
