### PR TITLE
Retry downloads a bit harder in a build script

### DIFF
--- a/crates/wizer/benches/uap-bench/build.rs
+++ b/crates/wizer/benches/uap-bench/build.rs
@@ -6,7 +6,7 @@ fn main() {
     let dest_path = std::path::Path::new(&out_dir).join("regexes.yaml");
 
     let status = Command::new("curl")
-        .args(&["-L", url, "--retry", "3"])
+        .args(&["-L", url, "--retry", "3", "--retry-all-errors"])
         .arg("-o")
         .arg(dest_path)
         .status()


### PR DESCRIPTION
Trying to handle [this failure](https://github.com/bytecodealliance/wasmtime/actions/runs/30511694716/job/90772994110)