### PR TITLE
cranelift: Run cprop on `scalar_to_vector`

### DIFF
--- a/cranelift/codegen/src/opts.rs
+++ b/cranelift/codegen/src/opts.rs
@@ -309,6 +309,11 @@ impl<'a, 'b, 'c> generated_code::Context for IsleContext<'a, 'b, 'c> {
         self.ctx.func.dfg.constants.insert(imm.into())
     }
 
+    fn scalar_to_vector_const64(&mut self, val: u64) -> Constant {
+        let imm = V128Imm(u128::from(val).to_le_bytes());
+        self.ctx.func.dfg.constants.insert(imm.into())
+    }
+
     type sextend_maybe_etor_returns = MaybeUnaryEtorIter<'a, 'b, 'c>;
     fn sextend_maybe_etor(&mut self, value: Value, returns: &mut Self::sextend_maybe_etor_returns) {
         *returns = MaybeUnaryEtorIter::new(Opcode::Sextend, value);

--- a/cranelift/codegen/src/opts/cprop.isle
+++ b/cranelift/codegen/src/opts/cprop.isle
@@ -295,6 +295,25 @@
 (decl splat64 (u64) Constant)
 (extern constructor splat64 splat64)
 
+
+;; `scalar_to_vector` places its scalar in lane zero and clears every other
+;; lane. A scalar constant can therefore become a vector constant with the
+;; scalar's bits in its lowest lane.
+(rule (simplify (scalar_to_vector (ty_vec128_int dst) (iconst ty n)))
+      (vconst dst (scalar_to_vector_const64 (u64_uextend_imm64 ty n))))
+(rule (simplify
+       (scalar_to_vector (ty_vec128 dst) (f16const _ (u16_from_ieee16 n))))
+      (vconst dst (scalar_to_vector_const64 (u16_into_u64 n))))
+(rule (simplify
+       (scalar_to_vector (ty_vec128 dst) (f32const _ (u32_from_ieee32 n))))
+      (vconst dst (scalar_to_vector_const64 (u32_into_u64 n))))
+(rule (simplify
+       (scalar_to_vector (ty_vec128 dst) (f64const _ (u64_from_ieee64 n))))
+      (vconst dst (scalar_to_vector_const64 n)))
+
+(decl scalar_to_vector_const64 (u64) Constant)
+(extern constructor scalar_to_vector_const64 scalar_to_vector_const64)
+
 ;; Reassociate nested shifts of constants to put constants together for cprop.
 ;;
 ;; ((A shift b) shift C) ==> ((A shift C) shift b)

--- a/cranelift/filetests/filetests/egraph/scalar-to-vector-vconst.clif
+++ b/cranelift/filetests/filetests/egraph/scalar-to-vector-vconst.clif
@@ -1,0 +1,108 @@
+test optimize precise-output
+set opt_level=speed
+target x86_64
+
+function %i8x16() -> i8x16 {
+block0:
+    v0 = iconst.i8 -2
+    v1 = scalar_to_vector.i8x16 v0
+    return v1
+}
+
+; function %i8x16() -> i8x16 fast {
+;     const0 = 0x000000000000000000000000000000fe
+;
+; block0:
+;     v2 = vconst.i8x16 const0
+;     return v2  ; v2 = const0
+; }
+
+function %i16x8() -> i16x8 {
+block0:
+    v0 = iconst.i16 0x1234
+    v1 = scalar_to_vector.i16x8 v0
+    return v1
+}
+
+; function %i16x8() -> i16x8 fast {
+;     const0 = 0x00000000000000000000000000001234
+;
+; block0:
+;     v2 = vconst.i16x8 const0
+;     return v2  ; v2 = const0
+; }
+
+function %i32x4() -> i32x4 {
+block0:
+    v0 = iconst.i32 0
+    v1 = scalar_to_vector.i32x4 v0
+    return v1
+}
+
+; function %i32x4() -> i32x4 fast {
+;     const0 = 0x00000000000000000000000000000000
+;
+; block0:
+;     v2 = vconst.i32x4 const0
+;     return v2  ; v2 = const0
+; }
+
+function %i64x2() -> i64x2 {
+block0:
+    v0 = iconst.i64 0x0123456789abcdef
+    v1 = scalar_to_vector.i64x2 v0
+    return v1
+}
+
+; function %i64x2() -> i64x2 fast {
+;     const0 = 0x00000000000000000123456789abcdef
+;
+; block0:
+;     v2 = vconst.i64x2 const0
+;     return v2  ; v2 = const0
+; }
+
+function %f16x8() -> f16x8 {
+block0:
+    v0 = f16const 0x1.5p2
+    v1 = scalar_to_vector.f16x8 v0
+    return v1
+}
+
+; function %f16x8() -> f16x8 fast {
+;     const0 = 0x00000000000000000000000000004540
+;
+; block0:
+;     v2 = vconst.f16x8 const0
+;     return v2  ; v2 = const0
+; }
+
+function %f32x4() -> f32x4 {
+block0:
+    v0 = f32const -0x1.5p0
+    v1 = scalar_to_vector.f32x4 v0
+    return v1
+}
+
+; function %f32x4() -> f32x4 fast {
+;     const0 = 0x000000000000000000000000bfa80000
+;
+; block0:
+;     v2 = vconst.f32x4 const0
+;     return v2  ; v2 = const0
+; }
+
+function %f64x2() -> f64x2 {
+block0:
+    v0 = f64const 0x1.5p2
+    v1 = scalar_to_vector.f64x2 v0
+    return v1
+}
+
+; function %f64x2() -> f64x2 fast {
+;     const0 = 0x00000000000000004015000000000000
+;
+; block0:
+;     v2 = vconst.f64x2 const0
+;     return v2  ; v2 = const0
+; }


### PR DESCRIPTION
👋 Hey,

This PR adds constant propagation through `scalar_to_vector`. This rule is not very useful by itself, but it allows other rules to run on it's result.