### PR TITLE
Fix AArch64 subword atomic unsigned min/max

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit.rs
@@ -1508,7 +1508,14 @@ impl MachInstEmit for Inst {
                     },
                     _ => None,
                 };
-
+                let zero_ext = match op {
+                    AtomicRMWLoopOp::Umin | AtomicRMWLoopOp::Umax => match ty {
+                        I16 => Some(ExtendOp::UXTH),
+                        I8 => Some(ExtendOp::UXTB),
+                        _ => None,
+                    },
+                    _ => None,
+                };
                 // sxt{b|h} the loaded result if necessary.
                 if sign_ext.is_some() {
                     let (_, from_bits) = sign_ext.unwrap();
@@ -1561,8 +1568,7 @@ impl MachInstEmit for Inst {
                             _ => unreachable!(),
                         };
 
-                        if sign_ext.is_some() {
-                            let (extendop, _) = sign_ext.unwrap();
+                        if let Some(extendop) = sign_ext.map(|(op, _)| op).or(zero_ext) {
                             Inst::AluRRRExtend {
                                 alu_op: ALUOp::SubS,
                                 size,

--- a/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
@@ -7284,7 +7284,7 @@ fn test_aarch64_binemit() {
             scratch1: writable_xreg(24),
             scratch2: writable_xreg(28),
         },
-        "3BFF5F087F031A6B7C339A9A3CFF180898FFFFB5",
+        "3BFF5F087F033A6B7C339A9A3CFF180898FFFFB5",
         "atomic_rmw_loop_umin_8 addr=x25 operand=x26 oldval=x27 scratch1=x24 scratch2=x28",
     ));
     insns.push((
@@ -7298,7 +7298,7 @@ fn test_aarch64_binemit() {
             scratch1: writable_xreg(24),
             scratch2: writable_xreg(28),
         },
-        "3BFF5F487F031A6B7C839A9A3CFF184898FFFFB5",
+        "3BFF5F487F233A6B7C839A9A3CFF184898FFFFB5",
         "atomic_rmw_loop_umax_16 addr=x25 operand=x26 oldval=x27 scratch1=x24 scratch2=x28",
     ));
 

--- a/cranelift/filetests/filetests/isa/aarch64/atomic-rmw.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/atomic-rmw.clif
@@ -1306,7 +1306,7 @@ block0(v0: i64, v1: i16):
 ;   mov x25, x0
 ;   mov x26, x1
 ;   ldaxrh w27, [x25] ; trap: heap_oob
-;   cmp w27, w26
+;   cmp w27, w26, uxth
 ;   csel x28, x27, x26, hi
 ;   stlxrh w24, w28, [x25] ; trap: heap_oob
 ;   cbnz x24, #0x1c
@@ -1349,7 +1349,7 @@ block0(v0: i64, v1: i8):
 ;   mov x25, x0
 ;   mov x26, x1
 ;   ldaxrb w27, [x25] ; trap: heap_oob
-;   cmp w27, w26
+;   cmp w27, w26, uxtb
 ;   csel x28, x27, x26, hi
 ;   stlxrb w24, w28, [x25] ; trap: heap_oob
 ;   cbnz x24, #0x1c
@@ -1652,7 +1652,7 @@ block0(v0: i64, v1: i16):
 ;   mov x25, x0
 ;   mov x26, x1
 ;   ldaxrh w27, [x25] ; trap: heap_oob
-;   cmp w27, w26
+;   cmp w27, w26, uxth
 ;   csel x28, x27, x26, lo
 ;   stlxrh w24, w28, [x25] ; trap: heap_oob
 ;   cbnz x24, #0x1c
@@ -1695,7 +1695,7 @@ block0(v0: i64, v1: i8):
 ;   mov x25, x0
 ;   mov x26, x1
 ;   ldaxrb w27, [x25] ; trap: heap_oob
-;   cmp w27, w26
+;   cmp w27, w26, uxtb
 ;   csel x28, x27, x26, lo
 ;   stlxrb w24, w28, [x25] ; trap: heap_oob
 ;   cbnz x24, #0x1c

--- a/cranelift/filetests/filetests/runtests/atomic-rmw-subword-little.clif
+++ b/cranelift/filetests/filetests/runtests/atomic-rmw-subword-little.clif
@@ -900,3 +900,31 @@ block0(v0: i32, v1: i64, v2: i8):
 ; run: %atomic_rmw_xchg_little_i8_no_res(0x12345678, 1, 0xff) == 0x1234ff78
 ; run: %atomic_rmw_xchg_little_i8_no_res(0x12345678, 0, 0x11) == 0x12345611
 ; run: %atomic_rmw_xchg_little_i8_no_res(0x12345678, 0, 0xff) == 0x123456ff
+
+function %atomic_rmw_umin_i8_reduced_operand(i32) -> i8 {
+    ss0 = explicit_slot 1
+
+block0(v0: i32):
+    v1 = stack_addr.i64 ss0
+    v2 = iconst.i8 32
+    store.i8 v2, v1
+    v3 = ireduce.i8 v0
+    v4 = atomic_rmw.i8 umin v1, v3
+    v5 = load.i8 v1
+    return v5
+}
+; run: %atomic_rmw_umin_i8_reduced_operand(0x110) == 16
+
+function %atomic_rmw_umax_i8_reduced_operand(i32) -> i8 {
+    ss0 = explicit_slot 1
+
+block0(v0: i32):
+    v1 = stack_addr.i64 ss0
+    v2 = iconst.i8 32
+    store.i8 v2, v1
+    v3 = ireduce.i8 v0
+    v4 = atomic_rmw.i8 umax v1, v3
+    v5 = load.i8 v1
+    return v5
+}
+; run: %atomic_rmw_umax_i8_reduced_operand(0x110) == 32


### PR DESCRIPTION
Fixes #13972.

  Zero-extend i8 and i16 operands in non-LSE AArch64 atomic `umin`/`umax` comparison loops. Values produced by `ireduce` can retain high register bits, so comparing the unextended 32-bit operand can select the wrong
  subword value.

  This updates the assembly and binary-emission expectations and adds runtime cases with dirty high operand bits.

  ## Testing

  - `cargo run -p cranelift-tools -- test cranelift/filetests/filetests/isa/aarch64/atomic-rmw.clif cranelift/filetests/filetests/runtests/atomic-rmw-subword-little.clif`
  - `cargo test -p cranelift-codegen --features all-arch --lib test_aarch64_binemit`
  - `cargo clippy -p cranelift-codegen --features all-arch --lib -- -D warnings`
  - `cargo fmt -p cranelift-codegen -p cranelift-filetests -- --check`