### PR TITLE
[24.0.x] Fix some API unsoundness with invaild cross-`Engine` usage

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,14 @@
+## 24.0.12
+
+Released 2026-07-31.
+
+### Fixed
+
+* Stores can mix up type indices between engines.
+  [GHSA-hgjw-h833-99q9](https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-hgjw-h833-99q9)
+
+--------------------------------------------------------------------------------
+
 ## 24.0.11
 
 Released 2026-06-24.

--- a/crates/wasmtime/src/runtime/component/instance.rs
+++ b/crates/wasmtime/src/runtime/component/instance.rs
@@ -490,12 +490,13 @@ impl<'a> Instantiator<'a> {
         component: &'a Component,
         store: &mut StoreOpaque,
         imports: &'a Arc<PrimaryMap<RuntimeImportIndex, RuntimeImport>>,
-    ) -> Instantiator<'a> {
+    ) -> Result<Instantiator<'a>> {
         let env_component = component.env_component();
-        store.modules_mut().register_component(component);
+        let (modules, engine) = store.modules_and_engine_mut();
+        modules.register_component(component, engine)?;
         let imported_resources: ImportedResources =
             PrimaryMap::with_capacity(env_component.imported_resources.len());
-        Instantiator {
+        Ok(Instantiator {
             component,
             imports,
             core_imports: OwnedImports::empty(),
@@ -509,7 +510,7 @@ impl<'a> Instantiator<'a> {
                 ),
                 imports: imports.clone(),
             },
-        }
+        })
     }
 
     fn run<T>(&mut self, store: &mut StoreContextMut<'_, T>) -> Result<()> {
@@ -830,7 +831,16 @@ impl<T> InstancePre<T> {
             .engine()
             .allocator()
             .increment_component_instance_count()?;
-        let mut instantiator = Instantiator::new(&self.component, store.0, &self.imports);
+        let mut instantiator = match Instantiator::new(&self.component, store.0, &self.imports) {
+            Ok(instantiator) => instantiator,
+            Err(e) => {
+                store
+                    .engine()
+                    .allocator()
+                    .decrement_component_instance_count();
+                return Err(e);
+            }
+        };
         instantiator.run(&mut store).map_err(|e| {
             store
                 .engine()

--- a/crates/wasmtime/src/runtime/component/linker.rs
+++ b/crates/wasmtime/src/runtime/component/linker.rs
@@ -208,7 +208,14 @@ impl<T> Linker<T> {
     /// Returns an error if this linker doesn't define a name that the
     /// `component` imports or if a name defined doesn't match the type of the
     /// item imported by the `component` provided.
+    ///
+    /// Returns an error if `component` was not compiled by the same
+    /// [`Engine`](crate::Engine) as this linker.
     pub fn instantiate_pre(&self, component: &Component) -> Result<InstancePre<T>> {
+        ensure!(
+            Engine::same(&self.engine, component.engine()),
+            "cross-`Engine` instantiation is not currently supported"
+        );
         self.typecheck(&component)?;
 
         // Now that all imports are known to be defined and satisfied by this

--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -2452,6 +2452,11 @@ impl HostFunc {
         );
     }
 
+    /// The engine that this function's type is registered with.
+    pub(crate) fn engine(&self) -> &Engine {
+        &self.engine
+    }
+
     pub(crate) fn sig_index(&self) -> VMSharedTypeIndex {
         self.func_ref().type_index
     }

--- a/crates/wasmtime/src/runtime/instance.rs
+++ b/crates/wasmtime/src/runtime/instance.rs
@@ -168,7 +168,7 @@ impl Instance {
                 bail!("cross-`Store` instantiation is not currently supported");
             }
         }
-        typecheck(module, imports, |cx, ty, item| {
+        typecheck(store.engine(), module, imports, |cx, ty, item| {
             let item = DefinitionType::from(store, item);
             cx.definition(ty, &item)
         })?;
@@ -264,7 +264,8 @@ impl Instance {
 
         // Register the module just before instantiation to ensure we keep the module
         // properly referenced while in use by the store.
-        let module_id = store.modules_mut().register_module(module);
+        let (modules, engine) = store.modules_and_engine_mut();
+        let module_id = modules.register_module(module, engine)?;
         store.fill_func_refs();
 
         // The first thing we do is issue an instance allocation request
@@ -805,14 +806,20 @@ impl<T> InstancePre<T> {
     /// This method is unsafe as the `T` of the `InstancePre<T>` is not
     /// guaranteed to be the same as the `T` within the `Store`, the caller must
     /// verify that.
-    pub(crate) unsafe fn new(module: &Module, items: Vec<Definition>) -> Result<InstancePre<T>> {
-        typecheck(module, &items, |cx, ty, item| cx.definition(ty, &item.ty()))?;
+    pub(crate) unsafe fn new(
+        engine: &Engine,
+        module: &Module,
+        items: Vec<Definition>,
+    ) -> Result<InstancePre<T>> {
+        typecheck(engine, module, &items, |cx, ty, item| {
+            cx.definition(ty, &item.ty())
+        })?;
 
         let mut func_refs = vec![];
         let mut host_funcs = 0;
         for item in &items {
             match item {
-                Definition::Extern(_, _) => {}
+                Definition::Extern { .. } => {}
                 Definition::HostFunc(f) => {
                     host_funcs += 1;
                     if f.func_ref().wasm_call.is_none() {
@@ -947,7 +954,7 @@ fn pre_instantiate_raw(
         // `T` of the store. Additionally the rooting necessary has happened
         // above.
         let item = match import {
-            Definition::Extern(e, _) => e.clone(),
+            Definition::Extern { item, .. } => item.clone(),
             Definition::HostFunc(func) => unsafe {
                 func.to_func_store_rooted(
                     store,
@@ -966,11 +973,51 @@ fn pre_instantiate_raw(
     Ok(imports)
 }
 
-fn typecheck<I>(
+/// An argument that can be supplied for one of a module's imports.
+///
+/// # Unsafety
+///
+/// `engine` must return the engine that this item's type indices are
+/// meaningful in, or `None` if the item does not carry a handle to one.
+/// Reporting the wrong engine would let type indices from one engine be
+/// interpreted in another.
+pub(crate) unsafe trait ImportArg {
+    /// The engine this item belongs to, if it carries a handle to one.
+    fn engine(&self) -> Option<&Engine>;
+}
+
+// SAFETY: `Extern::SharedMemory` is the only variant with an `Engine` handle.
+// The rest are just indices into a store's data, so the store is the only thing
+// that knows their engine.
+unsafe impl ImportArg for Extern {
+    fn engine(&self) -> Option<&Engine> {
+        match self {
+            Extern::SharedMemory(m) => Some(m.engine()),
+            Extern::Func(_) | Extern::Global(_) | Extern::Table(_) | Extern::Memory(_) => None,
+        }
+    }
+}
+
+// SAFETY: `Definition::engine` is complete.
+unsafe impl ImportArg for Definition {
+    fn engine(&self) -> Option<&Engine> {
+        Some(Definition::engine(self))
+    }
+}
+
+fn typecheck<I: ImportArg>(
+    engine: &Engine,
     module: &Module,
     import_args: &[I],
     check: impl Fn(&matching::MatchCx<'_>, &EntityType, &I) -> Result<()>,
 ) -> Result<()> {
+    // A module compiled by a different engine cannot be type-checked against
+    // at all: its type indices index that engine's registry, not ours.
+    ensure!(
+        Engine::same(engine, module.engine()),
+        "cross-`Engine` instantiation is not currently supported"
+    );
+
     let env_module = module.compiled_module().module();
     let expected_len = env_module.imports().count();
     let actual_len = import_args.len();
@@ -979,6 +1026,12 @@ fn typecheck<I>(
     }
     let cx = matching::MatchCx::new(module.engine());
     for ((name, field, mut expected_ty), actual) in env_module.imports().zip(import_args) {
+        if let Some(actual_engine) = actual.engine() {
+            ensure!(
+                Engine::same(engine, actual_engine),
+                "cross-`Engine` instantiation is not currently supported"
+            );
+        }
         expected_ty.canonicalize_for_runtime_usage(&mut |module_index| {
             module.signatures().shared_type(module_index).unwrap()
         });

--- a/crates/wasmtime/src/runtime/linker.rs
+++ b/crates/wasmtime/src/runtime/linker.rs
@@ -76,9 +76,10 @@ use log::warn;
 /// The [`Linker`] type is not compatible with usage between multiple [`Engine`]
 /// values. An [`Engine`] is provided when a [`Linker`] is created and only
 /// stores and items which originate from that [`Engine`] can be used with this
-/// [`Linker`]. If more than one [`Engine`] is used with a [`Linker`] then that
-/// may cause a panic at runtime, similar to how if a [`Func`] is used with the
-/// wrong [`Store`] that can also panic at runtime.
+/// [`Linker`]. Instantiating a [`Module`] from another [`Engine`] returns an
+/// error, and mixing engines in other ways may cause a panic at runtime,
+/// similar to how if a [`Func`] is used with the wrong [`Store`] that can also
+/// panic at runtime.
 ///
 /// [`Store`]: crate::Store
 /// [`Global`]: crate::Global
@@ -114,7 +115,13 @@ struct ImportKey {
 
 #[derive(Clone)]
 pub(crate) enum Definition {
-    Extern(Extern, DefinitionType),
+    Extern {
+        item: Extern,
+        ty: DefinitionType,
+        /// The engine of the store that `item` was taken from, which is the
+        /// engine that assigned any type indices within `ty`.
+        engine: Engine,
+    },
     HostFunc(Arc<HostFunc>),
 }
 
@@ -1196,6 +1203,10 @@ impl<T> Linker<T> {
         module: &Module,
         store: Option<&StoreOpaque>,
     ) -> Result<InstancePre<T>> {
+        ensure!(
+            Engine::same(&self.engine, module.engine()),
+            "cross-`Engine` instantiation is not currently supported"
+        );
         let mut imports = module
             .imports()
             .map(|import| self._get_by_import(&import))
@@ -1206,7 +1217,7 @@ impl<T> Linker<T> {
                 import.update_size(store);
             }
         }
-        unsafe { InstancePre::new(module, imports) }
+        unsafe { InstancePre::new(&self.engine, module, imports) }
     }
 
     /// Returns an iterator over all items defined in this `Linker`, in
@@ -1337,13 +1348,26 @@ impl<T> Default for Linker<T> {
 impl Definition {
     fn new(store: &StoreOpaque, item: Extern) -> Definition {
         let ty = DefinitionType::from(store, &item);
-        Definition::Extern(item, ty)
+        Definition::Extern {
+            item,
+            ty,
+            engine: store.engine().clone(),
+        }
     }
 
     pub(crate) fn ty(&self) -> DefinitionType {
         match self {
-            Definition::Extern(_, ty) => ty.clone(),
+            Definition::Extern { ty, .. } => ty.clone(),
             Definition::HostFunc(func) => DefinitionType::Func(func.sig_index()),
+        }
+    }
+
+    /// The engine that assigned the type indices within this definition's
+    /// [`Definition::ty`].
+    pub(crate) fn engine(&self) -> &Engine {
+        match self {
+            Definition::Extern { engine, .. } => engine,
+            Definition::HostFunc(func) => func.engine(),
         }
     }
 
@@ -1352,27 +1376,39 @@ impl Definition {
     /// `HostFunc` matches the `T` on the store.
     pub(crate) unsafe fn to_extern(&self, store: &mut StoreOpaque) -> Extern {
         match self {
-            Definition::Extern(e, _) => e.clone(),
+            Definition::Extern { item, .. } => item.clone(),
             Definition::HostFunc(func) => func.to_func(store).into(),
         }
     }
 
     pub(crate) fn comes_from_same_store(&self, store: &StoreOpaque) -> bool {
         match self {
-            Definition::Extern(e, _) => e.comes_from_same_store(store),
+            Definition::Extern { item, .. } => item.comes_from_same_store(store),
             Definition::HostFunc(_func) => true,
         }
     }
 
     fn update_size(&mut self, store: &StoreOpaque) {
         match self {
-            Definition::Extern(Extern::Memory(m), DefinitionType::Memory(_, size)) => {
+            Definition::Extern {
+                item: Extern::Memory(m),
+                ty: DefinitionType::Memory(_, size),
+                ..
+            } => {
                 *size = m.internal_size(store);
             }
-            Definition::Extern(Extern::SharedMemory(m), DefinitionType::Memory(_, size)) => {
+            Definition::Extern {
+                item: Extern::SharedMemory(m),
+                ty: DefinitionType::Memory(_, size),
+                ..
+            } => {
                 *size = m.size();
             }
-            Definition::Extern(Extern::Table(m), DefinitionType::Table(_, size)) => {
+            Definition::Extern {
+                item: Extern::Table(m),
+                ty: DefinitionType::Table(_, size),
+                ..
+            } => {
                 *size = m.internal_size(store);
             }
             _ => {}

--- a/crates/wasmtime/src/runtime/module/registry.rs
+++ b/crates/wasmtime/src/runtime/module/registry.rs
@@ -6,7 +6,7 @@ use crate::component::Component;
 use crate::prelude::*;
 use crate::runtime::vm::VMWasmCallFunction;
 use crate::sync::{OnceLock, RwLock};
-use crate::{code_memory::CodeMemory, FrameInfo, Module};
+use crate::{code_memory::CodeMemory, Engine, FrameInfo, Module};
 use alloc::collections::btree_map::{BTreeMap, Entry};
 use alloc::sync::Arc;
 use core::ptr::NonNull;
@@ -40,6 +40,45 @@ struct LoadedCode {
     /// Modules found within `self.code`, keyed by start address here of the
     /// address of the first function in the module.
     modules: BTreeMap<usize, Module>,
+}
+
+/// Either of the two kinds of thing that can be registered with a
+/// `ModuleRegistry`.
+enum ModuleOrComponent<'a> {
+    Module(&'a Module),
+    #[cfg(feature = "component-model")]
+    Component(&'a Component),
+}
+
+impl<'a> ModuleOrComponent<'a> {
+    /// The engine this was compiled by.
+    fn engine(&self) -> &'a Engine {
+        match self {
+            ModuleOrComponent::Module(m) => m.engine(),
+            #[cfg(feature = "component-model")]
+            ModuleOrComponent::Component(c) => c.engine(),
+        }
+    }
+
+    fn code_object(&self) -> &'a Arc<CodeObject> {
+        match self {
+            ModuleOrComponent::Module(m) => m.code_object(),
+            #[cfg(feature = "component-model")]
+            ModuleOrComponent::Component(c) => c.code_object(),
+        }
+    }
+
+    /// The `Module` to record in the registry, if any.
+    ///
+    /// Components do not have one: their code object holds the text of every
+    /// core module inside them, but none of those are registered individually.
+    fn module(&self) -> Option<&'a Module> {
+        match self {
+            ModuleOrComponent::Module(m) => Some(m),
+            #[cfg(feature = "component-model")]
+            ModuleOrComponent::Component(_) => None,
+        }
+    }
 }
 
 /// An identifier of a module that has previously been inserted into a
@@ -93,21 +132,42 @@ impl ModuleRegistry {
     }
 
     /// Registers a new module with the registry.
-    pub fn register_module(&mut self, module: &Module) -> RegisteredModuleId {
-        self.register(module.code_object(), Some(module)).unwrap()
+    ///
+    /// The `engine` must be the engine of the store that owns this registry.
+    pub fn register_module(
+        &mut self,
+        module: &Module,
+        engine: &Engine,
+    ) -> Result<RegisteredModuleId> {
+        Ok(self
+            .register(ModuleOrComponent::Module(module), engine)?
+            .unwrap())
     }
 
+    /// Registers a new component with the registry.
+    ///
+    /// The `engine` must be the engine of the store that owns this registry.
     #[cfg(feature = "component-model")]
-    pub fn register_component(&mut self, component: &Component) {
-        self.register(component.code_object(), None);
+    pub fn register_component(&mut self, component: &Component, engine: &Engine) -> Result<()> {
+        self.register(ModuleOrComponent::Component(component), engine)?;
+        Ok(())
     }
 
-    /// Registers a new module with the registry.
+    /// Registers a new module or component with the registry.
     fn register(
         &mut self,
-        code: &Arc<CodeObject>,
-        module: Option<&Module>,
-    ) -> Option<RegisteredModuleId> {
+        module_or_component: ModuleOrComponent<'_>,
+        engine: &Engine,
+    ) -> Result<Option<RegisteredModuleId>> {
+        // Nothing below here may run for a foreign module or component: the
+        // type indices it carries mean something else entirely in this engine.
+        ensure!(
+            Engine::same(engine, module_or_component.engine()),
+            "cross-`Engine` usage is not supported"
+        );
+
+        let module = module_or_component.module();
+        let code = module_or_component.code_object();
         let text = code.code_memory().text();
 
         // If there's not actually any functions in this module then we may
@@ -117,11 +177,11 @@ impl ModuleRegistry {
         // module in the future. For that reason we continue to register empty
         // modules and retain them.
         if text.is_empty() {
-            return module.map(|module| {
+            return Ok(module.map(|module| {
                 let id = RegisteredModuleId::WithoutCode(self.modules_without_code.len());
                 self.modules_without_code.push(module.clone());
                 id
-            });
+            }));
         }
 
         // The module code range is exclusive for end, so make it inclusive as
@@ -139,7 +199,7 @@ impl ModuleRegistry {
             if let Some(module) = module {
                 prev.push_module(module);
             }
-            return id;
+            return Ok(id);
         }
 
         // Assert that this module's code doesn't collide with any other
@@ -160,7 +220,7 @@ impl ModuleRegistry {
         }
         let prev = self.loaded_code.insert(end_addr, (start_addr, item));
         assert!(prev.is_none());
-        id
+        Ok(id)
     }
 
     /// Fetches frame information about a program counter in a backtrace.

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -1312,9 +1312,11 @@ impl StoreOpaque {
         &self.modules
     }
 
+    /// Get this store's module registry along with the engine that everything
+    /// registered in it must have been compiled by.
     #[inline]
-    pub(crate) fn modules_mut(&mut self) -> &mut ModuleRegistry {
-        &mut self.modules
+    pub(crate) fn modules_and_engine_mut(&mut self) -> (&mut ModuleRegistry, &Engine) {
+        (&mut self.modules, &self.engine)
     }
 
     pub(crate) fn func_refs(&mut self) -> &mut FuncRefs {

--- a/tests/all/cross_engine.rs
+++ b/tests/all/cross_engine.rs
@@ -1,0 +1,213 @@
+//! Tests that objects belonging to one `Engine` cannot be admitted into a
+//! `Store` that belongs to a different `Engine`.
+//!
+//! Type indices (`VMSharedTypeIndex`) are unique only within a single
+//! `Engine`. Two engines will happily hand out the same index for two
+//! completely unrelated types. When an object from one engine reaches a store
+//! from another, those numerically-equal-but-semantically-different indices
+//! collide: a host function's `wasm_call` field gets patched with a
+//! Wasm-to-array trampoline compiled for a different signature, so the
+//! trampoline reads and writes the wrong number of `ValRaw` slots in a stack
+//! buffer.
+//!
+//! Every API that lets an object into a store must therefore check that the
+//! object comes from the store's engine.
+
+use crate::ErrorExt;
+use std::sync::{Arc, Mutex};
+use wasmtime::component::{Component, Linker as ComponentLinker};
+use wasmtime::*;
+
+/// The value that [`observe_i64_in_host`] sends from Wasm to the host.
+const SENTINEL: i64 = 0x1122334455667788;
+
+/// A module whose only function type is `(func (param f64))`.
+///
+/// In a freshly created engine that type gets the same `VMSharedTypeIndex` as
+/// the `(func (param i64))` type used by [`observe_i64_in_host`], so if this
+/// module is registered with a store belonging to a different engine then its
+/// trampoline is what the host function ends up calling.
+const COLLIDING_MODULE: &str = r#"(module (func (export "f") (param f64)))"#;
+
+/// [`COLLIDING_MODULE`] wrapped up in a component.
+///
+/// The core module is deliberately left uninstantiated so that instantiating
+/// this component does not itself instantiate any core module.
+const COLLIDING_COMPONENT: &str = r#"
+    (component
+        (core module (func (export "f") (param f64)))
+    )
+"#;
+
+/// Two separate engines that assign the same type indices to different types.
+fn engine_pair() -> (Engine, Engine) {
+    (Engine::default(), Engine::default())
+}
+
+/// A module that passes [`SENTINEL`] to an imported host function.
+const OBSERVER_MODULE: &str = r#"
+    (module
+        (import "" "" (func $host (param i64)))
+        (func (export "go")
+            i64.const 0x1122334455667788
+            call $host))
+"#;
+
+/// Calls a host function that takes an `i64` and returns the value that the
+/// host actually observed, which should always be [`SENTINEL`].
+///
+/// This is the canary for cross-engine corruption: if a foreign module has
+/// been registered with `store`, then filling in this host function's
+/// `VMFuncRef::wasm_call` finds the foreign engine's `(param f64)` trampoline
+/// and the host sees a garbage value instead.
+fn observe_i64_in_host(store: &mut Store<()>) -> Result<i64> {
+    let observed = Arc::new(Mutex::new(0));
+    let host = Func::wrap(&mut *store, {
+        let observed = Arc::clone(&observed);
+        move |x: i64| *observed.lock().unwrap() = x
+    });
+    let engine = store.engine().clone();
+    let module = Module::new(&engine, OBSERVER_MODULE)?;
+    let instance = Instance::new(&mut *store, &module, &[host.into()])?;
+    instance
+        .get_typed_func::<(), ()>(&mut *store, "go")?
+        .call(&mut *store, ())?;
+    let observed = *observed.lock().unwrap();
+    Ok(observed)
+}
+
+/// Asserts that `store` is still usable and that nothing in it confuses one
+/// engine's type indices for another's.
+fn assert_store_is_uncorrupted(store: &mut Store<()>) -> Result<()> {
+    assert_eq!(observe_i64_in_host(store)?, SENTINEL);
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn instance_new_rejects_foreign_module() -> Result<()> {
+    let (a, b) = engine_pair();
+    let mut store = Store::new(&a, ());
+    let foreign = Module::new(&b, COLLIDING_MODULE)?;
+
+    Instance::new(&mut store, &foreign, &[])
+        .unwrap_err()
+        .assert_contains("cross-`Engine`");
+
+    assert_store_is_uncorrupted(&mut store)
+}
+
+/// A foreign module's imports must be rejected as cross-engine rather than
+/// type checked, since type checking would compare this engine's indices
+/// against the foreign engine's.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn instance_new_rejects_foreign_module_with_imports() -> Result<()> {
+    let (a, b) = engine_pair();
+    let mut store = Store::new(&a, ());
+
+    // Register an unrelated type first so that the host function below does not
+    // land on the same index in `a` that the module's imported type lands on in
+    // `b`.
+    let _ = Func::wrap(&mut store, |_: i32| {});
+    let host = Func::wrap(&mut store, |_: i64| {});
+
+    let foreign = Module::new(&b, r#"(module (import "" "" (func (param i64))))"#)?;
+
+    Instance::new(&mut store, &foreign, &[host.into()])
+        .unwrap_err()
+        .assert_contains("cross-`Engine`");
+
+    assert_store_is_uncorrupted(&mut store)
+}
+
+/// A linker and the module it instantiates can belong to the same engine while
+/// an individual item defined in that linker came from a store belonging to a
+/// different one, so each item has to be checked on its own.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn instantiate_pre_rejects_foreign_definition() -> Result<()> {
+    let (a, b) = engine_pair();
+
+    // Register an unrelated type first so that the function below does not land
+    // on the same index in `b` that the module's imported type lands on in `a`.
+    let mut foreign_store = Store::new(&b, ());
+    let _ = Func::wrap(&mut foreign_store, |_: i32| {});
+    let foreign = Func::wrap(&mut foreign_store, |_: f64| {});
+
+    let mut linker = Linker::<()>::new(&a);
+    linker.define(&foreign_store, "", "", foreign)?;
+
+    let module = Module::new(&a, r#"(module (import "" "" (func (param i64))))"#)?;
+
+    linker
+        .instantiate_pre(&module)
+        .err()
+        .expect("should reject an item defined from a different engine's store")
+        .assert_contains("cross-`Engine`");
+
+    let mut store = Store::new(&a, ());
+    assert_store_is_uncorrupted(&mut store)
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn instance_pre_instantiate_rejects_foreign_store() -> Result<()> {
+    let (a, b) = engine_pair();
+    let mut store = Store::new(&a, ());
+    let foreign = Module::new(&b, COLLIDING_MODULE)?;
+    let pre = Linker::<()>::new(&b).instantiate_pre(&foreign)?;
+
+    pre.instantiate(&mut store)
+        .err()
+        .expect("should reject a store from a different engine")
+        .assert_contains("cross-`Engine`");
+
+    assert_store_is_uncorrupted(&mut store)
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn linker_instantiate_pre_rejects_foreign_module() -> Result<()> {
+    let (a, b) = engine_pair();
+    let foreign = Module::new(&b, COLLIDING_MODULE)?;
+
+    Linker::<()>::new(&a)
+        .instantiate_pre(&foreign)
+        .err()
+        .expect("should reject a module from a different engine")
+        .assert_contains("cross-`Engine`");
+
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn component_linker_instantiate_pre_rejects_foreign_component() -> Result<()> {
+    let (a, b) = engine_pair();
+    let foreign = Component::new(&b, COLLIDING_COMPONENT)?;
+
+    ComponentLinker::<()>::new(&a)
+        .instantiate_pre(&foreign)
+        .err()
+        .expect("should reject a component from a different engine")
+        .assert_contains("cross-`Engine`");
+
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn component_instance_pre_instantiate_rejects_foreign_store() -> Result<()> {
+    let (a, b) = engine_pair();
+    let mut store = Store::new(&a, ());
+    let foreign = Component::new(&b, COLLIDING_COMPONENT)?;
+    let pre = ComponentLinker::<()>::new(&b).instantiate_pre(&foreign)?;
+
+    pre.instantiate(&mut store)
+        .err()
+        .expect("should reject a store from a different engine")
+        .assert_contains("cross-`Engine`");
+
+    assert_store_is_uncorrupted(&mut store)
+}

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -6,6 +6,7 @@ mod cli_tests;
 mod code_too_large;
 mod component_model;
 mod coredump;
+mod cross_engine;
 mod debug;
 mod defaults;
 mod epoch_interruption;
@@ -100,4 +101,18 @@ pub(crate) fn small_pool_config() -> wasmtime::PoolingAllocationConfig {
     config.total_stacks(1);
 
     config
+}
+
+trait ErrorExt {
+    fn assert_contains(&self, msg: &str);
+}
+
+impl ErrorExt for wasmtime::Error {
+    fn assert_contains(&self, msg: &str) {
+        if self.chain().any(|e| e.to_string().contains(msg)) {
+            return;
+        }
+
+        panic!("failed to find:\n{msg}\n\nwithin error message:\n{self:?}")
+    }
 }


### PR DESCRIPTION
Changes for today's security release to address https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-hgjw-h833-99q9.