### PR TITLE
fix: respect fixed-length list base offsets

### DIFF
--- a/crates/wasmtime/src/runtime/component/values.rs
+++ b/crates/wasmtime/src/runtime/component/values.rs
@@ -718,7 +718,7 @@ impl Val {
                 }
                 let elemsize = cx.types.canonical_abi(&ty.element).size32 as usize;
                 for (n, value) in values.iter().enumerate() {
-                    value.store(cx, ty.element, elemsize * n)?;
+                    value.store(cx, ty.element, offset + elemsize * n)?;
                 }
                 Ok(())
             }

--- a/tests/all/component_model/fixed_length_list.rs
+++ b/tests/all/component_model/fixed_length_list.rs
@@ -1,6 +1,6 @@
 #![cfg(not(miri))]
 
-use wasmtime::component::{Component, Linker};
+use wasmtime::component::{Component, Linker, Val};
 use wasmtime::{Config, Engine, Result, Store};
 
 #[test]
@@ -203,6 +203,53 @@ package test:fixed-length-lists {
         .call_nested_roundtrip(&mut store, inputa, inputb)
         .expect("no trap");
     assert_eq!(result, ([[1, 2], [3, 4]], [[-1, -2], [-3, -4]]));
+    Ok(())
+}
+
+#[test]
+fn dynamic_fixed_length_list_nested_in_tuple() -> Result<()> {
+    let wat = r#"
+(component
+  (type $l (list u32 4))
+  (type $t (tuple u32 $l))
+  (import "f" (func $f (result $t)))
+  (core module $mem (memory (export "memory") 1))
+  (core instance $memi (instantiate $mem))
+  (core func $f2 (canon lower (func $f) (memory $memi "memory")))
+  (core module $m
+    (import "" "f" (func $f (param i32)))
+    (import "mem" "memory" (memory 1))
+    (func (export "run") (result i32)
+      (call $f (i32.const 0))
+      (i32.load (i32.const 0)))
+  )
+  (core instance $ci (export "f" (func $f2)))
+  (core instance $mi (instantiate $m (with "" (instance $ci)) (with "mem" (instance $memi))))
+  (func (export "run") (result u32) (canon lift (core func $mi "run") (memory $memi "memory")))
+)
+"#;
+
+    let mut config = Config::new();
+    config.wasm_component_model_fixed_length_lists(true);
+    let engine = Engine::new(&config)?;
+    let component = Component::new(&engine, wat)?;
+    let mut linker = Linker::new(&engine);
+    linker.root().func_new("f", |_, _, _params, results| {
+        results[0] = Val::Tuple(vec![
+            Val::U32(0xaaaaaaaa),
+            Val::FixedLengthList(vec![
+                Val::U32(0x11111111),
+                Val::U32(0x22222222),
+                Val::U32(0x33333333),
+                Val::U32(0x44444444),
+            ]),
+        ]);
+        Ok(())
+    })?;
+    let mut store = Store::new(&engine, ());
+    let instance = linker.instantiate(&mut store, &component)?;
+    let run = instance.get_typed_func::<(), (u32,)>(&mut store, "run")?;
+    assert_eq!(run.call(&mut store, ())?, (0xaaaaaaaa,));
     Ok(())
 }
 


### PR DESCRIPTION
Fixes #13987.

  Dynamic `Val::FixedLengthList` lowering stored each element relative to the beginning of the canonical ABI allocation instead of the list's caller-provided base offset. When nested inside another
  value, this could overwrite adjacent fields.

  This change includes the base offset when storing each element and adds a regression test for a fixed-length list nested inside a tuple.

  Tests:

  - `cargo test --test all component_model::fixed_length_list`
  - `cargo test -p wasmtime --lib`
  - `cargo clippy -p wasmtime -p wasmtime-cli --all-targets`