### PR TITLE
Release Wasmtime 46.0.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1409,7 +1409,7 @@ jobs:
       - test_capi
       - test_debug_dwarf
       - test_fuzzing
-      - test_wasi_nn
+      # - test_wasi_nn
       - test_nightly
       - build
       - rustfmt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,7 +296,7 @@ dependencies = [
 
 [[package]]
 name = "byte-array-literals"
-version = "46.0.1"
+version = "46.0.2"
 
 [[package]]
 name = "byteorder"
@@ -708,7 +708,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.133.1"
+version = "0.133.2"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -721,7 +721,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.133.1"
+version = "0.133.2"
 dependencies = [
  "arbitrary",
  "arbtest",
@@ -739,14 +739,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.133.1"
+version = "0.133.2"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.133.1"
+version = "0.133.2"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.133.1"
+version = "0.133.2"
 dependencies = [
  "arbitrary",
  "serde",
@@ -764,7 +764,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.133.1"
+version = "0.133.2"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -800,7 +800,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.133.1"
+version = "0.133.2"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -811,18 +811,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.133.1"
+version = "0.133.2"
 
 [[package]]
 name = "cranelift-control"
-version = "0.133.1"
+version = "0.133.2"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.133.1"
+version = "0.133.2"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -864,7 +864,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.133.1"
+version = "0.133.2"
 dependencies = [
  "cranelift-codegen",
  "env_logger 0.11.5",
@@ -889,7 +889,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.133.1"
+version = "0.133.2"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -903,7 +903,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.133.1"
+version = "0.133.2"
 dependencies = [
  "codespan-reporting",
  "log",
@@ -911,7 +911,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.133.1"
+version = "0.133.2"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -933,7 +933,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.133.1"
+version = "0.133.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.133.1"
+version = "0.133.2"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.133.1"
+version = "0.133.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-reader"
-version = "0.133.1"
+version = "0.133.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -980,7 +980,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.133.1"
+version = "0.133.2"
 dependencies = [
  "clap",
  "cranelift-codegen",
@@ -990,7 +990,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.133.1"
+version = "0.133.2"
 
 [[package]]
 name = "cranelift-tools"
@@ -1252,7 +1252,7 @@ checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "embedding"
-version = "46.0.1"
+version = "46.0.2"
 dependencies = [
  "dlmalloc",
  "raw-cpuid",
@@ -2475,7 +2475,7 @@ dependencies = [
 
 [[package]]
 name = "min-platform-host"
-version = "46.0.1"
+version = "46.0.2"
 dependencies = [
  "libloading",
  "object 0.39.0",
@@ -2947,7 +2947,7 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "46.0.1"
+version = "46.0.2"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2971,7 +2971,7 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "46.0.1"
+version = "46.0.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4287,7 +4287,7 @@ version = "0.1.0"
 
 [[package]]
 name = "verify-component-adapter"
-version = "46.0.1"
+version = "46.0.2"
 dependencies = [
  "anyhow",
  "wasmparser 0.251.0",
@@ -4352,7 +4352,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-common"
-version = "46.0.1"
+version = "46.0.2"
 dependencies = [
  "async-trait",
  "bitflags 2.11.1",
@@ -4392,7 +4392,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter"
-version = "46.0.1"
+version = "46.0.2"
 dependencies = [
  "bitflags 2.11.1",
  "byte-array-literals",
@@ -4713,7 +4713,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "46.0.1"
+version = "46.0.2"
 dependencies = [
  "addr2line 0.26.0",
  "async-trait",
@@ -4775,7 +4775,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-bench-api"
-version = "46.0.1"
+version = "46.0.2"
 dependencies = [
  "cap-std",
  "clap",
@@ -4790,14 +4790,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api"
-version = "46.0.1"
+version = "46.0.2"
 dependencies = [
  "wasmtime-c-api-impl",
 ]
 
 [[package]]
 name = "wasmtime-c-api-impl"
-version = "46.0.1"
+version = "46.0.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4817,7 +4817,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "46.0.1"
+version = "46.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4898,7 +4898,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "46.0.1"
+version = "46.0.2"
 dependencies = [
  "clap",
  "file-per-thread-logger",
@@ -4912,7 +4912,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "46.0.1"
+version = "46.0.2"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -5029,7 +5029,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-c-api-macros"
-version = "46.0.1"
+version = "46.0.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5037,7 +5037,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "46.0.1"
+version = "46.0.2"
 dependencies = [
  "base64",
  "directories-next",
@@ -5058,7 +5058,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "46.0.1"
+version = "46.0.2"
 dependencies = [
  "anyhow",
  "component-macro-test-helpers",
@@ -5078,11 +5078,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "46.0.1"
+version = "46.0.2"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "46.0.1"
+version = "46.0.2"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.0",
@@ -5092,7 +5092,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "46.0.1"
+version = "46.0.2"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -5117,7 +5117,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-debugger"
-version = "46.0.1"
+version = "46.0.2"
 dependencies = [
  "async-trait",
  "env_logger 0.11.5",
@@ -5130,7 +5130,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-explorer"
-version = "46.0.1"
+version = "46.0.2"
 dependencies = [
  "capstone",
  "serde",
@@ -5144,7 +5144,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "46.0.1"
+version = "46.0.2"
 dependencies = [
  "backtrace",
  "cc",
@@ -5158,7 +5158,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-gdbstub-component"
-version = "46.0.1"
+version = "46.0.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -5174,11 +5174,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-gdbstub-component-artifact"
-version = "46.0.1"
+version = "46.0.2"
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "46.0.1"
+version = "46.0.2"
 dependencies = [
  "cc",
  "object 0.39.0",
@@ -5188,7 +5188,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "46.0.1"
+version = "46.0.2"
 dependencies = [
  "cfg-if",
  "libc",
@@ -5198,7 +5198,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "46.0.1"
+version = "46.0.2"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -5209,7 +5209,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "46.0.1"
+version = "46.0.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5218,7 +5218,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "46.0.1"
+version = "46.0.2"
 dependencies = [
  "cranelift-codegen",
  "gimli 0.33.0",
@@ -5233,7 +5233,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "46.0.1"
+version = "46.0.2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
@@ -5244,7 +5244,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wmemcheck"
-version = "46.0.1"
+version = "46.0.2"
 
 [[package]]
 name = "wasmtime-test-macros"
@@ -5259,7 +5259,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-test-util"
-version = "46.0.1"
+version = "46.0.2"
 dependencies = [
  "arbitrary",
  "arbtest",
@@ -5282,7 +5282,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "46.0.1"
+version = "46.0.2"
 dependencies = [
  "async-trait",
  "bitflags 2.11.1",
@@ -5315,7 +5315,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-config"
-version = "46.0.1"
+version = "46.0.2"
 dependencies = [
  "test-programs-artifacts",
  "tokio",
@@ -5325,7 +5325,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "46.0.1"
+version = "46.0.2"
 dependencies = [
  "async-trait",
  "base64",
@@ -5357,7 +5357,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "46.0.1"
+version = "46.0.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5368,7 +5368,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-keyvalue"
-version = "46.0.1"
+version = "46.0.2"
 dependencies = [
  "test-programs-artifacts",
  "tokio",
@@ -5378,7 +5378,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "46.0.1"
+version = "46.0.2"
 dependencies = [
  "cap-std",
  "libtest-mimic",
@@ -5398,7 +5398,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-threads"
-version = "46.0.1"
+version = "46.0.2"
 dependencies = [
  "log",
  "rand 0.10.1",
@@ -5409,7 +5409,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-tls"
-version = "46.0.1"
+version = "46.0.2"
 dependencies = [
  "bytes",
  "cfg-if",
@@ -5430,7 +5430,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "46.0.1"
+version = "46.0.2"
 dependencies = [
  "json-from-wast",
  "log",
@@ -5444,7 +5444,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wizer"
-version = "46.0.1"
+version = "46.0.2"
 dependencies = [
  "clap",
  "criterion",
@@ -5525,7 +5525,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "46.0.1"
+version = "46.0.2"
 dependencies = [
  "bitflags 2.11.1",
  "proptest",
@@ -5541,7 +5541,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "46.0.1"
+version = "46.0.2"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -5553,7 +5553,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "46.0.1"
+version = "46.0.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5608,7 +5608,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "46.0.1"
+version = "46.0.2"
 dependencies = [
  "cranelift-assembler-x64",
  "cranelift-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,7 +204,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "46.0.1"
+version = "46.0.2"
 authors = ["The Wasmtime Project Developers"]
 edition = "2024"
 # Wasmtime's current policy is that this number can be no larger than the
@@ -265,18 +265,18 @@ extra_unused_type_parameters = 'warn'
 # tooling but aren't intended to be widely depended on.
 #
 # All of these crates are supported though in the sense that
-wasmtime = { path = "crates/wasmtime", version = "46.0.1", default-features = false }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=46.0.1" }
-wasmtime-environ = { path = "crates/environ", version = "=46.0.1" }
-wasmtime-wasi = { path = "crates/wasi", version = "46.0.1", default-features = false }
-wasmtime-wasi-io = { path = "crates/wasi-io", version = "46.0.1", default-features = false }
-wasmtime-wasi-http = { path = "crates/wasi-http", version = "46.0.1", default-features = false }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "46.0.1" }
-wasmtime-wasi-config = { path = "crates/wasi-config", version = "46.0.1" }
-wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "46.0.1" }
-wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "46.0.1" }
-wasmtime-wasi-tls = { path = "crates/wasi-tls", version = "46.0.1" }
-wasmtime-wast = { path = "crates/wast", version = "=46.0.1" }
+wasmtime = { path = "crates/wasmtime", version = "46.0.2", default-features = false }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=46.0.2" }
+wasmtime-environ = { path = "crates/environ", version = "=46.0.2" }
+wasmtime-wasi = { path = "crates/wasi", version = "46.0.2", default-features = false }
+wasmtime-wasi-io = { path = "crates/wasi-io", version = "46.0.2", default-features = false }
+wasmtime-wasi-http = { path = "crates/wasi-http", version = "46.0.2", default-features = false }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "46.0.2" }
+wasmtime-wasi-config = { path = "crates/wasi-config", version = "46.0.2" }
+wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "46.0.2" }
+wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "46.0.2" }
+wasmtime-wasi-tls = { path = "crates/wasi-tls", version = "46.0.2" }
+wasmtime-wast = { path = "crates/wast", version = "=46.0.2" }
 
 # Internal Wasmtime-specific crates.
 #
@@ -285,55 +285,55 @@ wasmtime-wast = { path = "crates/wast", version = "=46.0.1" }
 # that these are internal unsupported crates for external use. These exist as
 # part of the project organization of other public crates in Wasmtime and are
 # otherwise not supported in terms of CVEs for example.
-wasmtime-core = { path = "crates/core", version = "=46.0.1", package = 'wasmtime-internal-core' }
-wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=46.0.1", package = 'wasmtime-internal-wmemcheck' }
-wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=46.0.1", package = 'wasmtime-internal-c-api-macros' }
-wasmtime-cache = { path = "crates/cache", version = "=46.0.1", package = 'wasmtime-internal-cache' }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=46.0.1", package = 'wasmtime-internal-cranelift' }
-wasmtime-winch = { path = "crates/winch", version = "=46.0.1", package = 'wasmtime-internal-winch'  }
-wasmtime-explorer = { path = "crates/explorer", version = "=46.0.1", package = 'wasmtime-internal-explorer'  }
-wasmtime-fiber = { path = "crates/fiber", version = "=46.0.1", package = 'wasmtime-internal-fiber' }
-wasmtime-jit-debug = { path = "crates/jit-debug", version = "=46.0.1", package = 'wasmtime-internal-jit-debug' }
-wasmtime-component-util = { path = "crates/component-util", version = "=46.0.1", package = 'wasmtime-internal-component-util' }
-wasmtime-component-macro = { path = "crates/component-macro", version = "=46.0.1", package = 'wasmtime-internal-component-macro' }
-wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=46.0.1", package = 'wasmtime-internal-versioned-export-macros' }
-wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=46.0.1", package = 'wasmtime-internal-jit-icache-coherence' }
-wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=46.0.1", package = 'wasmtime-internal-wit-bindgen' }
-wasmtime-unwinder = { path = "crates/unwinder", version = "=46.0.1", package = 'wasmtime-internal-unwinder' }
-wasmtime-debugger = { path = "crates/debugger", version = "=46.0.1", package = "wasmtime-internal-debugger" }
-gdbstub-component-artifact = { path = "crates/gdbstub-component/artifact", version = "=46.0.1", package = "wasmtime-internal-gdbstub-component-artifact" }
-wasmtime-wizer = { path = "crates/wizer", version = "46.0.1" }
+wasmtime-core = { path = "crates/core", version = "=46.0.2", package = 'wasmtime-internal-core' }
+wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=46.0.2", package = 'wasmtime-internal-wmemcheck' }
+wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=46.0.2", package = 'wasmtime-internal-c-api-macros' }
+wasmtime-cache = { path = "crates/cache", version = "=46.0.2", package = 'wasmtime-internal-cache' }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=46.0.2", package = 'wasmtime-internal-cranelift' }
+wasmtime-winch = { path = "crates/winch", version = "=46.0.2", package = 'wasmtime-internal-winch'  }
+wasmtime-explorer = { path = "crates/explorer", version = "=46.0.2", package = 'wasmtime-internal-explorer'  }
+wasmtime-fiber = { path = "crates/fiber", version = "=46.0.2", package = 'wasmtime-internal-fiber' }
+wasmtime-jit-debug = { path = "crates/jit-debug", version = "=46.0.2", package = 'wasmtime-internal-jit-debug' }
+wasmtime-component-util = { path = "crates/component-util", version = "=46.0.2", package = 'wasmtime-internal-component-util' }
+wasmtime-component-macro = { path = "crates/component-macro", version = "=46.0.2", package = 'wasmtime-internal-component-macro' }
+wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=46.0.2", package = 'wasmtime-internal-versioned-export-macros' }
+wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=46.0.2", package = 'wasmtime-internal-jit-icache-coherence' }
+wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=46.0.2", package = 'wasmtime-internal-wit-bindgen' }
+wasmtime-unwinder = { path = "crates/unwinder", version = "=46.0.2", package = 'wasmtime-internal-unwinder' }
+wasmtime-debugger = { path = "crates/debugger", version = "=46.0.2", package = "wasmtime-internal-debugger" }
+gdbstub-component-artifact = { path = "crates/gdbstub-component/artifact", version = "=46.0.2", package = "wasmtime-internal-gdbstub-component-artifact" }
+wasmtime-wizer = { path = "crates/wizer", version = "46.0.2" }
 
 # Miscellaneous crates without a `wasmtime-*` prefix in their name but still
 # used in the `wasmtime-*` family of crates depending on various features/etc.
-wiggle = { path = "crates/wiggle", version = "=46.0.1", default-features = false }
-wiggle-macro = { path = "crates/wiggle/macro", version = "=46.0.1" }
-wiggle-generate = { path = "crates/wiggle/generate", version = "=46.0.1" }
-wasi-common = { path = "crates/wasi-common", version = "=46.0.1", default-features = false }
-pulley-interpreter = { path = 'pulley', version = "=46.0.1" }
-pulley-macros = { path = 'pulley/macros', version = "=46.0.1" }
+wiggle = { path = "crates/wiggle", version = "=46.0.2", default-features = false }
+wiggle-macro = { path = "crates/wiggle/macro", version = "=46.0.2" }
+wiggle-generate = { path = "crates/wiggle/generate", version = "=46.0.2" }
+wasi-common = { path = "crates/wasi-common", version = "=46.0.2", default-features = false }
+pulley-interpreter = { path = 'pulley', version = "=46.0.2" }
+pulley-macros = { path = 'pulley/macros', version = "=46.0.2" }
 
 # Cranelift crates in this workspace
-cranelift-assembler-x64 = { path = "cranelift/assembler-x64", version = "0.133.1" }
-cranelift-codegen = { path = "cranelift/codegen", version = "0.133.1", default-features = false, features = ["unwind"] }
-cranelift-frontend = { path = "cranelift/frontend", version = "0.133.1" }
-cranelift-entity = { path = "cranelift/entity", version = "0.133.1" }
-cranelift-native = { path = "cranelift/native", version = "0.133.1" }
-cranelift-module = { path = "cranelift/module", version = "0.133.1" }
-cranelift-interpreter = { path = "cranelift/interpreter", version = "0.133.1" }
-cranelift-reader = { path = "cranelift/reader", version = "0.133.1" }
+cranelift-assembler-x64 = { path = "cranelift/assembler-x64", version = "0.133.2" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.133.2", default-features = false, features = ["unwind"] }
+cranelift-frontend = { path = "cranelift/frontend", version = "0.133.2" }
+cranelift-entity = { path = "cranelift/entity", version = "0.133.2" }
+cranelift-native = { path = "cranelift/native", version = "0.133.2" }
+cranelift-module = { path = "cranelift/module", version = "0.133.2" }
+cranelift-interpreter = { path = "cranelift/interpreter", version = "0.133.2" }
+cranelift-reader = { path = "cranelift/reader", version = "0.133.2" }
 cranelift-filetests = { path = "cranelift/filetests" }
-cranelift-object = { path = "cranelift/object", version = "0.133.1" }
-cranelift-jit = { path = "cranelift/jit", version = "0.133.1" }
+cranelift-object = { path = "cranelift/object", version = "0.133.2" }
+cranelift-jit = { path = "cranelift/jit", version = "0.133.2" }
 cranelift-fuzzgen = { path = "cranelift/fuzzgen" }
-cranelift-bforest = { path = "cranelift/bforest", version = "0.133.1" }
-cranelift-bitset = { path = "cranelift/bitset", version = "0.133.1" }
-cranelift-control = { path = "cranelift/control", version = "0.133.1", default-features = false }
-cranelift-srcgen = { path = "cranelift/srcgen", version = "0.133.1" }
-cranelift = { path = "cranelift/umbrella", version = "0.133.1" }
+cranelift-bforest = { path = "cranelift/bforest", version = "0.133.2" }
+cranelift-bitset = { path = "cranelift/bitset", version = "0.133.2" }
+cranelift-control = { path = "cranelift/control", version = "0.133.2", default-features = false }
+cranelift-srcgen = { path = "cranelift/srcgen", version = "0.133.2" }
+cranelift = { path = "cranelift/umbrella", version = "0.133.2" }
 
 # Winch crates in this workspace.
-winch-codegen = { path = "winch/codegen", version = "=46.0.1" }
+winch-codegen = { path = "winch/codegen", version = "=46.0.2" }
 
 # Internal crates not published to crates.io used in testing, builds, etc
 wasi-preview1-component-adapter = { path = "crates/wasi-preview1-component-adapter" }

--- a/cranelift/assembler-x64/Cargo.toml
+++ b/cranelift/assembler-x64/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-assembler-x64"
 description = "A Cranelift-specific x64 assembler"
-version = "0.133.1"
+version = "0.133.2"
 license = "Apache-2.0 WITH LLVM-exception"
 edition.workspace = true
 rust-version.workspace = true
@@ -16,7 +16,7 @@ arbtest = { workspace = true }
 capstone = { workspace = true }
 
 [build-dependencies]
-cranelift-assembler-x64-meta = { path = "meta", version = "0.133.1" }
+cranelift-assembler-x64-meta = { path = "meta", version = "0.133.2" }
 
 [lints]
 workspace = true

--- a/cranelift/assembler-x64/meta/Cargo.toml
+++ b/cranelift/assembler-x64/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-assembler-x64-meta"
 description = "Generate a Cranelift-specific assembler for x64 instructions"
-version = "0.133.1"
+version = "0.133.2"
 license = "Apache-2.0 WITH LLVM-exception"
 edition.workspace = true
 rust-version.workspace = true

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.133.1"
+version = "0.133.2"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"

--- a/cranelift/bitset/Cargo.toml
+++ b/cranelift/bitset/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bitset"
-version = "0.133.1"
+version = "0.133.2"
 description = "Various bitset stuff for use inside Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bitset"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.133.1"
+version = "0.133.2"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -25,7 +25,7 @@ anyhow = { workspace = true, optional = true, features = ['std'] }
 bumpalo = { workspace = true }
 capstone = { workspace = true, optional = true }
 cranelift-assembler-x64 = { workspace = true }
-cranelift-codegen-shared = { path = "./shared", version = "0.133.1" }
+cranelift-codegen-shared = { path = "./shared", version = "0.133.2" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
 cranelift-bitset = { workspace = true }
@@ -57,8 +57,8 @@ env_logger = { workspace = true }
 proptest = { workspace = true }
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.133.1" }
-cranelift-isle = { path = "../isle/isle", version = "=0.133.1" }
+cranelift-codegen-meta = { path = "meta", version = "0.133.2" }
+cranelift-isle = { path = "../isle/isle", version = "=0.133.2" }
 
 [features]
 default = ["std", "unwind", "host-arch", "timing"]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.133.1"
+version = "0.133.2"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -17,8 +17,8 @@ rustdoc-args = ["--document-private-items"]
 
 [dependencies]
 cranelift-srcgen = { workspace = true }
-cranelift-assembler-x64-meta = { path = "../../assembler-x64/meta", version = "0.133.1" }
-cranelift-codegen-shared = { path = "../shared", version = "0.133.1" }
+cranelift-assembler-x64-meta = { path = "../../assembler-x64/meta", version = "0.133.2" }
+cranelift-codegen-shared = { path = "../shared", version = "0.133.2" }
 pulley-interpreter = { workspace = true, optional = true }
 heck = "0.5.0"
 

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.133.1"
+version = "0.133.2"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/control/Cargo.toml
+++ b/cranelift/control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-control"
-version = "0.133.1"
+version = "0.133.2"
 description = "White-box fuzz testing framework"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.133.1"
+version = "0.133.2"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.133.1"
+version = "0.133.2"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.133.1"
+version = "0.133.2"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
-version = "0.133.1"
+version = "0.133.2"
 
 [lints]
 workspace = true

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.133.1"
+version = "0.133.2"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.133.1"
+version = "0.133.2"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.133.1"
+version = "0.133.2"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.133.1"
+version = "0.133.2"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.133.1"
+version = "0.133.2"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.133.1"
+version = "0.133.2"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/srcgen/Cargo.toml
+++ b/cranelift/srcgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-srcgen"
-version = "0.133.1"
+version = "0.133.2"
 authors = ["The Wasmtime Project Developers"]
 description = "Helper functions for generating Rust and ISLE files"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.133.1"
+version = "0.133.2"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -229,7 +229,7 @@
 /**
  * \brief Wasmtime version string.
  */
-#define WASMTIME_VERSION "46.0.1"
+#define WASMTIME_VERSION "46.0.2"
 /**
  * \brief Wasmtime major version number.
  */
@@ -241,6 +241,6 @@
 /**
  * \brief Wasmtime patch version number.
  */
-#define WASMTIME_VERSION_PATCH 1
+#define WASMTIME_VERSION_PATCH 2
 
 #endif // WASMTIME_API_H

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -13,6 +13,10 @@ audited_as = "0.131.1"
 version = "0.133.1"
 audited_as = "0.133.0"
 
+[[unpublished.cranelift]]
+version = "0.133.2"
+audited_as = "0.133.1"
+
 [[unpublished.cranelift-assembler-x64]]
 version = "0.132.0"
 audited_as = "0.130.1"
@@ -24,6 +28,10 @@ audited_as = "0.131.1"
 [[unpublished.cranelift-assembler-x64]]
 version = "0.133.1"
 audited_as = "0.133.0"
+
+[[unpublished.cranelift-assembler-x64]]
+version = "0.133.2"
+audited_as = "0.133.1"
 
 [[unpublished.cranelift-assembler-x64-meta]]
 version = "0.132.0"
@@ -37,6 +45,10 @@ audited_as = "0.131.1"
 version = "0.133.1"
 audited_as = "0.133.0"
 
+[[unpublished.cranelift-assembler-x64-meta]]
+version = "0.133.2"
+audited_as = "0.133.1"
+
 [[unpublished.cranelift-bforest]]
 version = "0.132.0"
 audited_as = "0.130.1"
@@ -48,6 +60,10 @@ audited_as = "0.131.1"
 [[unpublished.cranelift-bforest]]
 version = "0.133.1"
 audited_as = "0.133.0"
+
+[[unpublished.cranelift-bforest]]
+version = "0.133.2"
+audited_as = "0.133.1"
 
 [[unpublished.cranelift-bitset]]
 version = "0.132.0"
@@ -61,6 +77,10 @@ audited_as = "0.131.1"
 version = "0.133.1"
 audited_as = "0.133.0"
 
+[[unpublished.cranelift-bitset]]
+version = "0.133.2"
+audited_as = "0.133.1"
+
 [[unpublished.cranelift-codegen]]
 version = "0.132.0"
 audited_as = "0.130.1"
@@ -72,6 +92,10 @@ audited_as = "0.131.1"
 [[unpublished.cranelift-codegen]]
 version = "0.133.1"
 audited_as = "0.133.0"
+
+[[unpublished.cranelift-codegen]]
+version = "0.133.2"
+audited_as = "0.133.1"
 
 [[unpublished.cranelift-codegen-meta]]
 version = "0.132.0"
@@ -85,6 +109,10 @@ audited_as = "0.131.1"
 version = "0.133.1"
 audited_as = "0.133.0"
 
+[[unpublished.cranelift-codegen-meta]]
+version = "0.133.2"
+audited_as = "0.133.1"
+
 [[unpublished.cranelift-codegen-shared]]
 version = "0.132.0"
 audited_as = "0.130.1"
@@ -96,6 +124,10 @@ audited_as = "0.131.1"
 [[unpublished.cranelift-codegen-shared]]
 version = "0.133.1"
 audited_as = "0.133.0"
+
+[[unpublished.cranelift-codegen-shared]]
+version = "0.133.2"
+audited_as = "0.133.1"
 
 [[unpublished.cranelift-control]]
 version = "0.132.0"
@@ -109,6 +141,10 @@ audited_as = "0.131.1"
 version = "0.133.1"
 audited_as = "0.133.0"
 
+[[unpublished.cranelift-control]]
+version = "0.133.2"
+audited_as = "0.133.1"
+
 [[unpublished.cranelift-entity]]
 version = "0.132.0"
 audited_as = "0.130.1"
@@ -120,6 +156,10 @@ audited_as = "0.131.1"
 [[unpublished.cranelift-entity]]
 version = "0.133.1"
 audited_as = "0.133.0"
+
+[[unpublished.cranelift-entity]]
+version = "0.133.2"
+audited_as = "0.133.1"
 
 [[unpublished.cranelift-frontend]]
 version = "0.132.0"
@@ -133,6 +173,10 @@ audited_as = "0.131.1"
 version = "0.133.1"
 audited_as = "0.133.0"
 
+[[unpublished.cranelift-frontend]]
+version = "0.133.2"
+audited_as = "0.133.1"
+
 [[unpublished.cranelift-interpreter]]
 version = "0.132.0"
 audited_as = "0.130.1"
@@ -144,6 +188,10 @@ audited_as = "0.131.1"
 [[unpublished.cranelift-interpreter]]
 version = "0.133.1"
 audited_as = "0.133.0"
+
+[[unpublished.cranelift-interpreter]]
+version = "0.133.2"
+audited_as = "0.133.1"
 
 [[unpublished.cranelift-isle]]
 version = "0.132.0"
@@ -157,6 +205,10 @@ audited_as = "0.131.1"
 version = "0.133.1"
 audited_as = "0.133.0"
 
+[[unpublished.cranelift-isle]]
+version = "0.133.2"
+audited_as = "0.133.1"
+
 [[unpublished.cranelift-jit]]
 version = "0.132.0"
 audited_as = "0.130.1"
@@ -168,6 +220,10 @@ audited_as = "0.131.1"
 [[unpublished.cranelift-jit]]
 version = "0.133.1"
 audited_as = "0.133.0"
+
+[[unpublished.cranelift-jit]]
+version = "0.133.2"
+audited_as = "0.133.1"
 
 [[unpublished.cranelift-module]]
 version = "0.132.0"
@@ -181,6 +237,10 @@ audited_as = "0.131.1"
 version = "0.133.1"
 audited_as = "0.133.0"
 
+[[unpublished.cranelift-module]]
+version = "0.133.2"
+audited_as = "0.133.1"
+
 [[unpublished.cranelift-native]]
 version = "0.132.0"
 audited_as = "0.130.1"
@@ -192,6 +252,10 @@ audited_as = "0.131.1"
 [[unpublished.cranelift-native]]
 version = "0.133.1"
 audited_as = "0.133.0"
+
+[[unpublished.cranelift-native]]
+version = "0.133.2"
+audited_as = "0.133.1"
 
 [[unpublished.cranelift-object]]
 version = "0.132.0"
@@ -205,6 +269,10 @@ audited_as = "0.131.1"
 version = "0.133.1"
 audited_as = "0.133.0"
 
+[[unpublished.cranelift-object]]
+version = "0.133.2"
+audited_as = "0.133.1"
+
 [[unpublished.cranelift-reader]]
 version = "0.132.0"
 audited_as = "0.130.1"
@@ -216,6 +284,10 @@ audited_as = "0.131.1"
 [[unpublished.cranelift-reader]]
 version = "0.133.1"
 audited_as = "0.133.0"
+
+[[unpublished.cranelift-reader]]
+version = "0.133.2"
+audited_as = "0.133.1"
 
 [[unpublished.cranelift-serde]]
 version = "0.132.0"
@@ -229,6 +301,10 @@ audited_as = "0.131.1"
 version = "0.133.1"
 audited_as = "0.133.0"
 
+[[unpublished.cranelift-serde]]
+version = "0.133.2"
+audited_as = "0.133.1"
+
 [[unpublished.cranelift-srcgen]]
 version = "0.132.0"
 audited_as = "0.130.1"
@@ -241,6 +317,10 @@ audited_as = "0.131.1"
 version = "0.133.1"
 audited_as = "0.133.0"
 
+[[unpublished.cranelift-srcgen]]
+version = "0.133.2"
+audited_as = "0.133.1"
+
 [[unpublished.pulley-interpreter]]
 version = "45.0.0"
 audited_as = "43.0.1"
@@ -252,6 +332,10 @@ audited_as = "44.0.1"
 [[unpublished.pulley-interpreter]]
 version = "46.0.1"
 audited_as = "46.0.0"
+
+[[unpublished.pulley-interpreter]]
+version = "46.0.2"
+audited_as = "46.0.1"
 
 [[unpublished.pulley-macros]]
 version = "45.0.0"
@@ -265,6 +349,10 @@ audited_as = "44.0.1"
 version = "46.0.1"
 audited_as = "46.0.0"
 
+[[unpublished.pulley-macros]]
+version = "46.0.2"
+audited_as = "46.0.1"
+
 [[unpublished.wasi-common]]
 version = "45.0.0"
 audited_as = "43.0.1"
@@ -276,6 +364,10 @@ audited_as = "44.0.1"
 [[unpublished.wasi-common]]
 version = "46.0.1"
 audited_as = "46.0.0"
+
+[[unpublished.wasi-common]]
+version = "46.0.2"
+audited_as = "46.0.1"
 
 [[unpublished.wasmtime]]
 version = "45.0.0"
@@ -289,6 +381,10 @@ audited_as = "44.0.1"
 version = "46.0.1"
 audited_as = "46.0.0"
 
+[[unpublished.wasmtime]]
+version = "46.0.2"
+audited_as = "46.0.1"
+
 [[unpublished.wasmtime-cli]]
 version = "45.0.0"
 audited_as = "43.0.1"
@@ -300,6 +396,10 @@ audited_as = "44.0.1"
 [[unpublished.wasmtime-cli]]
 version = "46.0.1"
 audited_as = "46.0.0"
+
+[[unpublished.wasmtime-cli]]
+version = "46.0.2"
+audited_as = "46.0.1"
 
 [[unpublished.wasmtime-cli-flags]]
 version = "45.0.0"
@@ -313,6 +413,10 @@ audited_as = "44.0.1"
 version = "46.0.1"
 audited_as = "46.0.0"
 
+[[unpublished.wasmtime-cli-flags]]
+version = "46.0.2"
+audited_as = "46.0.1"
+
 [[unpublished.wasmtime-environ]]
 version = "45.0.0"
 audited_as = "43.0.1"
@@ -324,6 +428,10 @@ audited_as = "44.0.1"
 [[unpublished.wasmtime-environ]]
 version = "46.0.1"
 audited_as = "46.0.0"
+
+[[unpublished.wasmtime-environ]]
+version = "46.0.2"
+audited_as = "46.0.1"
 
 [[unpublished.wasmtime-internal-c-api-macros]]
 version = "45.0.0"
@@ -337,6 +445,10 @@ audited_as = "44.0.1"
 version = "46.0.1"
 audited_as = "46.0.0"
 
+[[unpublished.wasmtime-internal-c-api-macros]]
+version = "46.0.2"
+audited_as = "46.0.1"
+
 [[unpublished.wasmtime-internal-cache]]
 version = "45.0.0"
 audited_as = "43.0.1"
@@ -348,6 +460,10 @@ audited_as = "44.0.1"
 [[unpublished.wasmtime-internal-cache]]
 version = "46.0.1"
 audited_as = "46.0.0"
+
+[[unpublished.wasmtime-internal-cache]]
+version = "46.0.2"
+audited_as = "46.0.1"
 
 [[unpublished.wasmtime-internal-component-macro]]
 version = "45.0.0"
@@ -361,6 +477,10 @@ audited_as = "44.0.1"
 version = "46.0.1"
 audited_as = "46.0.0"
 
+[[unpublished.wasmtime-internal-component-macro]]
+version = "46.0.2"
+audited_as = "46.0.1"
+
 [[unpublished.wasmtime-internal-component-util]]
 version = "45.0.0"
 audited_as = "43.0.1"
@@ -372,6 +492,10 @@ audited_as = "44.0.1"
 [[unpublished.wasmtime-internal-component-util]]
 version = "46.0.1"
 audited_as = "46.0.0"
+
+[[unpublished.wasmtime-internal-component-util]]
+version = "46.0.2"
+audited_as = "46.0.1"
 
 [[unpublished.wasmtime-internal-core]]
 version = "45.0.0"
@@ -385,6 +509,10 @@ audited_as = "44.0.1"
 version = "46.0.1"
 audited_as = "46.0.0"
 
+[[unpublished.wasmtime-internal-core]]
+version = "46.0.2"
+audited_as = "46.0.1"
+
 [[unpublished.wasmtime-internal-cranelift]]
 version = "45.0.0"
 audited_as = "43.0.1"
@@ -396,6 +524,10 @@ audited_as = "44.0.1"
 [[unpublished.wasmtime-internal-cranelift]]
 version = "46.0.1"
 audited_as = "46.0.0"
+
+[[unpublished.wasmtime-internal-cranelift]]
+version = "46.0.2"
+audited_as = "46.0.1"
 
 [[unpublished.wasmtime-internal-debugger]]
 version = "45.0.0"
@@ -409,6 +541,10 @@ audited_as = "44.0.1"
 version = "46.0.1"
 audited_as = "46.0.0"
 
+[[unpublished.wasmtime-internal-debugger]]
+version = "46.0.2"
+audited_as = "46.0.1"
+
 [[unpublished.wasmtime-internal-explorer]]
 version = "45.0.0"
 audited_as = "43.0.1"
@@ -421,6 +557,10 @@ audited_as = "44.0.1"
 version = "46.0.1"
 audited_as = "46.0.0"
 
+[[unpublished.wasmtime-internal-explorer]]
+version = "46.0.2"
+audited_as = "46.0.1"
+
 [[unpublished.wasmtime-internal-fiber]]
 version = "45.0.0"
 audited_as = "43.0.1"
@@ -432,6 +572,10 @@ audited_as = "44.0.1"
 [[unpublished.wasmtime-internal-fiber]]
 version = "46.0.1"
 audited_as = "46.0.0"
+
+[[unpublished.wasmtime-internal-fiber]]
+version = "46.0.2"
+audited_as = "46.0.1"
 
 [[unpublished.wasmtime-internal-gdbstub-component-artifact]]
 version = "45.0.0"
@@ -445,6 +589,10 @@ audited_as = "44.0.1"
 version = "46.0.1"
 audited_as = "46.0.0"
 
+[[unpublished.wasmtime-internal-gdbstub-component-artifact]]
+version = "46.0.2"
+audited_as = "46.0.1"
+
 [[unpublished.wasmtime-internal-jit-debug]]
 version = "45.0.0"
 audited_as = "43.0.1"
@@ -456,6 +604,10 @@ audited_as = "44.0.1"
 [[unpublished.wasmtime-internal-jit-debug]]
 version = "46.0.1"
 audited_as = "46.0.0"
+
+[[unpublished.wasmtime-internal-jit-debug]]
+version = "46.0.2"
+audited_as = "46.0.1"
 
 [[unpublished.wasmtime-internal-jit-icache-coherence]]
 version = "45.0.0"
@@ -469,6 +621,10 @@ audited_as = "44.0.1"
 version = "46.0.1"
 audited_as = "46.0.0"
 
+[[unpublished.wasmtime-internal-jit-icache-coherence]]
+version = "46.0.2"
+audited_as = "46.0.1"
+
 [[unpublished.wasmtime-internal-unwinder]]
 version = "45.0.0"
 audited_as = "43.0.1"
@@ -480,6 +636,10 @@ audited_as = "44.0.1"
 [[unpublished.wasmtime-internal-unwinder]]
 version = "46.0.1"
 audited_as = "46.0.0"
+
+[[unpublished.wasmtime-internal-unwinder]]
+version = "46.0.2"
+audited_as = "46.0.1"
 
 [[unpublished.wasmtime-internal-versioned-export-macros]]
 version = "45.0.0"
@@ -493,6 +653,10 @@ audited_as = "44.0.1"
 version = "46.0.1"
 audited_as = "46.0.0"
 
+[[unpublished.wasmtime-internal-versioned-export-macros]]
+version = "46.0.2"
+audited_as = "46.0.1"
+
 [[unpublished.wasmtime-internal-winch]]
 version = "45.0.0"
 audited_as = "43.0.1"
@@ -504,6 +668,10 @@ audited_as = "44.0.1"
 [[unpublished.wasmtime-internal-winch]]
 version = "46.0.1"
 audited_as = "46.0.0"
+
+[[unpublished.wasmtime-internal-winch]]
+version = "46.0.2"
+audited_as = "46.0.1"
 
 [[unpublished.wasmtime-internal-wit-bindgen]]
 version = "45.0.0"
@@ -517,6 +685,10 @@ audited_as = "44.0.1"
 version = "46.0.1"
 audited_as = "46.0.0"
 
+[[unpublished.wasmtime-internal-wit-bindgen]]
+version = "46.0.2"
+audited_as = "46.0.1"
+
 [[unpublished.wasmtime-internal-wmemcheck]]
 version = "45.0.0"
 audited_as = "43.0.1"
@@ -528,6 +700,10 @@ audited_as = "44.0.1"
 [[unpublished.wasmtime-internal-wmemcheck]]
 version = "46.0.1"
 audited_as = "46.0.0"
+
+[[unpublished.wasmtime-internal-wmemcheck]]
+version = "46.0.2"
+audited_as = "46.0.1"
 
 [[unpublished.wasmtime-wasi]]
 version = "45.0.0"
@@ -541,6 +717,10 @@ audited_as = "44.0.1"
 version = "46.0.1"
 audited_as = "46.0.0"
 
+[[unpublished.wasmtime-wasi]]
+version = "46.0.2"
+audited_as = "46.0.1"
+
 [[unpublished.wasmtime-wasi-config]]
 version = "45.0.0"
 audited_as = "43.0.1"
@@ -552,6 +732,10 @@ audited_as = "44.0.1"
 [[unpublished.wasmtime-wasi-config]]
 version = "46.0.1"
 audited_as = "46.0.0"
+
+[[unpublished.wasmtime-wasi-config]]
+version = "46.0.2"
+audited_as = "46.0.1"
 
 [[unpublished.wasmtime-wasi-http]]
 version = "45.0.0"
@@ -565,6 +749,10 @@ audited_as = "44.0.1"
 version = "46.0.1"
 audited_as = "46.0.0"
 
+[[unpublished.wasmtime-wasi-http]]
+version = "46.0.2"
+audited_as = "46.0.1"
+
 [[unpublished.wasmtime-wasi-io]]
 version = "45.0.0"
 audited_as = "43.0.1"
@@ -576,6 +764,10 @@ audited_as = "44.0.1"
 [[unpublished.wasmtime-wasi-io]]
 version = "46.0.1"
 audited_as = "46.0.0"
+
+[[unpublished.wasmtime-wasi-io]]
+version = "46.0.2"
+audited_as = "46.0.1"
 
 [[unpublished.wasmtime-wasi-keyvalue]]
 version = "45.0.0"
@@ -589,6 +781,10 @@ audited_as = "44.0.1"
 version = "46.0.1"
 audited_as = "46.0.0"
 
+[[unpublished.wasmtime-wasi-keyvalue]]
+version = "46.0.2"
+audited_as = "46.0.1"
+
 [[unpublished.wasmtime-wasi-nn]]
 version = "45.0.0"
 audited_as = "43.0.1"
@@ -600,6 +796,10 @@ audited_as = "44.0.1"
 [[unpublished.wasmtime-wasi-nn]]
 version = "46.0.1"
 audited_as = "46.0.0"
+
+[[unpublished.wasmtime-wasi-nn]]
+version = "46.0.2"
+audited_as = "46.0.1"
 
 [[unpublished.wasmtime-wasi-threads]]
 version = "45.0.0"
@@ -613,6 +813,10 @@ audited_as = "44.0.1"
 version = "46.0.1"
 audited_as = "46.0.0"
 
+[[unpublished.wasmtime-wasi-threads]]
+version = "46.0.2"
+audited_as = "46.0.1"
+
 [[unpublished.wasmtime-wasi-tls]]
 version = "45.0.0"
 audited_as = "43.0.1"
@@ -624,6 +828,10 @@ audited_as = "44.0.1"
 [[unpublished.wasmtime-wasi-tls]]
 version = "46.0.1"
 audited_as = "46.0.0"
+
+[[unpublished.wasmtime-wasi-tls]]
+version = "46.0.2"
+audited_as = "46.0.1"
 
 [[unpublished.wasmtime-wast]]
 version = "45.0.0"
@@ -637,6 +845,10 @@ audited_as = "44.0.1"
 version = "46.0.1"
 audited_as = "46.0.0"
 
+[[unpublished.wasmtime-wast]]
+version = "46.0.2"
+audited_as = "46.0.1"
+
 [[unpublished.wasmtime-wizer]]
 version = "45.0.0"
 audited_as = "43.0.1"
@@ -648,6 +860,10 @@ audited_as = "44.0.1"
 [[unpublished.wasmtime-wizer]]
 version = "46.0.1"
 audited_as = "46.0.0"
+
+[[unpublished.wasmtime-wizer]]
+version = "46.0.2"
+audited_as = "46.0.1"
 
 [[unpublished.wiggle]]
 version = "45.0.0"
@@ -661,6 +877,10 @@ audited_as = "44.0.1"
 version = "46.0.1"
 audited_as = "46.0.0"
 
+[[unpublished.wiggle]]
+version = "46.0.2"
+audited_as = "46.0.1"
+
 [[unpublished.wiggle-generate]]
 version = "45.0.0"
 audited_as = "43.0.1"
@@ -673,6 +893,10 @@ audited_as = "44.0.1"
 version = "46.0.1"
 audited_as = "46.0.0"
 
+[[unpublished.wiggle-generate]]
+version = "46.0.2"
+audited_as = "46.0.1"
+
 [[unpublished.wiggle-macro]]
 version = "45.0.0"
 audited_as = "43.0.1"
@@ -684,6 +908,10 @@ audited_as = "44.0.1"
 [[unpublished.wiggle-macro]]
 version = "46.0.1"
 audited_as = "46.0.0"
+
+[[unpublished.wiggle-macro]]
+version = "46.0.2"
+audited_as = "46.0.1"
 
 [[unpublished.wiggle-test]]
 version = "0.0.0"
@@ -700,6 +928,10 @@ audited_as = "44.0.1"
 [[unpublished.winch-codegen]]
 version = "46.0.1"
 audited_as = "46.0.0"
+
+[[unpublished.winch-codegen]]
+version = "46.0.2"
+audited_as = "46.0.1"
 
 [[publisher.aho-corasick]]
 version = "1.0.2"
@@ -911,103 +1143,103 @@ user-login = "jrmuizel"
 user-name = "Jeff Muizelaar"
 
 [[publisher.cranelift]]
-version = "0.133.0"
-when = "2026-06-22"
+version = "0.133.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-assembler-x64]]
-version = "0.133.0"
-when = "2026-06-22"
+version = "0.133.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-assembler-x64-meta]]
-version = "0.133.0"
-when = "2026-06-22"
+version = "0.133.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-bforest]]
-version = "0.133.0"
-when = "2026-06-22"
+version = "0.133.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-bitset]]
-version = "0.133.0"
-when = "2026-06-22"
+version = "0.133.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-codegen]]
-version = "0.133.0"
-when = "2026-06-22"
+version = "0.133.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-codegen-meta]]
-version = "0.133.0"
-when = "2026-06-22"
+version = "0.133.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-codegen-shared]]
-version = "0.133.0"
-when = "2026-06-22"
+version = "0.133.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-control]]
-version = "0.133.0"
-when = "2026-06-22"
+version = "0.133.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-entity]]
-version = "0.133.0"
-when = "2026-06-22"
+version = "0.133.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-frontend]]
-version = "0.133.0"
-when = "2026-06-22"
+version = "0.133.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-interpreter]]
-version = "0.133.0"
-when = "2026-06-22"
+version = "0.133.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-isle]]
-version = "0.133.0"
-when = "2026-06-22"
+version = "0.133.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-jit]]
-version = "0.133.0"
-when = "2026-06-22"
+version = "0.133.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-module]]
-version = "0.133.0"
-when = "2026-06-22"
+version = "0.133.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-native]]
-version = "0.133.0"
-when = "2026-06-22"
+version = "0.133.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-object]]
-version = "0.133.0"
-when = "2026-06-22"
+version = "0.133.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-reader]]
-version = "0.133.0"
-when = "2026-06-22"
+version = "0.133.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-serde]]
-version = "0.133.0"
-when = "2026-06-22"
+version = "0.133.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-srcgen]]
-version = "0.133.0"
-when = "2026-06-22"
+version = "0.133.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.derive_arbitrary]]
@@ -1346,13 +1578,13 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.pulley-interpreter]]
-version = "46.0.0"
-when = "2026-06-22"
+version = "46.0.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.pulley-macros]]
-version = "46.0.0"
-when = "2026-06-22"
+version = "46.0.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.quote]]
@@ -1671,8 +1903,8 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wasi-common]]
-version = "46.0.0"
-when = "2026-06-22"
+version = "46.0.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasip1]]
@@ -1793,158 +2025,158 @@ when = "2026-05-28"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wasmtime]]
-version = "46.0.0"
-when = "2026-06-22"
+version = "46.0.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-cli]]
-version = "46.0.0"
-when = "2026-06-22"
+version = "46.0.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-cli-flags]]
-version = "46.0.0"
-when = "2026-06-22"
+version = "46.0.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-environ]]
-version = "46.0.0"
-when = "2026-06-22"
+version = "46.0.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-c-api-macros]]
-version = "46.0.0"
-when = "2026-06-22"
+version = "46.0.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-cache]]
-version = "46.0.0"
-when = "2026-06-22"
+version = "46.0.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-component-macro]]
-version = "46.0.0"
-when = "2026-06-22"
+version = "46.0.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-component-util]]
-version = "46.0.0"
-when = "2026-06-22"
+version = "46.0.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-core]]
-version = "46.0.0"
-when = "2026-06-22"
+version = "46.0.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-cranelift]]
-version = "46.0.0"
-when = "2026-06-22"
+version = "46.0.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-debugger]]
-version = "46.0.0"
-when = "2026-06-22"
+version = "46.0.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-explorer]]
-version = "46.0.0"
-when = "2026-06-22"
+version = "46.0.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-fiber]]
-version = "46.0.0"
-when = "2026-06-22"
+version = "46.0.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-gdbstub-component-artifact]]
-version = "46.0.0"
-when = "2026-06-22"
+version = "46.0.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-jit-debug]]
-version = "46.0.0"
-when = "2026-06-22"
+version = "46.0.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-jit-icache-coherence]]
-version = "46.0.0"
-when = "2026-06-22"
+version = "46.0.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-unwinder]]
-version = "46.0.0"
-when = "2026-06-22"
+version = "46.0.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-versioned-export-macros]]
-version = "46.0.0"
-when = "2026-06-22"
+version = "46.0.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-winch]]
-version = "46.0.0"
-when = "2026-06-22"
+version = "46.0.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-wit-bindgen]]
-version = "46.0.0"
-when = "2026-06-22"
+version = "46.0.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-wmemcheck]]
-version = "46.0.0"
-when = "2026-06-22"
+version = "46.0.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi]]
-version = "46.0.0"
-when = "2026-06-22"
+version = "46.0.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-config]]
-version = "46.0.0"
-when = "2026-06-22"
+version = "46.0.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-http]]
-version = "46.0.0"
-when = "2026-06-22"
+version = "46.0.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-io]]
-version = "46.0.0"
-when = "2026-06-22"
+version = "46.0.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-keyvalue]]
-version = "46.0.0"
-when = "2026-06-22"
+version = "46.0.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-nn]]
-version = "46.0.0"
-when = "2026-06-22"
+version = "46.0.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-threads]]
-version = "46.0.0"
-when = "2026-06-22"
+version = "46.0.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-tls]]
-version = "46.0.0"
-when = "2026-06-22"
+version = "46.0.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wast]]
-version = "46.0.0"
-when = "2026-06-22"
+version = "46.0.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wizer]]
-version = "46.0.0"
-when = "2026-06-22"
+version = "46.0.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wast]]
@@ -1958,18 +2190,18 @@ when = "2026-05-28"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wiggle]]
-version = "46.0.0"
-when = "2026-06-22"
+version = "46.0.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wiggle-generate]]
-version = "46.0.0"
-when = "2026-06-22"
+version = "46.0.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wiggle-macro]]
-version = "46.0.0"
-when = "2026-06-22"
+version = "46.0.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wiggle-test]]
@@ -1987,8 +2219,8 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.winch-codegen]]
-version = "46.0.0"
-when = "2026-06-22"
+version = "46.0.1"
+when = "2026-06-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.windows]]


### PR DESCRIPTION
This is an [automated pull request][process] from CI to create a patch release for Wasmtime 46.0.2, requested by @alexcrichton.

It's recommended that maintainers double-check that [RELEASES.md] is up-to-date and that there are no known issues before merging this PR. When this PR is merged a release tag will automatically be created, crates will be published, and CI artifacts will be produced.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/release-46.0.2/RELEASES.md
[process]: https://docs.wasmtime.dev/contributing-release-process.html
