### PR TITLE
Make `rc_for_type()` pass Type arg by reference instead of value

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -235,7 +235,7 @@ impl ABIMachineSpec for AArch64MachineDeps {
                 );
             }
 
-            let (rcs, reg_types) = Inst::rc_for_type(param.value_type)?;
+            let (rcs, reg_types) = Inst::rc_for_type(&param.value_type)?;
 
             if let ir::ArgumentPurpose::StructReturn = param.purpose {
                 assert!(

--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -1118,14 +1118,8 @@ impl MachInst for Inst {
 
     fn rc_for_type(ty: &Type) -> CodegenResult<(&[RegClass], &[Type])> {
         match *ty {
-            I8 => Ok((&[RegClass::Int], &[I8])),
-            I16 => Ok((&[RegClass::Int], &[I16])),
-            I32 => Ok((&[RegClass::Int], &[I32])),
-            I64 => Ok((&[RegClass::Int], &[I64])),
-            F16 => Ok((&[RegClass::Float], &[F16])),
-            F32 => Ok((&[RegClass::Float], &[F32])),
-            F64 => Ok((&[RegClass::Float], &[F64])),
-            F128 => Ok((&[RegClass::Float], &[F128])),
+            I8 | I16 | I32 | I64 => Ok((&[RegClass::Int], slice::from_ref(ty))),
+            F16 | F32 | F64 | F128 => Ok((&[RegClass::Float], slice::from_ref(ty))),
             I128 => Ok((&[RegClass::Int, RegClass::Int], &[I64, I64])),
             _ if ty.is_vector() && ty.bits() <= 128 => {
                 let types = &[types::I8X2, types::I8X4, types::I8X8, types::I8X16];

--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -1116,8 +1116,8 @@ impl MachInst for Inst {
         vec![vec![0x1f, 0x20, 0x03, 0xd5]]
     }
 
-    fn rc_for_type(ty: Type) -> CodegenResult<(&'static [RegClass], &'static [Type])> {
-        match ty {
+    fn rc_for_type(ty: &Type) -> CodegenResult<(&[RegClass], &[Type])> {
+        match *ty {
             I8 => Ok((&[RegClass::Int], &[I8])),
             I16 => Ok((&[RegClass::Int], &[I16])),
             I32 => Ok((&[RegClass::Int], &[I32])),

--- a/cranelift/codegen/src/isa/pulley_shared/abi.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/abi.rs
@@ -91,7 +91,7 @@ where
         for param in params {
             // Find the regclass(es) of the register(s) used to store a value of
             // this type.
-            let (rcs, reg_tys) = Self::I::rc_for_type(param.value_type)?;
+            let (rcs, reg_tys) = Self::I::rc_for_type(&param.value_type)?;
 
             let mut slots = ABIArgSlotVec::new();
             for (rc, reg_ty) in rcs.iter().zip(reg_tys.iter()) {

--- a/cranelift/codegen/src/isa/pulley_shared/inst/mod.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/inst/mod.rs
@@ -545,8 +545,8 @@ where
         vec![bytes]
     }
 
-    fn rc_for_type(ty: Type) -> CodegenResult<(&'static [RegClass], &'static [Type])> {
-        match ty {
+    fn rc_for_type(ty: &Type) -> CodegenResult<(&[RegClass], &[Type])> {
+        match *ty {
             I8 => Ok((&[RegClass::Int], &[I8])),
             I16 => Ok((&[RegClass::Int], &[I16])),
             I32 => Ok((&[RegClass::Int], &[I32])),

--- a/cranelift/codegen/src/isa/pulley_shared/inst/mod.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/inst/mod.rs
@@ -547,12 +547,8 @@ where
 
     fn rc_for_type(ty: &Type) -> CodegenResult<(&[RegClass], &[Type])> {
         match *ty {
-            I8 => Ok((&[RegClass::Int], &[I8])),
-            I16 => Ok((&[RegClass::Int], &[I16])),
-            I32 => Ok((&[RegClass::Int], &[I32])),
-            I64 => Ok((&[RegClass::Int], &[I64])),
-            F32 => Ok((&[RegClass::Float], &[F32])),
-            F64 => Ok((&[RegClass::Float], &[F64])),
+            I8 | I16 | I32 | I64 => Ok((&[RegClass::Int], core::slice::from_ref(ty))),
+            F32 | F64 => Ok((&[RegClass::Float], core::slice::from_ref(ty))),
             I128 => Ok((&[RegClass::Int, RegClass::Int], &[I64, I64])),
             _ if ty.is_vector() => {
                 debug_assert!(ty.bits() <= 512);

--- a/cranelift/codegen/src/isa/riscv64/abi.rs
+++ b/cranelift/codegen/src/isa/riscv64/abi.rs
@@ -132,7 +132,7 @@ impl ABIMachineSpec for Riscv64MachineDeps {
             }
 
             // Find regclass(es) of the register(s) used to store a value of this type.
-            let (rcs, reg_tys) = Inst::rc_for_type(param.value_type)?;
+            let (rcs, reg_tys) = Inst::rc_for_type(&param.value_type)?;
             let mut slots = ABIArgSlotVec::new();
             for (rc, reg_ty) in rcs.iter().zip(reg_tys.iter()) {
                 let next_reg = if (next_x_reg <= x_end) && *rc == RegClass::Int {

--- a/cranelift/codegen/src/isa/riscv64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/mod.rs
@@ -816,13 +816,8 @@ impl MachInst for Inst {
 
     fn rc_for_type(ty: &Type) -> CodegenResult<(&[RegClass], &[Type])> {
         match *ty {
-            I8 => Ok((&[RegClass::Int], &[I8])),
-            I16 => Ok((&[RegClass::Int], &[I16])),
-            I32 => Ok((&[RegClass::Int], &[I32])),
-            I64 => Ok((&[RegClass::Int], &[I64])),
-            F16 => Ok((&[RegClass::Float], &[F16])),
-            F32 => Ok((&[RegClass::Float], &[F32])),
-            F64 => Ok((&[RegClass::Float], &[F64])),
+            I8 | I16 | I32 | I64 => Ok((&[RegClass::Int], core::slice::from_ref(ty))),
+            F16 | F32 | F64 => Ok((&[RegClass::Float], core::slice::from_ref(ty))),
             // FIXME(#8312): Add support for Q extension
             F128 | I128 => Ok((&[RegClass::Int, RegClass::Int], &[I64, I64])),
             _ if ty.is_vector() => {

--- a/cranelift/codegen/src/isa/riscv64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/mod.rs
@@ -814,8 +814,8 @@ impl MachInst for Inst {
         vec![vec![0x13, 0x00, 0x00, 0x00]]
     }
 
-    fn rc_for_type(ty: Type) -> CodegenResult<(&'static [RegClass], &'static [Type])> {
-        match ty {
+    fn rc_for_type(ty: &Type) -> CodegenResult<(&[RegClass], &[Type])> {
+        match *ty {
             I8 => Ok((&[RegClass::Int], &[I8])),
             I16 => Ok((&[RegClass::Int], &[I16])),
             I32 => Ok((&[RegClass::Int], &[I32])),

--- a/cranelift/codegen/src/isa/s390x/abi.rs
+++ b/cranelift/codegen/src/isa/s390x/abi.rs
@@ -1110,7 +1110,7 @@ impl S390xMachineDeps {
         };
 
         // Helper routine to allocate a temp register for ty.
-        let temp_reg = |ty| match Inst::rc_for_type(ty).unwrap() {
+        let temp_reg = |ty| match Inst::rc_for_type(&ty).unwrap() {
             (&[RegClass::Int], _) => writable_gpr(0),
             (&[RegClass::Float], _) => writable_vr(1),
             _ => unreachable!(),

--- a/cranelift/codegen/src/isa/s390x/inst/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/mod.rs
@@ -1224,8 +1224,8 @@ impl MachInst for Inst {
         vec![vec![0x07, 0x07]]
     }
 
-    fn rc_for_type(ty: Type) -> CodegenResult<(&'static [RegClass], &'static [Type])> {
-        match ty {
+    fn rc_for_type(ty: &Type) -> CodegenResult<(&[RegClass], &[Type])> {
+        match *ty {
             types::I8 => Ok((&[RegClass::Int], &[types::I8])),
             types::I16 => Ok((&[RegClass::Int], &[types::I16])),
             types::I32 => Ok((&[RegClass::Int], &[types::I32])),

--- a/cranelift/codegen/src/isa/s390x/inst/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/mod.rs
@@ -1226,15 +1226,12 @@ impl MachInst for Inst {
 
     fn rc_for_type(ty: &Type) -> CodegenResult<(&[RegClass], &[Type])> {
         match *ty {
-            types::I8 => Ok((&[RegClass::Int], &[types::I8])),
-            types::I16 => Ok((&[RegClass::Int], &[types::I16])),
-            types::I32 => Ok((&[RegClass::Int], &[types::I32])),
-            types::I64 => Ok((&[RegClass::Int], &[types::I64])),
-            types::F16 => Ok((&[RegClass::Float], &[types::F16])),
-            types::F32 => Ok((&[RegClass::Float], &[types::F32])),
-            types::F64 => Ok((&[RegClass::Float], &[types::F64])),
-            types::F128 => Ok((&[RegClass::Float], &[types::F128])),
-            types::I128 => Ok((&[RegClass::Float], &[types::I128])),
+            types::I8 | types::I16 | types::I32 | types::I64 => {
+                Ok((&[RegClass::Int], core::slice::from_ref(ty)))
+            }
+            types::F16 | types::F32 | types::F64 | types::F128 | types::I128 => {
+                Ok((&[RegClass::Float], core::slice::from_ref(ty)))
+            }
             _ if ty.is_vector() && ty.bits() == 128 => Ok((&[RegClass::Float], &[types::I8X16])),
             _ => Err(CodegenError::Unsupported(format!(
                 "Unexpected SSA-value type: {ty}"

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -167,7 +167,7 @@ impl ABIMachineSpec for X64ABIMachineSpec {
             }
 
             // Find regclass(es) of the register(s) used to store a value of this type.
-            let (rcs, reg_tys) = Inst::rc_for_type(param.value_type)?;
+            let (rcs, reg_tys) = Inst::rc_for_type(&param.value_type)?;
 
             // Now assign ABIArgSlots for each register-sized part.
             //

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -1409,14 +1409,12 @@ impl MachInst for Inst {
 
     fn rc_for_type(ty: &Type) -> CodegenResult<(&[RegClass], &[Type])> {
         match *ty {
-            types::I8 => Ok((&[RegClass::Int], &[types::I8])),
-            types::I16 => Ok((&[RegClass::Int], &[types::I16])),
-            types::I32 => Ok((&[RegClass::Int], &[types::I32])),
-            types::I64 => Ok((&[RegClass::Int], &[types::I64])),
-            types::F16 => Ok((&[RegClass::Float], &[types::F16])),
-            types::F32 => Ok((&[RegClass::Float], &[types::F32])),
-            types::F64 => Ok((&[RegClass::Float], &[types::F64])),
-            types::F128 => Ok((&[RegClass::Float], &[types::F128])),
+            types::I8 | types::I16 | types::I32 | types::I64 => {
+                Ok((&[RegClass::Int], core::slice::from_ref(ty)))
+            }
+            types::F16 | types::F32 | types::F64 | types::F128 => {
+                Ok((&[RegClass::Float], core::slice::from_ref(ty)))
+            }
             types::I128 => Ok((&[RegClass::Int, RegClass::Int], &[types::I64, types::I64])),
             _ if ty.is_vector() && ty.bits() <= 128 => {
                 let types = &[types::I8X2, types::I8X4, types::I8X8, types::I8X16];

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -1407,8 +1407,8 @@ impl MachInst for Inst {
         ]
     }
 
-    fn rc_for_type(ty: Type) -> CodegenResult<(&'static [RegClass], &'static [Type])> {
-        match ty {
+    fn rc_for_type(ty: &Type) -> CodegenResult<(&[RegClass], &[Type])> {
+        match *ty {
             types::I8 => Ok((&[RegClass::Int], &[types::I8])),
             types::I16 => Ok((&[RegClass::Int], &[types::I16])),
             types::I32 => Ok((&[RegClass::Int], &[types::I32])),

--- a/cranelift/codegen/src/machinst/abi.rs
+++ b/cranelift/codegen/src/machinst/abi.rs
@@ -2416,7 +2416,7 @@ impl<M: ABIMachineSpec> Callee<M> {
     /// Generate a spill.
     pub fn gen_spill(&self, to_slot: SpillSlot, from_reg: RealReg) -> M::I {
         let ty = M::I::canonical_type_for_rc(from_reg.class());
-        debug_assert_eq!(<M>::I::rc_for_type(ty).unwrap().1, &[ty]);
+        debug_assert_eq!(<M>::I::rc_for_type(&ty).unwrap().1, &[ty]);
 
         let sp_off = self.get_spillslot_offset(to_slot);
         trace!("gen_spill: {from_reg:?} into slot {to_slot:?} at offset {sp_off}");
@@ -2428,7 +2428,7 @@ impl<M: ABIMachineSpec> Callee<M> {
     /// Generate a reload (fill).
     pub fn gen_reload(&self, to_reg: Writable<RealReg>, from_slot: SpillSlot) -> M::I {
         let ty = M::I::canonical_type_for_rc(to_reg.to_reg().class());
-        debug_assert_eq!(<M>::I::rc_for_type(ty).unwrap().1, &[ty]);
+        debug_assert_eq!(<M>::I::rc_for_type(&ty).unwrap().1, &[ty]);
 
         let sp_off = self.get_spillslot_offset(from_slot);
         trace!("gen_reload: {to_reg:?} from slot {from_slot:?} at offset {sp_off}");

--- a/cranelift/codegen/src/machinst/mod.rs
+++ b/cranelift/codegen/src/machinst/mod.rs
@@ -324,7 +324,7 @@ pub trait MachInst: Clone + Debug {
     /// target, an I64 may be stored in two registers, each of which holds an
     /// I32. The actually-stored types are used only to inform the backend when
     /// generating spills and reloads for individual registers.
-    fn rc_for_type(ty: Type) -> CodegenResult<(&'static [RegClass], &'static [Type])>;
+    fn rc_for_type(ty: &Type) -> CodegenResult<(&[RegClass], &[Type])>;
 
     /// Get an appropriate type that can fully hold a value in a given
     /// register class. This may not be the only type that maps to

--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -1718,7 +1718,7 @@ impl<I: VCodeInst> VRegAllocator<I> {
             return Err(CodegenError::CodeTooLarge);
         }
         let v = self.vreg_types.len();
-        let (regclasses, tys) = I::rc_for_type(ty)?;
+        let (regclasses, tys) = I::rc_for_type(&ty)?;
 
         // Check that new indices are in-bounds for regalloc2's
         // VReg/Operand representation.
@@ -1774,7 +1774,7 @@ impl<I: VCodeInst> VRegAllocator<I> {
     /// registers for the given type. This is meant to be used with
     /// deferred allocation errors (see `Lower::alloc_tmp()`).
     fn bogus_for_deferred_error(&self, ty: Type) -> ValueRegs<Reg> {
-        let (regclasses, _tys) = I::rc_for_type(ty).expect("must have valid type");
+        let (regclasses, _tys) = I::rc_for_type(&ty).expect("must have valid type");
         match regclasses {
             &[rc0] => ValueRegs::one(VReg::new(0, rc0).into()),
             &[rc0, rc1] => ValueRegs::two(VReg::new(0, rc0).into(), VReg::new(1, rc1).into()),


### PR DESCRIPTION
This PR changes `trait MachInst`:

```diff
- fn rc_for_type(ty: Type) -> CodegenResult<(&'static [RegClass], &'static [Type])>;
+ fn rc_for_type(ty: &Type) -> CodegenResult<(&[RegClass], &[Type])>;
```

This change is trivial to support from all call sites, and allows implementors to:
```diff
- I8 => Ok((&[RegClass::Int], &[I8])),
- I16 => Ok((&[RegClass::Int], &[I16])),
- I32 => Ok((&[RegClass::Int], &[I32])),
- I64 => Ok((&[RegClass::Int], &[I64])),
- F32 => Ok((&[RegClass::Float], &[F32])),
- F64 => Ok((&[RegClass::Float], &[F64])),
+ I8 | I16 | I32 | I64 => Ok((&[RegClass::Int], core::slice::from_ref(ty))),
+ F32 | F64 => Ok((&[RegClass::Float], core::slice::from_ref(ty))),
```

Not sure how overall valuable this patch is. This function has just been annoying to implement for SSA-style IRs, where `RegClass` doesn't matter and it's just returning whatever type was passed.