### PR TITLE
Run `cargo vet` in a loop on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -124,12 +124,22 @@ jobs:
         crate: cargo-vet
         version: 0.10.2
     - id: vet
-      run: cargo vet --locked
+      run: |
+        for attempt in 1 2 3 4 5; do
+          [ "$attempt" = "5" ] && exit 1
+          cargo vet --locked && break
+          sleep 5
+        done
       continue-on-error: ${{ github.event_name == 'pull_request' }}
 
     # Double-check that if versions are bumped that `cargo vet` still works.
     # This is intended to weed out mistakes such as #9115 from happening again.
-    - run: rustc scripts/publish.rs && ./publish bump-patch && cargo vet
+    - run: |
+        for attempt in 1 2 3 4 5; do
+          [ "$attempt" = "5" ] && exit 1
+          rustc scripts/publish.rs && ./publish bump-patch && cargo vet && break
+          sleep 5
+        done
       name: Ensure `cargo vet` works if versions are bumped
 
   cargo_vet_failure_for_prs:


### PR DESCRIPTION
There have been more and more spurious failures lately due to the networking in `cargo vet`. Run it in a loop like everything else in CI that might touch the network.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
