### PR TITLE
Ignore `p2_udp_send_to_closed_receiver` on macOS

### DIFF
--- a/crates/wasi/tests/all/p2/async_.rs
+++ b/crates/wasi/tests/all/p2/async_.rs
@@ -372,6 +372,9 @@ async fn p2_udp_connect() {
     run(P2_UDP_CONNECT_COMPONENT, |_| {}).await.unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
+// See the comment on the `p2::sync` variation of this test; for why this is
+// ignored on macos
+#[cfg_attr(target_os = "macos", ignore)]
 async fn p2_udp_send_to_closed_receiver() {
     run(P2_UDP_SEND_TO_CLOSED_RECEIVER_COMPONENT, |_| {})
         .await

--- a/crates/wasi/tests/all/p2/sync.rs
+++ b/crates/wasi/tests/all/p2/sync.rs
@@ -350,6 +350,11 @@ fn p2_udp_connect() {
 // consistently fails when run in combination with the `p2::async_` variation,
 // and we've thus far been unable to determine the reason.
 #[cfg_attr(windows, ignore = "This test is flaky on Windows.")]
+// This test is flaky on macOS in CI. One possible reason is that this relies on
+// a port being closed which concurrent tests can otherwise re-bind. Another
+// reason is that maybe this is just flaky on macOS (LLMs say something about
+// the OS rate-limiting ICMP messages if they're to be believed).
+#[cfg_attr(target_os = "macos", ignore = "This test is flaky on macOS.")]
 fn p2_udp_send_to_closed_receiver() {
     run(P2_UDP_SEND_TO_CLOSED_RECEIVER_COMPONENT, |_| {}).unwrap()
 }


### PR DESCRIPTION
This [failed on CI recently][log] and it was already flaky on Windows. Maybe eventually we'll just remove this test for flakiness, but for now I'd like to keep flaky tests out of the critical path of the merge queue.

[log]: https://github.com/bytecodealliance/wasmtime/actions/runs/30563046634/job/90940763865

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
