### PR TITLE
Exceptions: trace exception index inside a WasmHeapTy.

### DIFF
--- a/crates/environ/src/types.rs
+++ b/crates/environ/src/types.rs
@@ -554,6 +554,7 @@ impl TypeTrace for WasmHeapType {
             Self::ConcreteFunc(i) => func(i),
             Self::ConcreteStruct(i) => func(i),
             Self::ConcreteCont(i) => func(i),
+            Self::ConcreteExn(i) => func(i),
             _ => Ok(()),
         }
     }
@@ -567,6 +568,7 @@ impl TypeTrace for WasmHeapType {
             Self::ConcreteFunc(i) => func(i),
             Self::ConcreteStruct(i) => func(i),
             Self::ConcreteCont(i) => func(i),
+            Self::ConcreteExn(i) => func(i),
             _ => Ok(()),
         }
     }

--- a/crates/environ/src/types.rs
+++ b/crates/environ/src/types.rs
@@ -555,7 +555,22 @@ impl TypeTrace for WasmHeapType {
             Self::ConcreteStruct(i) => func(i),
             Self::ConcreteCont(i) => func(i),
             Self::ConcreteExn(i) => func(i),
-            _ => Ok(()),
+            // Top/bottom lattice elements have no inner type
+            // reference.
+            Self::Extern
+            | Self::NoExtern
+            | Self::Func
+            | Self::NoFunc
+            | Self::Cont
+            | Self::NoCont
+            | Self::Any
+            | Self::Eq
+            | Self::I31
+            | Self::Array
+            | Self::Struct
+            | Self::Exn
+            | Self::NoExn
+            | Self::None => Ok(()),
         }
     }
 
@@ -569,7 +584,22 @@ impl TypeTrace for WasmHeapType {
             Self::ConcreteStruct(i) => func(i),
             Self::ConcreteCont(i) => func(i),
             Self::ConcreteExn(i) => func(i),
-            _ => Ok(()),
+            // Top/bottom lattice elements have no inner type
+            // reference.
+            Self::Extern
+            | Self::NoExtern
+            | Self::Func
+            | Self::NoFunc
+            | Self::Cont
+            | Self::NoCont
+            | Self::Any
+            | Self::Eq
+            | Self::I31
+            | Self::Array
+            | Self::Struct
+            | Self::Exn
+            | Self::NoExn
+            | Self::None => Ok(()),
         }
     }
 }


### PR DESCRIPTION
I believe this is unreachable in practice because aggregate Wasm types can hold only `exnref` (/ `noexnref`); the Wasm type system does not have a concrete exn as a separate type that could appear within an aggregate. Nevertheless, for completeness, we should have this match arm.

Pointed out by Alex (thanks!).

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
