### PR TITLE
fix(cranelift): Charge for initializing locals

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -485,6 +485,14 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
         self.fuel_save_from_var(builder);
     }
 
+    /// Allocating space for locals incurs a cost, even when the locals are
+    /// never used via local.set/get ops.
+    pub(crate) fn charge_fuel_for_locals(&mut self, num_locals: u32) {
+        if self.tunables.consume_fuel {
+            self.fuel_consumed += i64::from(num_locals);
+        }
+    }
+
     fn fuel_before_op(
         &mut self,
         op: &Operator<'_>,

--- a/crates/cranelift/src/translate/func_translator.rs
+++ b/crates/cranelift/src/translate/func_translator.rs
@@ -196,15 +196,18 @@ fn parse_local_decls(
 ) -> WasmResult<()> {
     let mut next_local = num_params;
     let local_count = reader.read_var_u32()?;
+    let mut overall_local_count = 0;
 
     for _ in 0..local_count {
         builder.set_srcloc(cur_srcloc(reader));
         let pos = reader.original_position();
         let count = reader.read_var_u32()?;
+        overall_local_count += count;
         let ty = reader.read()?;
         validator.define_locals(pos, count, ty)?;
         declare_locals(builder, count, ty, &mut next_local, environ)?;
     }
+    environ.charge_fuel_for_locals(overall_local_count);
 
     Ok(())
 }

--- a/tests/all/fuel.rs
+++ b/tests/all/fuel.rs
@@ -823,7 +823,9 @@ fn custom_variable_operator_cost(config: &mut Config) -> Result<()> {
                 + u64::from(variable.array_init_elem_per_element)
                 + u64::from(variable.array_new_default_per_element)
                 + u64::from(variable.array_new_per_element))
-        + 1;
+        + 1
+        // 3 locals declared, charged at function entry.
+        + 3;
     assert_eq!(consumed, cost_of_execution);
 
     Ok(())

--- a/tests/all/fuel.wast
+++ b/tests/all/fuel.wast
@@ -190,7 +190,7 @@
       end
     )
     (start $f)))
-(assert_fuel 55 ;; 5 loop instructions, 10 iterations, 2 header instrs, 1 func
+(assert_fuel 56 ;; 5 loop instructions, 10 iterations, 2 header instrs, 1 func, 1 local
   (module
     (func $f
       (local i32)
@@ -383,5 +383,22 @@
       i32.const 100
       array.new $a
       drop
+    )
+    (start $f)))
+
+;; Declaring locals costs 1 fuel each, even when they're never used. An
+;; empty function costs 3 fuel, so N locals cost 3 + N.
+(assert_fuel 4
+  (module
+    (func $f (local i32))
+    (start $f)))
+
+(assert_fuel 8
+  (module
+    (func $f
+      (local i32 i32)
+      (local i64)
+      (local f64)
+      (local funcref)
     )
     (start $f)))


### PR DESCRIPTION
This has been briefly discussed in a private zulip chat with @alexcrichton.

With this PR, 1 fuel is charged for every declared local when a function is invoked. 
The reason is that functions may declare up to 50'000 locals without using them on some execution path. In this case, no fuel is spent on accessing them, but the runtime and memory cost of initializing them may be paid anyway (if the optimizer cannot remove them due to some other execution path). In a loop, this can cause significant work that is unaccounted for by fuel. 

Locals may have different sizes which could be respected, if we wanted to charge for every byte. Should we? Fuel is currently very coarse-grained, so it does not seem appropriate to get into the details here. 