### PR TITLE
Don't use `std::env::vars` for inheriting env vars

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -326,10 +326,10 @@ impl RunCommon {
             for (k, v) in std::env::vars_os() {
                 let k = k
                     .to_str()
-                    .ok_or_else(|| format_err!("environment variable {k:?} not valid utf-8"))?;
+                    .ok_or_else(|| format_err!("environment variable name {k:?} not valid utf-8"))?;
                 let v = v
                     .to_str()
-                    .ok_or_else(|| format_err!("environment variable {v:?} not valid utf-8"))?;
+                    .ok_or_else(|| format_err!("environment variable {k:?} value {v:?} not valid utf-8"))?;
                 builder.env(&k, &v);
             }
         }

--- a/src/common.rs
+++ b/src/common.rs
@@ -323,7 +323,13 @@ impl RunCommon {
         builder.allow_blocking_current_thread(self.common.wasm.timeout.is_none());
 
         if self.common.wasi.inherit_env == Some(true) {
-            for (k, v) in std::env::vars() {
+            for (k, v) in std::env::vars_os() {
+                let k = k
+                    .to_str()
+                    .ok_or_else(|| format_err!("environment variable {k:?} not valid utf-8"))?;
+                let v = v
+                    .to_str()
+                    .ok_or_else(|| format_err!("environment variable {v:?} not valid utf-8"))?;
                 builder.env(&k, &v);
             }
         }

--- a/src/common.rs
+++ b/src/common.rs
@@ -324,12 +324,12 @@ impl RunCommon {
 
         if self.common.wasi.inherit_env == Some(true) {
             for (k, v) in std::env::vars_os() {
-                let k = k
-                    .to_str()
-                    .ok_or_else(|| format_err!("environment variable name {k:?} not valid utf-8"))?;
-                let v = v
-                    .to_str()
-                    .ok_or_else(|| format_err!("environment variable {k:?} value {v:?} not valid utf-8"))?;
+                let k = k.to_str().ok_or_else(|| {
+                    format_err!("environment variable name {k:?} not valid utf-8")
+                })?;
+                let v = v.to_str().ok_or_else(|| {
+                    format_err!("environment variable {k:?} value {v:?} not valid utf-8")
+                })?;
                 builder.env(&k, &v);
             }
         }

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -3590,3 +3590,64 @@ fn hot_blocks_fib() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+#[cfg(unix)]
+fn non_utf8_raises_error() -> Result<()> {
+    use std::ffi::{OsStr, OsString};
+    use std::os::unix::prelude::*;
+
+    let invalid_utf8 = OsStr::from_bytes(b"\xFF");
+
+    // If everything is valid this should succeed...
+    {
+        let mut cmd = get_wasmtime_command()?;
+        cmd.arg("-Sinherit-env")
+            .arg("tests/all/cli_tests/simple.wat");
+        let output = cmd.output()?;
+        assert!(output.status.success());
+    }
+
+    // -Sinherit-env
+    {
+        let mut cmd = get_wasmtime_command()?;
+        cmd.arg("-Sinherit-env")
+            .arg("tests/all/cli_tests/simple.wat");
+        cmd.env("HI", invalid_utf8);
+        let output = cmd.output()?;
+        if output.status.success() {
+            bail!("should have failed: {output:?}")
+        }
+    }
+    // --env=HI
+    {
+        let mut cmd = get_wasmtime_command()?;
+        cmd.arg("--env=HI").arg("tests/all/cli_tests/simple.wat");
+        cmd.env("HI", invalid_utf8);
+        let output = cmd.output()?;
+        if output.status.success() {
+            bail!("should have failed: {output:?}")
+        }
+    }
+    // --env=HI=$bad
+    {
+        let mut cmd = get_wasmtime_command()?;
+        let mut bad = OsString::from("--env=HI=");
+        bad.push(invalid_utf8);
+        cmd.arg(&bad).arg("tests/all/cli_tests/simple.wat");
+        let output = cmd.output()?;
+        if output.status.success() {
+            bail!("should have failed: {output:?}")
+        }
+    }
+    // $bad (bare argument)
+    {
+        let mut cmd = get_wasmtime_command()?;
+        cmd.arg("tests/all/cli_tests/simple.wat").arg(invalid_utf8);
+        let output = cmd.output()?;
+        if output.status.success() {
+            bail!("should have failed: {output:?}")
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
This internally panics on environment variables with invalid utf-8, but that's something we want to catch gracefully on the CLI.

Closes #14014

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
