### PR TITLE
[36.0.x] Fix some API unsoundness with invaild cross-`Engine` usage

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,14 @@
+## 36.0.13
+
+Released 2026-07-31.
+
+### Fixed
+
+* Stores can mix up type indices between engines.
+  [GHSA-hgjw-h833-99q9](https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-hgjw-h833-99q9)
+
+--------------------------------------------------------------------------------
+
 ## 36.0.12
 
 Released 2026-06-24.
@@ -37,7 +48,7 @@ Released 2026-05-05.
 
 ### Fixed
 
-* Cranelift's timing infrastructure is now more robust in the face of buggy system clocks. 
+* Cranelift's timing infrastructure is now more robust in the face of buggy system clocks.
   [#12709](https://github.com/bytecodealliance/wasmtime/pull/12709)
   [#13253](https://github.com/bytecodealliance/wasmtime/pull/13253)
 

--- a/crates/wasmtime/src/runtime/component/instance.rs
+++ b/crates/wasmtime/src/runtime/component/instance.rs
@@ -607,13 +607,15 @@ pub(crate) enum RuntimeImport {
 pub type ImportedResources = PrimaryMap<ResourceIndex, ResourceType>;
 
 impl<'a> Instantiator<'a> {
+    /// Returns an error if `component` was not compiled by `store`'s engine.
     fn new(
         component: &'a Component,
         store: &mut StoreOpaque,
         imports: &'a Arc<PrimaryMap<RuntimeImportIndex, RuntimeImport>>,
-    ) -> Instantiator<'a> {
+    ) -> Result<Instantiator<'a>> {
         let env_component = component.env_component();
-        store.modules_mut().register_component(component);
+        let (modules, engine) = store.modules_and_engine_mut();
+        modules.register_component(component, engine)?;
         let imported_resources: ImportedResources =
             PrimaryMap::with_capacity(env_component.imported_resources.len());
 
@@ -626,12 +628,12 @@ impl<'a> Instantiator<'a> {
         );
         let id = store.store_data_mut().push_component_instance(instance);
 
-        Instantiator {
+        Ok(Instantiator {
             component,
             imports,
             core_imports: OwnedImports::empty(),
             id,
-        }
+        })
     }
 
     fn run<T>(&mut self, store: &mut StoreContextMut<'_, T>) -> Result<()> {
@@ -1020,7 +1022,16 @@ impl<T: 'static> InstancePre<T> {
             .engine()
             .allocator()
             .increment_component_instance_count()?;
-        let mut instantiator = Instantiator::new(&self.component, store.0, &self.imports);
+        let mut instantiator = match Instantiator::new(&self.component, store.0, &self.imports) {
+            Ok(instantiator) => instantiator,
+            Err(e) => {
+                store
+                    .engine()
+                    .allocator()
+                    .decrement_component_instance_count();
+                return Err(e);
+            }
+        };
         instantiator.run(&mut store).map_err(|e| {
             store
                 .engine()

--- a/crates/wasmtime/src/runtime/component/linker.rs
+++ b/crates/wasmtime/src/runtime/component/linker.rs
@@ -211,7 +211,14 @@ impl<T: 'static> Linker<T> {
     /// Returns an error if this linker doesn't define a name that the
     /// `component` imports or if a name defined doesn't match the type of the
     /// item imported by the `component` provided.
+    ///
+    /// Returns an error if `component` was not compiled by the same
+    /// [`Engine`](crate::Engine) as this linker.
     pub fn instantiate_pre(&self, component: &Component) -> Result<InstancePre<T>> {
+        ensure!(
+            Engine::same(&self.engine, component.engine()),
+            "cross-`Engine` instantiation is not currently supported"
+        );
         let cx = self.typecheck(&component)?;
 
         // A successful typecheck resolves all of the imported resources used by

--- a/crates/wasmtime/src/runtime/externals/global.rs
+++ b/crates/wasmtime/src/runtime/externals/global.rs
@@ -59,6 +59,9 @@ impl Global {
     /// Returns an error if the `ty` provided does not match the type of the
     /// value `val`, or if `val` comes from a different store than `store`.
     ///
+    /// Returns an error if the content type of `ty` was not created with the
+    /// same [`Engine`](crate::Engine) as `store`.
+    ///
     /// # Examples
     ///
     /// ```

--- a/crates/wasmtime/src/runtime/externals/table.rs
+++ b/crates/wasmtime/src/runtime/externals/table.rs
@@ -52,6 +52,9 @@ impl Table {
     /// Returns an error if `init` does not match the element type of the table,
     /// or if `init` does not belong to the `store` provided.
     ///
+    /// Returns an error if the element type of `ty` was not created with the
+    /// same [`Engine`](crate::Engine) as `store`.
+    ///
     /// # Panics
     ///
     /// This function will panic when used with a [`Store`](`crate::Store`)
@@ -98,6 +101,11 @@ impl Table {
     ///
     /// This function will panic when used with a non-async
     /// [`Store`](`crate::Store`)
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the element type of `ty` was not created with the
+    /// same [`Engine`](crate::Engine) as `store`.
     #[cfg(feature = "async")]
     pub async fn new_async(
         mut store: impl AsContextMut<Data: Send>,

--- a/crates/wasmtime/src/runtime/externals/tag.rs
+++ b/crates/wasmtime/src/runtime/externals/tag.rs
@@ -32,6 +32,11 @@ impl Tag {
     /// (see also: [`Store::limiter_async`](`crate::Store::limiter_async`).
     /// When using an async resource limiter, use [`Tag::new_async`]
     /// instead.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `ty` was not created with the same
+    /// [`Engine`](crate::Engine) as `store`.
     pub fn new(mut store: impl AsContextMut, ty: &TagType) -> Result<Tag> {
         generate_tag_export(store.as_context_mut().0, ty)
     }

--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -2623,6 +2623,10 @@ impl HostFunc {
         );
     }
 
+    pub(crate) fn engine(&self) -> &Engine {
+        &self.engine
+    }
+
     pub(crate) fn sig_index(&self) -> VMSharedTypeIndex {
         self.func_ref().type_index
     }

--- a/crates/wasmtime/src/runtime/gc/enabled/arrayref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/arrayref.rs
@@ -68,6 +68,11 @@ pub struct ArrayRefPre {
 impl ArrayRefPre {
     /// Create a new `ArrayRefPre` that is associated with the given store
     /// and type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `ty` was not created with the same
+    /// [`Engine`](crate::Engine) as `store`.
     pub fn new(mut store: impl AsContextMut, ty: ArrayType) -> Self {
         Self::_new(store.as_context_mut().0, ty)
     }

--- a/crates/wasmtime/src/runtime/gc/enabled/exnref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/exnref.rs
@@ -70,6 +70,11 @@ pub struct ExnRefPre {
 impl ExnRefPre {
     /// Create a new `ExnRefPre` that is associated with the given store
     /// and type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `ty` was not created with the same
+    /// [`Engine`](crate::Engine) as `store`.
     pub fn new(mut store: impl AsContextMut, ty: ExnType) -> Self {
         Self::_new(store.as_context_mut().0, ty)
     }

--- a/crates/wasmtime/src/runtime/gc/enabled/structref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/structref.rs
@@ -66,6 +66,11 @@ pub struct StructRefPre {
 impl StructRefPre {
     /// Create a new `StructRefPre` that is associated with the given store
     /// and type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `ty` was not created with the same
+    /// [`Engine`](crate::Engine) as `store`.
     pub fn new(mut store: impl AsContextMut, ty: StructType) -> Self {
         Self::_new(store.as_context_mut().0, ty)
     }

--- a/crates/wasmtime/src/runtime/instance.rs
+++ b/crates/wasmtime/src/runtime/instance.rs
@@ -160,7 +160,7 @@ impl Instance {
             }
         }
 
-        typecheck(module, imports, |cx, ty, item| {
+        typecheck(store.engine(), module, imports, |cx, ty, item| {
             let item = DefinitionType::from(store, item);
             cx.definition(ty, &item)
         })?;
@@ -174,7 +174,8 @@ impl Instance {
         // Note that under normal operation this shouldn't do much as the list
         // of funcs-with-holes should generally be empty. As a result the
         // process of filling this out is not super optimized at this point.
-        store.modules_mut().register_module(module);
+        let (modules, engine) = store.modules_and_engine_mut();
+        modules.register_module(module, engine)?;
         let (funcrefs, modules) = store.func_refs_and_modules();
         funcrefs.fill(modules);
 
@@ -281,7 +282,8 @@ impl Instance {
 
         // Register the module just before instantiation to ensure we keep the module
         // properly referenced while in use by the store.
-        let module_id = store.modules_mut().register_module(module);
+        let (modules, engine) = store.modules_and_engine_mut();
+        let module_id = modules.register_module(module, engine)?;
 
         // The first thing we do is issue an instance allocation request
         // to the instance allocator. This, on success, will give us an
@@ -764,19 +766,31 @@ impl<T: 'static> InstancePre<T> {
     /// Creates a new `InstancePre` which type-checks the `items` provided and
     /// on success is ready to instantiate a new instance.
     ///
+    /// `engine` is the engine that `items` belong to, and this returns an error
+    /// if that is not also `module`'s engine. This also returns an error if an
+    /// individual item within `items` reports an engine of its own that is not
+    /// `engine`, which happens when that item was taken from a store belonging
+    /// to a different engine than the linker it was defined in.
+    ///
     /// # Unsafety
     ///
     /// This method is unsafe as the `T` of the `InstancePre<T>` is not
     /// guaranteed to be the same as the `T` within the `Store`, the caller must
     /// verify that.
-    pub(crate) unsafe fn new(module: &Module, items: Vec<Definition>) -> Result<InstancePre<T>> {
-        typecheck(module, &items, |cx, ty, item| cx.definition(ty, &item.ty()))?;
+    pub(crate) unsafe fn new(
+        engine: &Engine,
+        module: &Module,
+        items: Vec<Definition>,
+    ) -> Result<InstancePre<T>> {
+        typecheck(engine, module, &items, |cx, ty, item| {
+            cx.definition(ty, &item.ty())
+        })?;
 
         let mut func_refs = vec![];
         let mut host_funcs = 0;
         for item in &items {
             match item {
-                Definition::Extern(_, _) => {}
+                Definition::Extern { .. } => {}
                 Definition::HostFunc(f) => {
                     host_funcs += 1;
                     if f.func_ref().wasm_call.is_none() {
@@ -889,7 +903,8 @@ fn pre_instantiate_raw(
 ) -> Result<OwnedImports> {
     // Register this module and use it to fill out any funcref wasm_call holes
     // we can. For more comments on this see `typecheck_externs`.
-    store.modules_mut().register_module(module);
+    let (modules, engine) = store.modules_and_engine_mut();
+    modules.register_module(module, engine)?;
     let (funcrefs, modules) = store.func_refs_and_modules();
     funcrefs.fill(modules);
 
@@ -919,7 +934,7 @@ fn pre_instantiate_raw(
         // `T` of the store. Additionally the rooting necessary has happened
         // above.
         let item = match import {
-            Definition::Extern(e, _) => e.clone(),
+            Definition::Extern { item, .. } => item.clone(),
             Definition::HostFunc(func) => unsafe {
                 func.to_func_store_rooted(
                     store,
@@ -938,11 +953,62 @@ fn pre_instantiate_raw(
     Ok(imports)
 }
 
+/// An item that can be supplied as an import argument during instantiation.
+///
+/// # Safety
+///
+/// Implementations must return an associated engine if they own a handle to
+/// one. Failure to do so may allow cross-`Engine` type confusion.
+///
+/// (Items that are just identifiers indexing into a store, for example
+/// `Extern::Global(wasmtime::Global)`, do not have their own handle to an
+/// engine. Their engine is the engine of the store they belong to, and it is
+/// the store, not them, that holds an owning handle to the engine.)
+unsafe trait ImportArg {
+    fn engine(&self) -> Option<&Engine>;
+}
+
+// SAFETY: `Extern::SharedMemory` is the only variant with an `Engine` handle.
+unsafe impl ImportArg for Extern {
+    fn engine(&self) -> Option<&Engine> {
+        match self {
+            Extern::SharedMemory(m) => Some(m.engine()),
+            Extern::Func(_)
+            | Extern::Global(_)
+            | Extern::Table(_)
+            | Extern::Memory(_)
+            | Extern::Tag(_) => None,
+        }
+    }
+}
+
+// SAFETY: `Definition::engine` is complete.
+unsafe impl ImportArg for Definition {
+    fn engine(&self) -> Option<&Engine> {
+        Some(Definition::engine(self))
+    }
+}
+
+/// Type check the `import_args` against the imports that `module` declares.
+///
+/// `engine` is the engine that the `import_args` belong to. It must be the same
+/// engine as `module`'s: entity types are compared by `VMSharedTypeIndex`, which
+/// only means anything within the engine that assigned it, so checking one
+/// engine's items against another engine's module would compare unrelated types
+/// and consider them equal.
 fn typecheck<I>(
+    engine: &Engine,
     module: &Module,
     import_args: &[I],
     check: impl Fn(&matching::MatchCx<'_>, &EntityType, &I) -> Result<()>,
-) -> Result<()> {
+) -> Result<()>
+where
+    I: ImportArg,
+{
+    ensure!(
+        Engine::same(engine, module.engine()),
+        "cross-`Engine` instantiation is not currently supported"
+    );
     let env_module = module.compiled_module().module();
     let expected_len = env_module.imports().count();
     let actual_len = import_args.len();
@@ -952,6 +1018,14 @@ fn typecheck<I>(
     let cx = matching::MatchCx::new(module.engine());
     for ((name, field, expected_ty), actual) in env_module.imports().zip(import_args) {
         debug_assert!(expected_ty.is_canonicalized_for_runtime_usage());
+        if let Some(actual_engine) = actual.engine() {
+            ensure!(
+                Engine::same(actual_engine, engine),
+                "cross-`Engine` instantiation is not currently supported: \
+                 the item provided for `{name}::{field}` belongs to a \
+                 different engine than the module being instantiated"
+            );
+        }
         check(&cx, &expected_ty, actual)
             .with_context(|| format!("incompatible import type for `{name}::{field}`"))?;
     }

--- a/crates/wasmtime/src/runtime/linker.rs
+++ b/crates/wasmtime/src/runtime/linker.rs
@@ -74,9 +74,10 @@ use log::warn;
 /// The [`Linker`] type is not compatible with usage between multiple [`Engine`]
 /// values. An [`Engine`] is provided when a [`Linker`] is created and only
 /// stores and items which originate from that [`Engine`] can be used with this
-/// [`Linker`]. If more than one [`Engine`] is used with a [`Linker`] then that
-/// may cause a panic at runtime, similar to how if a [`Func`] is used with the
-/// wrong [`Store`] that can also panic at runtime.
+/// [`Linker`]. Instantiating a [`Module`] from another [`Engine`] returns an
+/// error, and mixing engines in other ways may cause a panic at runtime,
+/// similar to how if a [`Func`] is used with the wrong [`Store`] that can also
+/// panic at runtime.
 ///
 /// [`Store`]: crate::Store
 /// [`Global`]: crate::Global
@@ -118,7 +119,13 @@ struct ImportKey {
 
 #[derive(Clone)]
 pub(crate) enum Definition {
-    Extern(Extern, DefinitionType),
+    Extern {
+        item: Extern,
+        ty: DefinitionType,
+        /// The engine of the store that `item` was taken from, which is the
+        /// engine that assigned any type indices within `ty`.
+        engine: Engine,
+    },
     HostFunc(Arc<HostFunc>),
 }
 
@@ -1221,6 +1228,10 @@ impl<T> Linker<T> {
     where
         T: 'static,
     {
+        ensure!(
+            Engine::same(&self.engine, module.engine()),
+            "cross-`Engine` instantiation is not currently supported"
+        );
         let mut imports = module
             .imports()
             .map(|import| self._get_by_import(&import))
@@ -1230,7 +1241,7 @@ impl<T> Linker<T> {
                 import.update_size(store);
             }
         }
-        unsafe { InstancePre::new(module, imports) }
+        unsafe { InstancePre::new(&self.engine, module, imports) }
     }
 
     /// Returns an iterator over all items defined in this `Linker`, in
@@ -1369,13 +1380,26 @@ impl<T: 'static> Default for Linker<T> {
 impl Definition {
     fn new(store: &StoreOpaque, item: Extern) -> Definition {
         let ty = DefinitionType::from(store, &item);
-        Definition::Extern(item, ty)
+        Definition::Extern {
+            item,
+            ty,
+            engine: store.engine().clone(),
+        }
     }
 
     pub(crate) fn ty(&self) -> DefinitionType {
         match self {
-            Definition::Extern(_, ty) => ty.clone(),
+            Definition::Extern { ty, .. } => ty.clone(),
             Definition::HostFunc(func) => DefinitionType::Func(func.sig_index()),
+        }
+    }
+
+    /// The engine that assigned the type indices within this definition's
+    /// [`Definition::ty`].
+    pub(crate) fn engine(&self) -> &Engine {
+        match self {
+            Definition::Extern { engine, .. } => engine,
+            Definition::HostFunc(func) => func.engine(),
         }
     }
 
@@ -1388,7 +1412,7 @@ impl Definition {
     /// `HostFunc` matches the `T` on the store.
     pub(crate) unsafe fn to_extern(&self, store: &mut StoreOpaque) -> Extern {
         match self {
-            Definition::Extern(e, _) => e.clone(),
+            Definition::Extern { item, .. } => item.clone(),
             // SAFETY: the contract of this function is the same as what's
             // required of `to_func`, that `T` of the store matches the `T` of
             // this original definition.
@@ -1398,20 +1422,32 @@ impl Definition {
 
     pub(crate) fn comes_from_same_store(&self, store: &StoreOpaque) -> bool {
         match self {
-            Definition::Extern(e, _) => e.comes_from_same_store(store),
+            Definition::Extern { item, .. } => item.comes_from_same_store(store),
             Definition::HostFunc(_func) => true,
         }
     }
 
     fn update_size(&mut self, store: &StoreOpaque) {
         match self {
-            Definition::Extern(Extern::Memory(m), DefinitionType::Memory(_, size)) => {
+            Definition::Extern {
+                item: Extern::Memory(m),
+                ty: DefinitionType::Memory(_, size),
+                ..
+            } => {
                 *size = m.internal_size(store);
             }
-            Definition::Extern(Extern::SharedMemory(m), DefinitionType::Memory(_, size)) => {
+            Definition::Extern {
+                item: Extern::SharedMemory(m),
+                ty: DefinitionType::Memory(_, size),
+                ..
+            } => {
                 *size = m.size();
             }
-            Definition::Extern(Extern::Table(m), DefinitionType::Table(_, size)) => {
+            Definition::Extern {
+                item: Extern::Table(m),
+                ty: DefinitionType::Table(_, size),
+                ..
+            } => {
                 *size = m.internal_size(store);
             }
             _ => {}

--- a/crates/wasmtime/src/runtime/module/registry.rs
+++ b/crates/wasmtime/src/runtime/module/registry.rs
@@ -6,7 +6,7 @@ use crate::component::Component;
 use crate::prelude::*;
 use crate::runtime::vm::VMWasmCallFunction;
 use crate::sync::{OnceLock, RwLock};
-use crate::{FrameInfo, Module, code_memory::CodeMemory};
+use crate::{Engine, FrameInfo, Module, code_memory::CodeMemory};
 use alloc::collections::btree_map::{BTreeMap, Entry};
 use alloc::sync::Arc;
 use core::ptr::NonNull;
@@ -57,6 +57,22 @@ pub enum RegisteredModuleId {
     LoadedCode(usize),
 }
 
+enum ModuleOrComponent<'a> {
+    Module(&'a Module),
+    #[cfg(feature = "component-model")]
+    Component(&'a Component),
+}
+
+impl<'a> ModuleOrComponent<'a> {
+    fn engine(&self) -> &'a Engine {
+        match self {
+            ModuleOrComponent::Module(module) => module.engine(),
+            #[cfg(feature = "component-model")]
+            ModuleOrComponent::Component(component) => component.engine(),
+        }
+    }
+}
+
 impl ModuleRegistry {
     /// Get a previously-registered module by id.
     pub fn lookup_module_by_id(&self, id: RegisteredModuleId) -> Option<&Module> {
@@ -99,21 +115,57 @@ impl ModuleRegistry {
     }
 
     /// Registers a new module with the registry.
-    pub fn register_module(&mut self, module: &Module) -> RegisteredModuleId {
-        self.register(module.code_object(), Some(module)).unwrap()
+    ///
+    /// Returns an error if `module` was not compiled by `engine`.
+    pub fn register_module(
+        &mut self,
+        module: &Module,
+        engine: &Engine,
+    ) -> Result<RegisteredModuleId> {
+        Ok(self
+            .register(ModuleOrComponent::Module(module), engine)?
+            .unwrap())
     }
 
+    /// Registers a new component with the registry.
+    ///
+    /// Returns an error if `component` was not compiled by `engine`.
     #[cfg(feature = "component-model")]
-    pub fn register_component(&mut self, component: &Component) {
-        self.register(component.code_object(), None);
+    pub fn register_component(&mut self, component: &Component, engine: &Engine) -> Result<()> {
+        self.register(ModuleOrComponent::Component(component), engine)?;
+        Ok(())
     }
 
-    /// Registers a new module with the registry.
+    /// Registers a new module or component with the registry.
+    ///
+    /// Returns an error if `module_or_component` was not compiled by `engine`.
+    /// All code and metadata enters a store through here, so callers
+    /// registering on a store's behalf pass that store's engine to keep foreign
+    /// code out of it.
     fn register(
         &mut self,
-        code: &Arc<CodeObject>,
-        module: Option<&Module>,
-    ) -> Option<RegisteredModuleId> {
+        module_or_component: ModuleOrComponent<'_>,
+        engine: &Engine,
+    ) -> Result<Option<RegisteredModuleId>> {
+        // Nothing below here may run for a foreign module or component: the
+        // type indices it carries mean something else entirely in this
+        // engine.
+        ensure!(
+            Engine::same(engine, module_or_component.engine()),
+            "cross-`Engine` usage is not supported"
+        );
+
+        let code = match module_or_component {
+            ModuleOrComponent::Module(module) => module.code_object(),
+            #[cfg(feature = "component-model")]
+            ModuleOrComponent::Component(component) => component.code_object(),
+        };
+        let module = match module_or_component {
+            ModuleOrComponent::Module(module) => Some(module),
+            #[cfg(feature = "component-model")]
+            ModuleOrComponent::Component(_) => None,
+        };
+
         let text = code.code_memory().text();
 
         // If there's not actually any functions in this module then we may
@@ -123,11 +175,11 @@ impl ModuleRegistry {
         // module in the future. For that reason we continue to register empty
         // modules and retain them.
         if text.is_empty() {
-            return module.map(|module| {
+            return Ok(module.map(|module| {
                 let id = RegisteredModuleId::WithoutCode(self.modules_without_code.len());
                 self.modules_without_code.push(module.clone());
                 id
-            });
+            }));
         }
 
         // The module code range is exclusive for end, so make it inclusive as
@@ -145,7 +197,7 @@ impl ModuleRegistry {
             if let Some(module) = module {
                 prev.push_module(module);
             }
-            return id;
+            return Ok(id);
         }
 
         // Assert that this module's code doesn't collide with any other
@@ -167,7 +219,7 @@ impl ModuleRegistry {
         }
         let prev = self.loaded_code.insert(end_addr, (start_addr, item));
         assert!(prev.is_none());
-        id
+        Ok(id)
     }
 
     /// Fetches frame information about a program counter in a backtrace.

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -1254,9 +1254,11 @@ impl StoreOpaque {
         &self.modules
     }
 
+    /// Get this store's module registry along with the engine that everything
+    /// registered in it must have been compiled by.
     #[inline]
-    pub(crate) fn modules_mut(&mut self) -> &mut ModuleRegistry {
-        &mut self.modules
+    pub(crate) fn modules_and_engine_mut(&mut self) -> (&mut ModuleRegistry, &Engine) {
+        (&mut self.modules, &self.engine)
     }
 
     pub(crate) fn func_refs_and_modules(&mut self) -> (&mut FuncRefs, &ModuleRegistry) {
@@ -1721,8 +1723,18 @@ impl StoreOpaque {
     /// type in this store, and we don't have to worry about the type being
     /// reclaimed (since it is possible that none of the Wasm modules in this
     /// store are holding it alive).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `ty` was not registered with this store's engine. The types
+    /// here are keyed by their `VMSharedTypeIndex`, which only means anything
+    /// within the engine that assigned it.
     #[cfg(feature = "gc")]
     pub(crate) fn insert_gc_host_alloc_type(&mut self, ty: crate::type_registry::RegisteredType) {
+        assert!(
+            Engine::same(self.engine(), ty.engine()),
+            "type used with wrong engine"
+        );
         self.gc_host_alloc_types.insert(ty);
     }
 

--- a/crates/wasmtime/src/runtime/trampoline/table.rs
+++ b/crates/wasmtime/src/runtime/trampoline/table.rs
@@ -25,18 +25,20 @@ pub fn create_table(store: &mut StoreOpaque, table: &TableType) -> Result<Instan
 
     let imports = Imports::default();
 
+    let runtime_info = ModuleRuntimeInfo::bare_with_registered_type(
+        Arc::new(module),
+        store.engine(),
+        table.element().clone().into_registered_type(),
+    )?;
+
     unsafe {
         let allocator =
             OnDemandInstanceAllocator::new(store.engine().config().mem_creator.clone(), 0, false);
-        let module = Arc::new(module);
         store.allocate_instance(
             AllocateInstanceKind::Dummy {
                 allocator: &allocator,
             },
-            &ModuleRuntimeInfo::bare_with_registered_type(
-                module,
-                table.element().clone().into_registered_type(),
-            ),
+            &runtime_info,
             imports,
         )
     }

--- a/crates/wasmtime/src/runtime/trampoline/tag.rs
+++ b/crates/wasmtime/src/runtime/trampoline/tag.rs
@@ -26,15 +26,24 @@ pub fn create_tag(store: &mut StoreOpaque, ty: &TagType) -> Result<InstanceId> {
 
     let imports = Imports::default();
 
+    // The tag's signature type is referred to by engine-level type index from
+    // the dummy module's `Tag`, so its `RegisteredType` must be handed to the
+    // instance's runtime info to keep that index rooted in the engine's type
+    // registry for as long as the instance (and thus the store) is alive.
+    let runtime_info = ModuleRuntimeInfo::bare_with_registered_type(
+        Arc::new(module),
+        store.engine(),
+        Some(func_ty),
+    )?;
+
     unsafe {
         let allocator =
             OnDemandInstanceAllocator::new(store.engine().config().mem_creator.clone(), 0, false);
-        let module = Arc::new(module);
         store.allocate_instance(
             AllocateInstanceKind::Dummy {
                 allocator: &allocator,
             },
-            &ModuleRuntimeInfo::bare_with_registered_type(module, Some(func_ty)),
+            &runtime_info,
             imports,
         )
     }

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -341,10 +341,31 @@ pub struct BareModuleInfo {
 
 impl ModuleRuntimeInfo {
     pub(crate) fn bare(module: Arc<wasmtime_environ::Module>) -> Self {
-        ModuleRuntimeInfo::bare_with_registered_type(module, None)
+        ModuleRuntimeInfo::new_bare(module, None)
     }
 
+    /// Same as [`ModuleRuntimeInfo::bare`], but additionally keeps
+    /// `registered_type` alive for as long as the resulting instance.
+    ///
+    /// This is the choke point at which a host-allocated table or tag holds a
+    /// `VMSharedTypeIndex` alive on behalf of a store, so it is where we check
+    /// that the type belongs to that store's engine. Returns an error if
+    /// `registered_type` was not registered with `engine`.
     pub(crate) fn bare_with_registered_type(
+        module: Arc<wasmtime_environ::Module>,
+        engine: &crate::Engine,
+        registered_type: Option<RegisteredType>,
+    ) -> Result<Self> {
+        if let Some(ty) = registered_type.as_ref() {
+            ensure!(
+                crate::Engine::same(engine, ty.engine()),
+                "type used with wrong engine"
+            );
+        }
+        Ok(ModuleRuntimeInfo::new_bare(module, registered_type))
+    }
+
+    fn new_bare(
         module: Arc<wasmtime_environ::Module>,
         registered_type: Option<RegisteredType>,
     ) -> Self {

--- a/tests/all/arrays.rs
+++ b/tests/all/arrays.rs
@@ -1,4 +1,4 @@
-use super::gc_store;
+use super::{gc_engine, gc_store};
 use wasmtime::*;
 
 #[test]
@@ -70,11 +70,12 @@ fn array_new_cross_store_initial_elem() {
 #[test]
 #[should_panic = "wrong store"]
 fn array_new_cross_store_pre() {
-    let mut store1 = gc_store().unwrap();
-    let mut store2 = gc_store().unwrap();
+    let engine = gc_engine().unwrap();
+    let mut store1 = Store::new(&engine, ());
+    let mut store2 = Store::new(&engine, ());
 
     let array_ty = ArrayType::new(
-        store1.engine(),
+        &engine,
         FieldType::new(Mutability::Var, StorageType::ValType(ValType::ANYREF)),
     );
     let pre = ArrayRefPre::new(&mut store2, array_ty);
@@ -155,11 +156,12 @@ fn array_new_fixed_cross_store_initial_elem() {
 #[test]
 #[should_panic = "wrong store"]
 fn array_new_fixed_cross_store_pre() {
-    let mut store1 = gc_store().unwrap();
-    let mut store2 = gc_store().unwrap();
+    let engine = gc_engine().unwrap();
+    let mut store1 = Store::new(&engine, ());
+    let mut store2 = Store::new(&engine, ());
 
     let array_ty = ArrayType::new(
-        store1.engine(),
+        &engine,
         FieldType::new(Mutability::Var, StorageType::ValType(ValType::ANYREF)),
     );
     let pre = ArrayRefPre::new(&mut store2, array_ty);

--- a/tests/all/cross_engine.rs
+++ b/tests/all/cross_engine.rs
@@ -1,0 +1,385 @@
+//! Tests that objects belonging to one `Engine` cannot be admitted into a
+//! `Store` that belongs to a different `Engine`.
+//!
+//! Type indices (`VMSharedTypeIndex`) are unique only within a single
+//! `Engine`. Two engines will happily hand out the same index for two
+//! completely unrelated types. When an object from one engine reaches a store
+//! from another, those numerically-equal-but-semantically-different indices
+//! collide:
+//!
+//! * A host function's `wasm_call` field gets patched with a Wasm-to-array
+//!   trampoline compiled for a different signature, so the trampoline reads
+//!   and writes the wrong number of `ValRaw` slots in a stack buffer.
+//!
+//! * The garbage collector traces a Wasm object using a foreign type's
+//!   layout.
+//!
+//! Every API that lets an object into a store must therefore check that the
+//! object comes from the store's engine.
+
+use crate::ErrorExt;
+use std::sync::{Arc, Mutex};
+use wasmtime::component::{Component, Linker as ComponentLinker};
+use wasmtime::*;
+
+/// The value that [`observe_i64_in_host`] sends from Wasm to the host.
+const SENTINEL: i64 = 0x1122334455667788;
+
+/// A module whose only function type is `(func (param f64))`.
+///
+/// In a freshly created engine that type gets the same `VMSharedTypeIndex` as
+/// the `(func (param i64))` type used by [`observe_i64_in_host`], so if this
+/// module is registered with a store belonging to a different engine then its
+/// trampoline is what the host function ends up calling.
+const COLLIDING_MODULE: &str = r#"(module (func (export "f") (param f64)))"#;
+
+/// [`COLLIDING_MODULE`] wrapped up in a component.
+///
+/// The core module is deliberately left uninstantiated so that instantiating
+/// this component does not itself instantiate any core module.
+const COLLIDING_COMPONENT: &str = r#"
+    (component
+        (core module (func (export "f") (param f64)))
+    )
+"#;
+
+/// Two separate engines that assign the same type indices to different types.
+fn engine_pair() -> (Engine, Engine) {
+    (Engine::default(), Engine::default())
+}
+
+/// Same as [`engine_pair`], but with a customized configuration.
+fn engine_pair_with(f: impl Fn(&mut Config)) -> Result<(Engine, Engine)> {
+    let mut config = Config::new();
+    f(&mut config);
+    Ok((Engine::new(&config)?, Engine::new(&config)?))
+}
+
+/// A module that passes [`SENTINEL`] to an imported host function.
+const OBSERVER_MODULE: &str = r#"
+    (module
+        (import "" "" (func $host (param i64)))
+        (func (export "go")
+            i64.const 0x1122334455667788
+            call $host))
+"#;
+
+/// Calls a host function that takes an `i64` and returns the value that the
+/// host actually observed, which should always be [`SENTINEL`].
+///
+/// This is the canary for cross-engine corruption: if a foreign module has
+/// been registered with `store`, then filling in this host function's
+/// `VMFuncRef::wasm_call` finds the foreign engine's `(param f64)` trampoline
+/// and the host sees a garbage value instead.
+fn observe_i64_in_host(store: &mut Store<()>) -> Result<i64> {
+    let observed = Arc::new(Mutex::new(0));
+    let host = Func::wrap(&mut *store, {
+        let observed = Arc::clone(&observed);
+        move |x: i64| *observed.lock().unwrap() = x
+    });
+    let engine = store.engine().clone();
+    let module = Module::new(&engine, OBSERVER_MODULE)?;
+    let instance = Instance::new(&mut *store, &module, &[host.into()])?;
+    instance
+        .get_typed_func::<(), ()>(&mut *store, "go")?
+        .call(&mut *store, ())?;
+    let observed = *observed.lock().unwrap();
+    Ok(observed)
+}
+
+/// Same as [`observe_i64_in_host`], but for stores that have async support
+/// enabled, where the synchronous entry points may not be used.
+async fn observe_i64_in_host_async(store: &mut Store<()>) -> Result<i64> {
+    let observed = Arc::new(Mutex::new(0));
+    let host = Func::wrap(&mut *store, {
+        let observed = Arc::clone(&observed);
+        move |x: i64| *observed.lock().unwrap() = x
+    });
+    let engine = store.engine().clone();
+    let module = Module::new(&engine, OBSERVER_MODULE)?;
+    let instance = Instance::new_async(&mut *store, &module, &[host.into()]).await?;
+    instance
+        .get_typed_func::<(), ()>(&mut *store, "go")?
+        .call_async(&mut *store, ())
+        .await?;
+    let observed = *observed.lock().unwrap();
+    Ok(observed)
+}
+
+/// Asserts that `store` is still usable and that nothing in it confuses one
+/// engine's type indices for another's.
+fn assert_store_is_uncorrupted(store: &mut Store<()>) -> Result<()> {
+    assert_eq!(observe_i64_in_host(store)?, SENTINEL);
+    Ok(())
+}
+
+/// Async variant of [`assert_store_is_uncorrupted`].
+async fn assert_store_is_uncorrupted_async(store: &mut Store<()>) -> Result<()> {
+    assert_eq!(observe_i64_in_host_async(store).await?, SENTINEL);
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn instance_new_rejects_foreign_module() -> Result<()> {
+    let (a, b) = engine_pair();
+    let mut store = Store::new(&a, ());
+    let foreign = Module::new(&b, COLLIDING_MODULE)?;
+
+    Instance::new(&mut store, &foreign, &[])
+        .unwrap_err()
+        .assert_contains("cross-`Engine`");
+
+    assert_store_is_uncorrupted(&mut store)
+}
+
+/// A foreign module's imports must be rejected as cross-engine rather than
+/// type checked, since type checking would compare this engine's indices
+/// against the foreign engine's.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn instance_new_rejects_foreign_module_with_imports() -> Result<()> {
+    let (a, b) = engine_pair();
+    let mut store = Store::new(&a, ());
+
+    // Register an unrelated type first so that the host function below does not
+    // land on the same index in `a` that the module's imported type lands on in
+    // `b`.
+    let _ = Func::wrap(&mut store, |_: i32| {});
+    let host = Func::wrap(&mut store, |_: i64| {});
+
+    let foreign = Module::new(&b, r#"(module (import "" "" (func (param i64))))"#)?;
+
+    Instance::new(&mut store, &foreign, &[host.into()])
+        .unwrap_err()
+        .assert_contains("cross-`Engine`");
+
+    assert_store_is_uncorrupted(&mut store)
+}
+
+/// A linker and the module it instantiates can belong to the same engine while
+/// an individual item defined in that linker came from a store belonging to a
+/// different one, so each item has to be checked on its own.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn instantiate_pre_rejects_foreign_definition() -> Result<()> {
+    let (a, b) = engine_pair();
+
+    // Register an unrelated type first so that the function below does not land
+    // on the same index in `b` that the module's imported type lands on in `a`.
+    let mut foreign_store = Store::new(&b, ());
+    let _ = Func::wrap(&mut foreign_store, |_: i32| {});
+    let foreign = Func::wrap(&mut foreign_store, |_: f64| {});
+
+    let mut linker = Linker::<()>::new(&a);
+    linker.define(&foreign_store, "", "", foreign)?;
+
+    let module = Module::new(&a, r#"(module (import "" "" (func (param i64))))"#)?;
+
+    linker
+        .instantiate_pre(&module)
+        .err()
+        .expect("should reject an item defined from a different engine's store")
+        .assert_contains("cross-`Engine`");
+
+    let mut store = Store::new(&a, ());
+    assert_store_is_uncorrupted(&mut store)
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn instance_pre_instantiate_rejects_foreign_store() -> Result<()> {
+    let (a, b) = engine_pair();
+    let mut store = Store::new(&a, ());
+    let foreign = Module::new(&b, COLLIDING_MODULE)?;
+    let pre = Linker::<()>::new(&b).instantiate_pre(&foreign)?;
+
+    pre.instantiate(&mut store)
+        .unwrap_err()
+        .assert_contains("cross-`Engine`");
+
+    assert_store_is_uncorrupted(&mut store)
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn linker_instantiate_pre_rejects_foreign_module() -> Result<()> {
+    let (a, b) = engine_pair();
+    let foreign = Module::new(&b, COLLIDING_MODULE)?;
+
+    Linker::<()>::new(&a)
+        .instantiate_pre(&foreign)
+        .err()
+        .expect("should reject a module from a different engine")
+        .assert_contains("cross-`Engine`");
+
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn component_linker_instantiate_pre_rejects_foreign_component() -> Result<()> {
+    let (a, b) = engine_pair();
+    let foreign = Component::new(&b, COLLIDING_COMPONENT)?;
+
+    ComponentLinker::<()>::new(&a)
+        .instantiate_pre(&foreign)
+        .err()
+        .expect("should reject a component from a different engine")
+        .assert_contains("cross-`Engine`");
+
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn component_instance_pre_instantiate_rejects_foreign_store() -> Result<()> {
+    let (a, b) = engine_pair();
+    let mut store = Store::new(&a, ());
+    let foreign = Component::new(&b, COLLIDING_COMPONENT)?;
+    let pre = ComponentLinker::<()>::new(&b).instantiate_pre(&foreign)?;
+
+    pre.instantiate(&mut store)
+        .unwrap_err()
+        .assert_contains("cross-`Engine`");
+
+    assert_store_is_uncorrupted(&mut store)
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn tag_new_rejects_foreign_type() -> Result<()> {
+    let (a, b) = engine_pair_with(|config| {
+        config.wasm_exceptions(true);
+    })?;
+    let mut store = Store::new(&a, ());
+    let foreign_ty = TagType::new(FuncType::new(&b, [ValType::I32], []));
+
+    Tag::new(&mut store, &foreign_ty)
+        .unwrap_err()
+        .assert_contains("wrong engine");
+
+    assert_store_is_uncorrupted(&mut store)
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn table_new_rejects_foreign_type() -> Result<()> {
+    let (a, b) = engine_pair_with(|config| {
+        config.wasm_gc(true);
+    })?;
+    let mut store = Store::new(&a, ());
+    let foreign_struct = StructType::new(
+        &b,
+        [FieldType::new(
+            Mutability::Const,
+            StorageType::ValType(ValType::I32),
+        )],
+    )?;
+    let foreign_heap_ty = HeapType::ConcreteStruct(foreign_struct);
+    let foreign_ty = TableType::new(RefType::new(true, foreign_heap_ty.clone()), 0, None);
+
+    Table::new(&mut store, foreign_ty, Ref::null(&foreign_heap_ty))
+        .unwrap_err()
+        .assert_contains("wrong engine");
+
+    assert_store_is_uncorrupted(&mut store)
+}
+
+/// Same as [`table_new_rejects_foreign_type`], but for the async variant, which
+/// reaches the same check by a different path.
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn table_new_async_rejects_foreign_type() -> Result<()> {
+    let (a, b) = engine_pair_with(|config| {
+        config.wasm_gc(true);
+        config.async_support(true);
+    })?;
+    let mut store = Store::new(&a, ());
+    let foreign_struct = StructType::new(
+        &b,
+        [FieldType::new(
+            Mutability::Const,
+            StorageType::ValType(ValType::I32),
+        )],
+    )?;
+    let foreign_heap_ty = HeapType::ConcreteStruct(foreign_struct);
+    let foreign_ty = TableType::new(RefType::new(true, foreign_heap_ty.clone()), 0, None);
+
+    Table::new_async(&mut store, foreign_ty, Ref::null(&foreign_heap_ty))
+        .await
+        .unwrap_err()
+        .assert_contains("wrong engine");
+
+    assert_store_is_uncorrupted_async(&mut store).await
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn global_new_rejects_foreign_type() -> Result<()> {
+    let (a, b) = engine_pair_with(|config| {
+        config.wasm_gc(true);
+    })?;
+    let mut store = Store::new(&a, ());
+    let foreign_struct = StructType::new(
+        &b,
+        [FieldType::new(
+            Mutability::Const,
+            StorageType::ValType(ValType::I32),
+        )],
+    )?;
+    let foreign_heap_ty = HeapType::ConcreteStruct(foreign_struct);
+    let foreign_ty = GlobalType::new(
+        ValType::Ref(RefType::new(true, foreign_heap_ty.clone())),
+        Mutability::Const,
+    );
+
+    Global::new(&mut store, foreign_ty, Ref::null(&foreign_heap_ty).into())
+        .unwrap_err()
+        .assert_contains("wrong engine");
+
+    assert_store_is_uncorrupted(&mut store)
+}
+
+#[test]
+#[should_panic = "wrong engine"]
+fn struct_ref_pre_rejects_foreign_type() {
+    let (a, b) = engine_pair();
+    let mut store = Store::new(&a, ());
+    let foreign_ty = StructType::new(
+        &b,
+        [FieldType::new(
+            Mutability::Const,
+            StorageType::ValType(ValType::I32),
+        )],
+    )
+    .unwrap();
+
+    let _ = StructRefPre::new(&mut store, foreign_ty);
+}
+
+#[test]
+#[should_panic = "wrong engine"]
+fn array_ref_pre_rejects_foreign_type() {
+    let (a, b) = engine_pair();
+    let mut store = Store::new(&a, ());
+    let foreign_ty = ArrayType::new(
+        &b,
+        FieldType::new(Mutability::Const, StorageType::ValType(ValType::I32)),
+    );
+
+    let _ = ArrayRefPre::new(&mut store, foreign_ty);
+}
+
+#[test]
+#[should_panic = "wrong engine"]
+fn exn_ref_pre_rejects_foreign_type() {
+    let (a, b) = engine_pair_with(|config| {
+        config.wasm_exceptions(true);
+    })
+    .unwrap();
+    let mut store = Store::new(&a, ());
+    let foreign_ty = ExnType::new(&b, [ValType::I32]).unwrap();
+
+    let _ = ExnRefPre::new(&mut store, foreign_ty);
+}

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -9,6 +9,7 @@ mod cli_tests;
 mod code_too_large;
 mod component_model;
 mod coredump;
+mod cross_engine;
 mod custom_code_memory;
 mod debug;
 mod defaults;
@@ -112,14 +113,18 @@ pub(crate) fn small_pool_config() -> wasmtime::PoolingAllocationConfig {
 }
 
 pub(crate) fn gc_store() -> Result<wasmtime::Store<()>> {
+    Ok(wasmtime::Store::new(&gc_engine()?, ()))
+}
+
+/// A helper to create an engine with GC enabled.
+pub(crate) fn gc_engine() -> Result<wasmtime::Engine> {
     let _ = env_logger::try_init();
 
     let mut config = wasmtime::Config::new();
     config.wasm_function_references(true);
     config.wasm_gc(true);
 
-    let engine = wasmtime::Engine::new(&config)?;
-    Ok(wasmtime::Store::new(&engine, ()))
+    wasmtime::Engine::new(&config)
 }
 
 trait ErrorExt {

--- a/tests/all/structs.rs
+++ b/tests/all/structs.rs
@@ -1,4 +1,4 @@
-use super::gc_store;
+use super::{gc_engine, gc_store};
 use wasmtime::*;
 use wasmtime_test_macros::wasmtime_test;
 
@@ -77,10 +77,11 @@ fn struct_new_cross_store_field() {
 #[test]
 #[should_panic = "wrong store"]
 fn struct_new_cross_store_pre() {
-    let mut store = gc_store().unwrap();
-    let struct_ty = StructType::new(store.engine(), []).unwrap();
+    let engine = gc_engine().unwrap();
+    let mut store = Store::new(&engine, ());
+    let struct_ty = StructType::new(&engine, []).unwrap();
 
-    let mut other_store = gc_store().unwrap();
+    let mut other_store = Store::new(&engine, ());
     let pre = StructRefPre::new(&mut other_store, struct_ty);
 
     // This should panic.


### PR DESCRIPTION
Changes for today's security release to address https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-hgjw-h833-99q9.