### PR TITLE
[47.0.x] Backports for today's security advisories

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1438,7 +1438,7 @@ jobs:
       - test_capi
       - test_debug_dwarf
       - test_fuzzing
-      - test_wasi_nn
+      # - test_wasi_nn
       - test_nightly
       - build
       - rustfmt

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,17 @@
+## 47.0.3
+
+Released 2026-07-31.
+
+### Fixed
+
+* Stores can mix up type indices between engines.
+  [GHSA-hgjw-h833-99q9](https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-hgjw-h833-99q9)
+
+* Preemption and traps during bulk operations enable breaking internal VM state.
+  [GHSA-2hw9-mc66-jc2q](https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-2hw9-mc66-jc2q)
+
+--------------------------------------------------------------------------------
+
 ## 47.0.2
 
 Released 2026-07-21.

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -663,21 +663,6 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
         builder.switch_to_block(continuation_block);
     }
 
-    /// Manually insert a fuel check, as opposed to what already happens around
-    /// normal loops headers and function entries.
-    ///
-    /// This can be used for expensive opcodes, such as `array.copy`, where the
-    /// operation's runtime is a function of the runtime state.
-    fn manual_fuel_check(&mut self, builder: &mut FunctionBuilder<'_>, fuel_to_consume: ir::Value) {
-        self.fuel_increment_var(builder);
-
-        let fuel = builder.use_var(self.fuel_var);
-        let fuel = builder.ins().iadd(fuel, fuel_to_consume);
-        builder.def_var(self.fuel_var, fuel);
-
-        self.fuel_check(builder);
-    }
-
     fn epoch_function_entry(&mut self, builder: &mut FunctionBuilder<'_>) {
         debug_assert!(self.epoch_deadline_var.is_reserved_value());
         self.epoch_deadline_var = builder.declare_var(ir::types::I64);
@@ -2604,6 +2589,8 @@ impl FuncEnvironment<'_> {
         delta: ir::Value,
         init_value: ir::Value,
     ) -> WasmResult<ir::Value> {
+        self.pre_translate_bulk_op(builder, delta)?;
+
         let mut pos = builder.cursor();
         let table = self.table(table_index);
         let (table_vmctx, defined_table_index) =
@@ -2644,7 +2631,16 @@ impl FuncEnvironment<'_> {
         builder.ins().brif(failed, done_block, &[], fill_block, &[]);
 
         builder.switch_to_block(fill_block);
-        self.translate_table_fill(builder, table_index, result_idx, init_value, delta)?;
+        self.translate_entity_fill(
+            builder,
+            CheckedEntity::Table {
+                table: table_index,
+                initialized: false,
+            },
+            result_idx,
+            init_value,
+            delta,
+        )?;
         builder.ins().jump(done_block, &[]);
 
         builder.switch_to_block(done_block);
@@ -3566,7 +3562,11 @@ impl FuncEnvironment<'_> {
     /// The main purpose of this helper is to handle situations when fuel and
     /// epochs are enabled to break up the copy into a loop of chunks with
     /// preemption checks between them.
-    fn raw_bulk_memory_operation(&mut self, builder: &mut FunctionBuilder<'_>, mut op: BulkOp) {
+    fn raw_bulk_memory_operation(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        op: BulkOp,
+    ) -> WasmResult<()> {
         // Fast path: a copy whose byte length is a small compile-time constant is
         // expanded inline (see `emit_inline_memcpy`), skipping the libcall's fixed
         // per-call cost (a wasm/host transition and an indirect call) that
@@ -3587,253 +3587,29 @@ impl FuncEnvironment<'_> {
         } = op
         {
             if bytes <= INLINE_COPY_MAX_BYTES {
-                if self.tunables.consume_fuel {
-                    self.fuel_consumed += bytes as i64;
-                }
                 let src_region = self.bulk_copy_alias_region(builder.func, src_entity);
                 let dst_region = self.bulk_copy_alias_region(builder.func, dst_entity);
                 self.emit_inline_memcpy(builder, dst, src, bytes, src_region, dst_region);
-                return;
+                return Ok(());
             }
         }
-
-        // Very scientifically chosen. Or, more seriously, this is just an
-        // arbitrary number for now. 100k copies of this size locally takes half
-        // a second, so seems like a reasonably large chunk size to not hit perf
-        // too much by chunking but also enable time slicing.
-        const UNINTERRUPTABLE_CHUNK_SIZE: i64 = 128 << 20;
 
         let mut pos = builder.cursor();
         let vmctx = self.vmctx_val(&mut pos);
-        let pointer_type = self.pointer_type();
 
         // Performs a raw call to the actual libcall, as dictated by the
-        // provided `op`. This unconditionally inserts epoch/fuel checks for all
-        // calls.
-        let raw_call =
-            |env: &mut FuncEnvironment<'_>, builder: &mut FunctionBuilder<'_>, op: &_| {
-                if env.tunables.epoch_interruption {
-                    env.epoch_check(builder);
-                }
-                match *op {
-                    BulkOp::MemoryCopy { dst, src, len, .. } => {
-                        if env.tunables.consume_fuel {
-                            // Note that fuel is always a 64-bit counter.
-                            let fuel_consumed = match env.pointer_type() {
-                                ir::types::I32 => builder.ins().uextend(ir::types::I64, len),
-                                ir::types::I64 => len,
-                                _ => unreachable!(),
-                            };
-                            env.manual_fuel_check(builder, fuel_consumed);
-                        }
-                        let memory_copy = env.builtin_functions.memory_copy(&mut builder.func);
-                        builder.ins().call(memory_copy, &[vmctx, dst, src, len]);
-                    }
-                    BulkOp::MemoryFill { dst, val, len } => {
-                        if env.tunables.consume_fuel {
-                            let fuel_consumed = match env.pointer_type() {
-                                ir::types::I32 => builder.ins().uextend(ir::types::I64, len),
-                                ir::types::I64 => len,
-                                _ => unreachable!(),
-                            };
-                            env.manual_fuel_check(builder, fuel_consumed);
-                        }
-                        let memory_fill = env.builtin_functions.memory_fill(&mut builder.func);
-                        builder.ins().call(memory_fill, &[vmctx, dst, val, len]);
-                    }
-                }
-            };
-
-        // If epochs and fuel are disabled, then just call the libcall and
-        // return. No need for the loops below.
-        if !self.tunables.epoch_interruption && !self.tunables.consume_fuel {
-            raw_call(self, builder, &op);
-            return;
-        }
-
-        // If fuel is enabled, first take all the pending fuel and flush it to
-        // our internal variable. This is necessary to avoid picking up all
-        // pending fuel on each turn of the loop below.
-        if self.tunables.consume_fuel {
-            self.fuel_increment_var(builder);
-        }
-
-        let current_block = builder.current_block().unwrap();
-        let chunk_block = builder.create_block();
-        let last_chunk_block = builder.create_block();
-
-        builder.ensure_inserted_block();
-        builder.insert_block_after(chunk_block, current_block);
-        builder.insert_block_after(last_chunk_block, chunk_block);
-
-        let chunk = builder
-            .ins()
-            .iconst(pointer_type, UNINTERRUPTABLE_CHUNK_SIZE);
-
-        // For `memcpy` when chunking this up we might need to do a backwards
-        // copy or a forwards copy. Determine that here and jump to the
-        // backwards copy if needed.
-        let backwards_block = if let BulkOp::MemoryCopy { dst, src, .. } = op {
-            let forwards = builder.ins().icmp(IntCC::UnsignedGreaterThan, src, dst);
-            let forwards_block = builder.create_block();
-            let backwards_block = builder.create_block();
-            builder
-                .ins()
-                .brif(forwards, forwards_block, &[], backwards_block, &[]);
-            builder.switch_to_block(forwards_block);
-            builder.seal_block(forwards_block);
-            Some((backwards_block, op.clone()))
-        } else {
-            None
-        };
-
-        // Helper closure to test if the length in `op` is larger than `chunk`,
-        // and if so do a single chunk. Else this goes to the final block with
-        // the final operation.
-        let has_chunk_branch =
-            |builder: &mut FunctionBuilder<'_>, op: &_, chunk_block, last_chunk_block| {
-                let len = match *op {
-                    BulkOp::MemoryCopy { len, .. } | BulkOp::MemoryFill { len, .. } => len,
-                };
-                let has_chunk = builder.ins().icmp(IntCC::UnsignedGreaterThan, len, chunk);
-                match *op {
-                    BulkOp::MemoryCopy { dst, src, len, .. } => {
-                        builder.ins().brif(
-                            has_chunk,
-                            chunk_block,
-                            &[dst.into(), src.into(), len.into()],
-                            last_chunk_block,
-                            &[dst.into(), src.into(), len.into()],
-                        );
-                    }
-                    BulkOp::MemoryFill { dst, len, .. } => {
-                        builder.ins().brif(
-                            has_chunk,
-                            chunk_block,
-                            &[dst.into(), len.into()],
-                            last_chunk_block,
-                            &[dst.into(), len.into()],
-                        );
-                    }
-                }
-            };
-
-        let append_block_params = |builder: &mut FunctionBuilder<'_>, block, op: &mut _| match op {
+        // provided `op`.
+        match op {
             BulkOp::MemoryCopy { dst, src, len, .. } => {
-                *dst = builder.append_block_param(block, pointer_type);
-                *src = builder.append_block_param(block, pointer_type);
-                *len = builder.append_block_param(block, pointer_type);
+                let memory_copy = self.builtin_functions.memory_copy(&mut builder.func);
+                builder.ins().call(memory_copy, &[vmctx, dst, src, len]);
             }
-            BulkOp::MemoryFill { dst, len, .. } => {
-                *dst = builder.append_block_param(block, pointer_type);
-                *len = builder.append_block_param(block, pointer_type);
+            BulkOp::MemoryFill { dst, val, len } => {
+                let memory_fill = self.builtin_functions.memory_fill(&mut builder.func);
+                builder.ins().call(memory_fill, &[vmctx, dst, val, len]);
             }
-        };
-
-        // Forwards copy: dispatch to the per-chunk loop or the final iteration
-        // if there's no chunks.
-        has_chunk_branch(builder, &op, chunk_block, last_chunk_block);
-
-        // Forwards copy: In the block with per-chunk copies, each operation
-        // performs `chunk` length of bytes and then decrements the current
-        // length by `chunk`. Afterwards a condition tests if we do another
-        // chunk or break out for the final chunk.
-        builder.switch_to_block(chunk_block);
-        append_block_params(builder, chunk_block, &mut op);
-        let op_len = match &mut op {
-            BulkOp::MemoryCopy { len, .. } | BulkOp::MemoryFill { len, .. } => len,
-        };
-        let remaining_len = *op_len;
-        *op_len = chunk;
-        raw_call(self, builder, &op);
-        match &mut op {
-            BulkOp::MemoryCopy { dst, src, len, .. } => {
-                *dst = builder.ins().iadd(*dst, chunk);
-                *src = builder.ins().iadd(*src, chunk);
-                *len = builder.ins().isub(remaining_len, chunk);
-            }
-            BulkOp::MemoryFill { len, dst, .. } => {
-                *dst = builder.ins().iadd(*dst, chunk);
-                *len = builder.ins().isub(remaining_len, chunk);
-            }
-        };
-        has_chunk_branch(builder, &op, chunk_block, last_chunk_block);
-        builder.seal_block(chunk_block);
-
-        // Backwards copy: similar to the above but with adjustments on where
-        // increments/decrements happen. Notably:
-        //
-        // * Initial src/end are the final byte address
-        // * Each chunk starts out by decrementing src/end as opposed to above
-        //   where the increment happens at the end.
-        // * The final block performs the final decrement before jumping to the
-        //   shared `last_chunk_block` between the forwards/backwards paths.
-        if let Some((backwards_block, mut op)) = backwards_block {
-            // Setup `dst=dst+len` and `src=src+len`, then see if we have a
-            // chunk.
-            builder.switch_to_block(backwards_block);
-            builder.seal_block(backwards_block);
-            let backwards_chunk_block = builder.create_block();
-            let backwards_last_chunk_block = builder.create_block();
-            let BulkOp::MemoryCopy { dst, src, len, .. } = &mut op else {
-                unreachable!()
-            };
-            *dst = builder.ins().iadd(*dst, *len);
-            *src = builder.ins().iadd(*src, *len);
-            has_chunk_branch(
-                builder,
-                &op,
-                backwards_chunk_block,
-                backwards_last_chunk_block,
-            );
-
-            // Execute the per-chunk backwards copy, adjusting pointers before
-            // the copy itself.
-            builder.switch_to_block(backwards_chunk_block);
-            append_block_params(builder, backwards_chunk_block, &mut op);
-            let BulkOp::MemoryCopy { dst, src, len, .. } = &mut op else {
-                unreachable!()
-            };
-            let remaining_len = *len;
-            *len = chunk;
-            *dst = builder.ins().isub(*dst, chunk);
-            *src = builder.ins().isub(*src, chunk);
-            raw_call(self, builder, &op);
-            let BulkOp::MemoryCopy { len, .. } = &mut op else {
-                unreachable!()
-            };
-            *len = builder.ins().isub(remaining_len, chunk);
-            has_chunk_branch(
-                builder,
-                &op,
-                backwards_chunk_block,
-                backwards_last_chunk_block,
-            );
-            builder.seal_block(backwards_chunk_block);
-
-            // Final backwards chunk: adjust the dst/src to be their true base
-            // pointers and then delegate to `last_chunk_block` for the actual
-            // memcpy.
-            builder.switch_to_block(backwards_last_chunk_block);
-            builder.seal_block(backwards_last_chunk_block);
-            append_block_params(builder, backwards_last_chunk_block, &mut op);
-            let BulkOp::MemoryCopy { dst, src, len, .. } = &mut op else {
-                unreachable!()
-            };
-            *dst = builder.ins().isub(*dst, *len);
-            *src = builder.ins().isub(*src, *len);
-            builder.ins().jump(
-                last_chunk_block,
-                &[(*dst).into(), (*src).into(), (*len).into()],
-            );
         }
-
-        // In the final block we know that the length of the operation is less
-        // than `chunk`.
-        builder.switch_to_block(last_chunk_block);
-        builder.seal_block(last_chunk_block);
-        append_block_params(builder, last_chunk_block, &mut op);
-        raw_call(self, builder, &op);
+        Ok(())
     }
 
     /// Emits a generic "fill" of `entity` from `dst` for `len` elements,
@@ -3844,6 +3620,13 @@ impl FuncEnvironment<'_> {
     /// `dst` and `len` values must be typed appropriately for `entity`. This
     /// will perform a bounds-check before actually executing the operation and
     /// then afterwards will perform the operation.
+    ///
+    /// This function will charge fuel/check epochs before it executes anything
+    /// internally. This is only done for cases where `entity` is already
+    /// initialized, however, as otherwise this wasm operation hasn't yet
+    /// completed. Callers where `entity` is uninitialized must manually invoke
+    /// `self.pre_translate_bulk_op` before calling this (probably at the start
+    /// of the entire wasm opcode).
     fn translate_entity_fill(
         &mut self,
         builder: &mut FunctionBuilder<'_>,
@@ -3855,6 +3638,10 @@ impl FuncEnvironment<'_> {
         let entity = entity.into();
         let idx_type = entity.index_type(self);
 
+        if entity.is_initialized() {
+            self.pre_translate_bulk_op(builder, len)?;
+        }
+
         // Bounds check `dst+len` and convert it to a raw heap address.
         let raw_dst_addr = self.translate_entity_bounds_check(builder, entity, dst, len)?;
 
@@ -3864,26 +3651,22 @@ impl FuncEnvironment<'_> {
             self.unchecked_cast_wasm_addr_to_native_addr(&mut builder.cursor(), len, idx_type);
 
         match entity {
-            CheckedEntity::Memory(_) => {
-                self.raw_bulk_memory_operation(
-                    builder,
-                    BulkOp::MemoryFill {
-                        dst: raw_dst_addr,
-                        val,
-                        len: len_ptr,
-                    },
-                );
-            }
+            CheckedEntity::Memory(_) => self.raw_bulk_memory_operation(
+                builder,
+                BulkOp::MemoryFill {
+                    dst: raw_dst_addr,
+                    val,
+                    len: len_ptr,
+                },
+            ),
             CheckedEntity::Table { .. } | CheckedEntity::Array { .. } => {
-                self.emit_raw_array_or_table_fill(builder, entity, raw_dst_addr, val, len_ptr)?;
+                self.emit_raw_array_or_table_fill(builder, entity, raw_dst_addr, val, len_ptr)
             }
             // Not allowed to be written to in wasm.
             CheckedEntity::Data { .. } | CheckedEntity::Elem(_) | CheckedEntity::RuntimeData(_) => {
                 unreachable!()
             }
         }
-
-        Ok(())
     }
 
     /// Performs a manual element-by-element fill of `entity`, starting at
@@ -3926,7 +3709,7 @@ impl FuncEnvironment<'_> {
         if entity.allows_memset(self)
             && let Some(value) = self.fill_value_as_memset(builder, elem_ty, value)
         {
-            self.raw_bulk_memory_operation(
+            return self.raw_bulk_memory_operation(
                 builder,
                 BulkOp::MemoryFill {
                     dst: dst_elem_addr,
@@ -3934,7 +3717,6 @@ impl FuncEnvironment<'_> {
                     len: copy_byte_len,
                 },
             );
-            return Ok(());
         }
 
         // Funcref values are intern'd when stored on the GC heap, and the
@@ -3975,12 +3757,6 @@ impl FuncEnvironment<'_> {
         builder.insert_block_after(loop_block, current_block);
         builder.insert_block_after(continue_block, loop_block);
 
-        // Before entering the loop below flush our fuel counters to ensure
-        // that previous instructions' fuel isn't counted once-per-iteration.
-        if self.tunables.consume_fuel {
-            self.fuel_increment_var(builder);
-        }
-
         // Current block: test to see if this is actually an empty copy. If it
         // is then skip over the entire loop, otherwise enter the loop and
         // perform the first ieration.
@@ -3998,11 +3774,6 @@ impl FuncEnvironment<'_> {
         // by the element size, then see if we turn again or exit.
         builder.switch_to_block(loop_block);
         let elem_addr = builder.append_block_param(loop_block, pointer_ty);
-        // Consume one unit of fuel per loop iteration.
-        if self.tunables.consume_fuel {
-            self.fuel_consumed += 1;
-        }
-        self.translate_loop_header(builder)?;
         match entity {
             CheckedEntity::Table { table, initialized } => {
                 assert!(!is_pre_interned_funcref);
@@ -4182,6 +3953,10 @@ impl FuncEnvironment<'_> {
     /// of the copy. Both `dst` and `src` have types appropriate to index their
     /// respective entities, and `len` has a type that's the smaller of the two
     /// index types.
+    ///
+    /// This function will charge fuel/check epochs before it executes anything
+    /// internally when `dst_entity` is already initialized. See
+    /// `translate_entity_fill` for information on this.
     fn translate_entity_copy(
         &mut self,
         builder: &mut FunctionBuilder<'_>,
@@ -4195,6 +3970,10 @@ impl FuncEnvironment<'_> {
         let src_entity = src_entity.into();
         let dst_idx_ty = dst_entity.index_type(self);
         let src_idx_ty = src_entity.index_type(self);
+
+        if dst_entity.is_initialized() {
+            self.pre_translate_bulk_op(builder, len)?;
+        }
 
         // The length is 32-bit if either is 32-bit, but if they're both 64-bit
         // then it's 64-bit.
@@ -4252,8 +4031,7 @@ impl FuncEnvironment<'_> {
                         src_entity,
                         dst_entity,
                     },
-                );
-                Ok(())
+                )
             }
 
             // Tables/arrays are sometimes a memcpy, sometimes a per-element
@@ -4598,7 +4376,7 @@ impl FuncEnvironment<'_> {
         // parameters (or expand it inline; see `raw_bulk_memory_operation`).
         if !type_forbids_memcpy && dst_element_size == src_element_size {
             let const_len = const_count.and_then(|c| c.checked_mul(u64::from(dst_element_size)));
-            self.raw_bulk_memory_operation(
+            return self.raw_bulk_memory_operation(
                 builder,
                 BulkOp::MemoryCopy {
                     dst: dst_elem_addr,
@@ -4609,7 +4387,6 @@ impl FuncEnvironment<'_> {
                     dst_entity,
                 },
             );
-            return Ok(());
         }
 
         // For other copies, this is a per-element loop. Use the helper to
@@ -4880,13 +4657,6 @@ impl FuncEnvironment<'_> {
         builder.insert_block_after(backwards_block, forward_block);
         builder.insert_block_after(done_block, backwards_block);
 
-        // Update our local fuel counter, if enabled, before entering the loops
-        // below. This zeros out `self.fuel_consumed` so we don't consume
-        // previous fuel on each iteration of the loop.
-        if self.tunables.consume_fuel {
-            self.fuel_increment_var(builder);
-        }
-
         // Terminate `current_block` by testing to see if we're copying any
         // elements at all.
         builder
@@ -4976,11 +4746,6 @@ impl FuncEnvironment<'_> {
         let src_cur = builder.append_block_param(forward_block, self.pointer_type());
         let src_index = builder.append_block_param(forward_block, src_index_ty);
         let forward_keepalives = append_keepalive_params(builder, forward_block);
-        // Consume a single unit of fuel on each iteration of the loop.
-        if self.tunables.consume_fuel {
-            self.fuel_consumed += 1;
-        }
-        self.translate_loop_header(builder)?;
         copy_one(self, builder, dst_cur, src_cur, src_index)?;
         let dst_next = builder
             .ins()
@@ -5006,10 +4771,6 @@ impl FuncEnvironment<'_> {
         let src_cur = builder.append_block_param(backwards_block, self.pointer_type());
         let src_index = builder.append_block_param(backwards_block, src_index_ty);
         let backward_keepalives = append_keepalive_params(builder, backwards_block);
-        if self.tunables.consume_fuel {
-            self.fuel_consumed += 1;
-        }
-        self.translate_loop_header(builder)?;
         let dst_cur = {
             let size = builder
                 .ins()
@@ -5131,6 +4892,61 @@ impl FuncEnvironment<'_> {
         );
         let ret = pos.func.dfg.inst_results(call_inst)[0];
         Ok(builder.ins().ireduce(ir::types::I32, ret))
+    }
+
+    /// Translation prefix before bulk operations such as `memory.copy`.
+    ///
+    /// Takes the `cost` of the operation, proportional to the amount of data
+    /// being moved, and checks fuel/epochs as necessary. The `cost` value is
+    /// interepreted as an unsigned integer and automatically cast up to fuel's
+    /// 64-bit type.
+    fn pre_translate_bulk_op(
+        &mut self,
+        builder: &mut FunctionBuilder,
+        cost: ir::Value,
+    ) -> WasmResult<()> {
+        let const_cost =
+            Self::value_as_const_int(builder, cost).map(|c| i64::try_from(c).unwrap_or(i64::MAX));
+
+        if self.tunables.consume_fuel {
+            match const_cost {
+                // Fold constant costs directly into internal state.
+                Some(cost) => self.fuel_consumed = self.fuel_consumed.saturating_add(cost),
+
+                None => {
+                    // Note that fuel is always a 64-bit counter.
+                    //
+                    // Also note that the cost is clamped to `i64::MAX` to
+                    // prevent fuel counter overflows since `cost` is otherwise
+                    // an untrusted value.
+                    let cost = match builder.func.dfg.value_type(cost) {
+                        ir::types::I32 => builder.ins().uextend(ir::types::I64, cost),
+                        ir::types::I64 => {
+                            let max = builder.ins().iconst(ir::types::I64, i64::MAX);
+                            builder.ins().umin(cost, max)
+                        }
+                        _ => unreachable!(),
+                    };
+                    self.fuel_increment_var(builder);
+                    let fuel = builder.use_var(self.fuel_var);
+                    let fuel = builder.ins().iadd(fuel, cost);
+                    builder.def_var(self.fuel_var, fuel);
+                }
+            }
+        }
+
+        // Skip explicit fuel/epoch checks for operations which are
+        // subjectively, and statically, considered cheap.
+        const SMALL_BULK_OP_COST: i64 = 128;
+        if let Some(cost) = const_cost
+            && cost <= SMALL_BULK_OP_COST
+        {
+            return Ok(());
+        }
+
+        // This isn't a loop header but for fuel/epoch purposes it's the same
+        // thing.
+        self.translate_loop_header(builder)
     }
 
     pub fn translate_loop_header(&mut self, builder: &mut FunctionBuilder) -> WasmResult<()> {
@@ -5968,6 +5784,7 @@ impl FuncEnvironment<'_> {
             index_type_to_ir_type(ty.idx_type),
             ty.limits.min.cast_signed(),
         );
+        self.pre_translate_bulk_op(builder, len)?;
         self.translate_entity_fill(
             builder,
             CheckedEntity::Table {
@@ -6403,6 +6220,19 @@ impl CheckedEntity {
             // Tables that are lazily initialized can't be memset because the
             // initialized bit needs to be set when storing values.
             CheckedEntity::Table { .. } => !env.tunables.table_lazy_init,
+        }
+    }
+
+    /// Returns whether this entity is initialized.
+    fn is_initialized(&self) -> bool {
+        match self {
+            CheckedEntity::Memory(_)
+            | CheckedEntity::Data { .. }
+            | CheckedEntity::RuntimeData(_)
+            | CheckedEntity::Elem(_) => true,
+            CheckedEntity::Array { initialized, .. } | CheckedEntity::Table { initialized, .. } => {
+                *initialized
+            }
         }
     }
 }

--- a/crates/cranelift/src/func_environ/gc.rs
+++ b/crates/cranelift/src/func_environ/gc.rs
@@ -773,6 +773,8 @@ pub fn translate_array_new(
     len: ir::Value,
 ) -> WasmResult<ir::Value> {
     log::trace!("translate_array_new({array_type_index:?}, {elem:?}, {len:?})");
+    func_env.pre_translate_bulk_op(builder, len)?;
+
     let result =
         gc_compiler(func_env)?.alloc_uninit_array(func_env, builder, array_type_index, len)?;
     let zero = builder.ins().iconst(ir::types::I32, 0);
@@ -799,6 +801,7 @@ pub fn translate_array_new_default(
     len: ir::Value,
 ) -> WasmResult<ir::Value> {
     log::trace!("translate_array_new_default({array_type_index:?}, {len:?})");
+    func_env.pre_translate_bulk_op(builder, len)?;
 
     let interned_ty = func_env.module.types[array_type_index].unwrap_module_type_index();
     let array_ty = func_env.types.unwrap_array(interned_ty)?;
@@ -1721,6 +1724,8 @@ pub fn translate_array_new_entity(
     entity_offset: ir::Value,
     len: ir::Value,
 ) -> WasmResult<ir::Value> {
+    env.pre_translate_bulk_op(builder, len)?;
+
     // Before actually allocating this array first do a bounds-check on the
     // passive entity itself.
     let interned_type_index = env.module.types[array_type_index].unwrap_module_type_index();

--- a/crates/wasmtime/src/runtime/component/linker.rs
+++ b/crates/wasmtime/src/runtime/component/linker.rs
@@ -227,10 +227,17 @@ impl<T: 'static> Linker<T> {
     /// `component` imports or if a name defined doesn't match the type of the
     /// item imported by the `component` provided.
     ///
+    /// Returns an error if `component` was not compiled by the same
+    /// [`Engine`](crate::Engine) as this linker.
+    ///
     /// This function will return an [`OutOfMemory`][crate::OutOfMemory] error when
     /// memory allocation fails. See the `OutOfMemory` type's documentation for
     /// details on Wasmtime's out-of-memory handling.
     pub fn instantiate_pre(&self, component: &Component) -> Result<InstancePre<T>> {
+        ensure!(
+            Engine::same(&self.engine, component.engine()),
+            "cross-`Engine` instantiation is not currently supported"
+        );
         let cx = self.typecheck(&component)?;
 
         // A successful typecheck resolves all of the imported resources used by

--- a/crates/wasmtime/src/runtime/debug.rs
+++ b/crates/wasmtime/src/runtime/debug.rs
@@ -6,7 +6,7 @@ use crate::module::RegisterBreakpointState;
 use crate::store::StoreId;
 use crate::vm::{Activation, Backtrace};
 use crate::{
-    AnyRef, AsContextMut, CodeMemory, ExnRef, Extern, ExternRef, Func, Instance, Module,
+    AnyRef, AsContextMut, CodeMemory, Engine, ExnRef, Extern, ExternRef, Func, Instance, Module,
     OwnedRooted, StoreContext, StoreContextMut, Val,
     code::StoreCodePC,
     module::ModuleRegistry,
@@ -153,8 +153,8 @@ impl StoreOpaque {
             return None;
         }
 
-        let (breakpoints, registry) = self.breakpoints_and_registry_mut();
-        Some(breakpoints.edit(registry))
+        let (breakpoints, registry, engine) = self.breakpoints_and_registry_and_engine_mut();
+        Some(breakpoints.edit(registry, engine))
     }
 
     fn debug_all_instances(&mut self) -> Vec<Instance> {
@@ -999,6 +999,8 @@ impl BreakpointKey {
 pub struct BreakpointEdit<'a> {
     state: &'a mut BreakpointState,
     registry: &'a mut ModuleRegistry,
+    /// The engine that owns everything in `registry`.
+    engine: &'a Engine,
     /// Modules that have been edited.
     ///
     /// Invariant: each of these modules' CodeMemory objects is
@@ -1007,10 +1009,15 @@ pub struct BreakpointEdit<'a> {
 }
 
 impl BreakpointState {
-    pub(crate) fn edit<'a>(&'a mut self, registry: &'a mut ModuleRegistry) -> BreakpointEdit<'a> {
+    pub(crate) fn edit<'a>(
+        &'a mut self,
+        registry: &'a mut ModuleRegistry,
+        engine: &'a Engine,
+    ) -> BreakpointEdit<'a> {
         BreakpointEdit {
             state: self,
             registry,
+            engine,
             dirty_modules: BTreeSet::new(),
         }
     }
@@ -1045,6 +1052,21 @@ impl BreakpointState {
 }
 
 impl<'a> BreakpointEdit<'a> {
+    /// Errors if `module` does not belong to the same engine as the store
+    /// being edited.
+    ///
+    /// The module registry rejects foreign modules on its own, but breakpoint
+    /// bookkeeping is updated before a module reaches the registry, and
+    /// removing a breakpoint that was never added does not touch the registry
+    /// at all. So this editing session checks up front as well.
+    fn check_engine(&self, module: &Module) -> Result<()> {
+        crate::ensure!(
+            crate::Engine::same(self.engine, module.engine()),
+            "cross-`Engine` breakpoint editing is not supported"
+        );
+        Ok(())
+    }
+
     fn get_code_memory<'b>(
         breakpoints: &BreakpointState,
         registry: &'b mut ModuleRegistry,
@@ -1089,7 +1111,13 @@ impl<'a> BreakpointEdit<'a> {
     /// available opcode PC.
     ///
     /// No effect if the breakpoint is already set.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `module` was not compiled by the same engine as
+    /// the store being edited.
     pub fn add_breakpoint(&mut self, module: &Module, pc: ModulePC) -> Result<()> {
+        self.check_engine(module)?;
         let frame_table = module
             .frame_table()
             .expect("Frame table must be present when guest-debug is enabled");
@@ -1120,7 +1148,13 @@ impl<'a> BreakpointEdit<'a> {
     /// that module.
     ///
     /// No effect if the breakpoint was not set.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `module` was not compiled by the same engine as
+    /// the store being edited.
     pub fn remove_breakpoint(&mut self, module: &Module, pc: ModulePC) -> Result<()> {
+        self.check_engine(module)?;
         let requested_key = BreakpointKey::from_raw(module, pc);
         let actual_key = self
             .state

--- a/crates/wasmtime/src/runtime/externals/global.rs
+++ b/crates/wasmtime/src/runtime/externals/global.rs
@@ -59,6 +59,9 @@ impl Global {
     /// Returns an error if the `ty` provided does not match the type of the
     /// value `val`, or if `val` comes from a different store than `store`.
     ///
+    /// Returns an error if the content type of `ty` was not created with the
+    /// same [`Engine`](crate::Engine) as `store`.
+    ///
     /// This function will return an [`OutOfMemory`][crate::OutOfMemory] error when
     /// memory allocation fails. See the `OutOfMemory` type's documentation for
     /// details on Wasmtime's out-of-memory handling.

--- a/crates/wasmtime/src/runtime/externals/table.rs
+++ b/crates/wasmtime/src/runtime/externals/table.rs
@@ -56,6 +56,9 @@ impl Table {
     /// Returns an error if `init` does not match the element type of the table,
     /// or if `init` does not belong to the `store` provided.
     ///
+    /// Returns an error if the element type of `ty` was not created with the
+    /// same [`Engine`](crate::Engine) as `store`.
+    ///
     /// This function will also return an error when used with a
     /// [`Store`](`crate::Store`) which has a
     /// [`ResourceLimiterAsync`](`crate::ResourceLimiterAsync`) (see also:
@@ -106,6 +109,9 @@ impl Table {
     /// [`ResourceLimiterAsync`](`crate::ResourceLimiterAsync`).
     ///
     /// # Errors
+    ///
+    /// Returns an error if the element type of `ty` was not created with the
+    /// same [`Engine`](crate::Engine) as `store`.
     ///
     /// This function will return an [`OutOfMemory`][crate::OutOfMemory] error when
     /// memory allocation fails. See the `OutOfMemory` type's documentation for

--- a/crates/wasmtime/src/runtime/externals/tag.rs
+++ b/crates/wasmtime/src/runtime/externals/tag.rs
@@ -27,6 +27,9 @@ impl Tag {
     ///
     /// # Errors
     ///
+    /// Returns an error if `ty` was not created with the same
+    /// [`Engine`](crate::Engine) as `store`.
+    ///
     /// This function will return an [`OutOfMemory`][crate::OutOfMemory] error when
     /// memory allocation fails. See the `OutOfMemory` type's documentation for
     /// details on Wasmtime's out-of-memory handling.

--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -2770,6 +2770,10 @@ impl HostFunc {
         );
     }
 
+    pub(crate) fn engine(&self) -> &Engine {
+        &self.engine
+    }
+
     pub(crate) fn sig_index(&self) -> VMSharedTypeIndex {
         self.func_ref().type_index
     }

--- a/crates/wasmtime/src/runtime/gc/enabled/arrayref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/arrayref.rs
@@ -70,6 +70,11 @@ pub struct ArrayRefPre {
 impl ArrayRefPre {
     /// Create a new `ArrayRefPre` that is associated with the given store
     /// and type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `ty` was not created with the same
+    /// [`Engine`](crate::Engine) as `store`.
     pub fn new(mut store: impl AsContextMut, ty: ArrayType) -> Self {
         Self::_new(store.as_context_mut().0, ty)
     }

--- a/crates/wasmtime/src/runtime/gc/enabled/exnref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/exnref.rs
@@ -73,6 +73,11 @@ pub struct ExnRefPre {
 impl ExnRefPre {
     /// Create a new `ExnRefPre` that is associated with the given store
     /// and type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `ty` was not created with the same
+    /// [`Engine`](crate::Engine) as `store`.
     pub fn new(mut store: impl AsContextMut, ty: ExnType) -> Self {
         Self::_new(store.as_context_mut().0, ty)
     }

--- a/crates/wasmtime/src/runtime/gc/enabled/structref.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/structref.rs
@@ -70,6 +70,11 @@ pub struct StructRefPre {
 impl StructRefPre {
     /// Create a new `StructRefPre` that is associated with the given store
     /// and type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `ty` was not created with the same
+    /// [`Engine`](crate::Engine) as `store`.
     pub fn new(mut store: impl AsContextMut, ty: StructType) -> Self {
         Self::_new(store.as_context_mut().0, ty)
     }

--- a/crates/wasmtime/src/runtime/instance.rs
+++ b/crates/wasmtime/src/runtime/instance.rs
@@ -219,7 +219,7 @@ impl Instance {
             }
         }
 
-        typecheck(module, imports, |cx, ty, item| {
+        typecheck(store.engine(), module, imports, |cx, ty, item| {
             let item = DefinitionType::from(store, item);
             cx.definition(ty, &item)
         })?;
@@ -815,20 +815,32 @@ impl<T: 'static> InstancePre<T> {
     /// Creates a new `InstancePre` which type-checks the `items` provided and
     /// on success is ready to instantiate a new instance.
     ///
+    /// `engine` is the engine that `items` belong to, and this returns an error
+    /// if that is not also `module`'s engine. This also returns an error if an
+    /// individual item within `items` reports an engine of its own that is not
+    /// `engine`, which happens when that item was taken from a store belonging
+    /// to a different engine than the linker it was defined in.
+    ///
     /// # Unsafety
     ///
     /// This method is unsafe as the `T` of the `InstancePre<T>` is not
     /// guaranteed to be the same as the `T` within the `Store`, the caller must
     /// verify that.
-    pub(crate) unsafe fn new(module: &Module, items: TryVec<Definition>) -> Result<InstancePre<T>> {
-        typecheck(module, &items, |cx, ty, item| cx.definition(ty, &item.ty()))?;
+    pub(crate) unsafe fn new(
+        engine: &Engine,
+        module: &Module,
+        items: TryVec<Definition>,
+    ) -> Result<InstancePre<T>> {
+        typecheck(engine, module, &items, |cx, ty, item| {
+            cx.definition(ty, &item.ty())
+        })?;
 
         let mut func_refs = TryVec::with_capacity(items.len())?;
         let mut host_funcs = 0;
         let mut asyncness = Asyncness::No;
         for item in &items {
             match item {
-                Definition::Extern(_, _) => {}
+                Definition::Extern { .. } => {}
                 Definition::HostFunc(f) => {
                     host_funcs += 1;
                     if f.func_ref().wasm_call.is_none() {
@@ -995,7 +1007,7 @@ fn pre_instantiate_raw(
         // `T` of the store. Additionally the rooting necessary has happened
         // above.
         let item = match import {
-            Definition::Extern(e, _) => e.clone(),
+            Definition::Extern { item, .. } => item.clone(),
             Definition::HostFunc(func) => unsafe {
                 func.to_func_store_rooted(
                     store,
@@ -1014,11 +1026,62 @@ fn pre_instantiate_raw(
     Ok(imports)
 }
 
+/// An item that can be supplied as an import argument during instantiation.
+///
+/// # Safety
+///
+/// Implementations must return an associated engine if they own a handle to
+/// one. Failure to do so may allow cross-`Engine` type confusion.
+///
+/// (Items that are just identifiers indexing into a store, for example
+/// `Extern::Global(wasmtime::Global)`, do not have their own handle to an
+/// engine. Their engine is the engine of the store they belong to, and it is
+/// the store, not them, that holds an owning handle to the engine.)
+unsafe trait ImportArg {
+    fn engine(&self) -> Option<&Engine>;
+}
+
+// SAFETY: `Extern::SharedMemory` is the only variant with an `Engine` handle.
+unsafe impl ImportArg for Extern {
+    fn engine(&self) -> Option<&Engine> {
+        match self {
+            Extern::SharedMemory(m) => Some(m.engine()),
+            Extern::Func(_)
+            | Extern::Global(_)
+            | Extern::Table(_)
+            | Extern::Memory(_)
+            | Extern::Tag(_) => None,
+        }
+    }
+}
+
+// SAFETY: `Definition::engine` is complete.
+unsafe impl ImportArg for Definition {
+    fn engine(&self) -> Option<&Engine> {
+        Some(Definition::engine(self))
+    }
+}
+
+/// Type check the `import_args` against the imports that `module` declares.
+///
+/// `engine` is the engine that the `import_args` belong to. It must be the same
+/// engine as `module`'s: entity types are compared by `VMSharedTypeIndex`, which
+/// only means anything within the engine that assigned it, so checking one
+/// engine's items against another engine's module would compare unrelated types
+/// and consider them equal.
 fn typecheck<I>(
+    engine: &Engine,
     module: &Module,
     import_args: &[I],
     check: impl Fn(&matching::MatchCx<'_>, &EntityType, &I) -> Result<()>,
-) -> Result<()> {
+) -> Result<()>
+where
+    I: ImportArg,
+{
+    ensure!(
+        Engine::same(engine, module.engine()),
+        "cross-`Engine` instantiation is not currently supported"
+    );
     let env_module = module.compiled_module().module();
     let expected_len = env_module.imports().count();
     let actual_len = import_args.len();
@@ -1028,6 +1091,14 @@ fn typecheck<I>(
     let cx = matching::MatchCx::new(module.engine());
     for ((name, field, expected_ty), actual) in env_module.imports().zip(import_args) {
         debug_assert!(expected_ty.is_canonicalized_for_runtime_usage());
+        if let Some(actual_engine) = actual.engine() {
+            ensure!(
+                Engine::same(actual_engine, engine),
+                "cross-`Engine` instantiation is not currently supported: \
+                 the item provided for `{name}::{field}` belongs to a \
+                 different engine than the module being instantiated"
+            );
+        }
         check(&cx, &expected_ty, actual)
             .with_context(|| format!("incompatible import type for `{name}::{field}`"))?;
     }

--- a/crates/wasmtime/src/runtime/linker.rs
+++ b/crates/wasmtime/src/runtime/linker.rs
@@ -75,9 +75,10 @@ use wasmtime_environ::{Atom, PanicOnOom, StringPool};
 /// The [`Linker`] type is not compatible with usage between multiple [`Engine`]
 /// values. An [`Engine`] is provided when a [`Linker`] is created and only
 /// stores and items which originate from that [`Engine`] can be used with this
-/// [`Linker`]. If more than one [`Engine`] is used with a [`Linker`] then that
-/// may cause a panic at runtime, similar to how if a [`Func`] is used with the
-/// wrong [`Store`] that can also panic at runtime.
+/// [`Linker`]. Instantiating a [`Module`] from another [`Engine`] returns an
+/// error, and mixing engines in other ways may cause a panic at runtime,
+/// similar to how if a [`Func`] is used with the wrong [`Store`] that can also
+/// panic at runtime.
 ///
 /// [`Store`]: crate::Store
 /// [`Global`]: crate::Global
@@ -124,7 +125,13 @@ impl TryClone for ImportKey {
 
 #[derive(Clone)]
 pub(crate) enum Definition {
-    Extern(Extern, DefinitionType),
+    Extern {
+        item: Extern,
+        ty: DefinitionType,
+        /// The engine of the store that `item` was taken from, which is the
+        /// engine that assigned any type indices within `ty`.
+        engine: Engine,
+    },
     HostFunc(Arc<HostFunc>),
 }
 
@@ -1225,6 +1232,10 @@ impl<T> Linker<T> {
     where
         T: 'static,
     {
+        ensure!(
+            Engine::same(&self.engine, module.engine()),
+            "cross-`Engine` instantiation is not currently supported"
+        );
         let mut imports: TryVec<_> = module
             .imports()
             .map(|import| Ok(self._get_by_import(&import)?))
@@ -1234,7 +1245,7 @@ impl<T> Linker<T> {
                 import.update_size(store);
             }
         }
-        unsafe { InstancePre::new(module, imports) }
+        unsafe { InstancePre::new(&self.engine, module, imports) }
     }
 
     /// Returns an iterator over all items defined in this `Linker`, in
@@ -1427,13 +1438,26 @@ impl<T: 'static> Default for Linker<T> {
 impl Definition {
     fn new(store: &StoreOpaque, item: Extern) -> Definition {
         let ty = DefinitionType::from(store, &item);
-        Definition::Extern(item, ty)
+        Definition::Extern {
+            item,
+            ty,
+            engine: store.engine().clone(),
+        }
     }
 
     pub(crate) fn ty(&self) -> DefinitionType {
         match self {
-            Definition::Extern(_, ty) => *ty,
+            Definition::Extern { ty, .. } => *ty,
             Definition::HostFunc(func) => DefinitionType::Func(func.sig_index()),
+        }
+    }
+
+    /// The engine that assigned the type indices within this definition's
+    /// [`Definition::ty`].
+    pub(crate) fn engine(&self) -> &Engine {
+        match self {
+            Definition::Extern { engine, .. } => engine,
+            Definition::HostFunc(func) => func.engine(),
         }
     }
 
@@ -1446,7 +1470,7 @@ impl Definition {
     /// `HostFunc` matches the `T` on the store.
     pub(crate) unsafe fn to_extern(&self, store: &mut StoreOpaque) -> Result<Extern, OutOfMemory> {
         match self {
-            Definition::Extern(e, _) => Ok(e.clone()),
+            Definition::Extern { item, .. } => Ok(item.clone()),
             // SAFETY: the contract of this function is the same as what's
             // required of `to_func`, that `T` of the store matches the `T` of
             // this original definition.
@@ -1456,20 +1480,32 @@ impl Definition {
 
     pub(crate) fn comes_from_same_store(&self, store: &StoreOpaque) -> bool {
         match self {
-            Definition::Extern(e, _) => e.comes_from_same_store(store),
+            Definition::Extern { item, .. } => item.comes_from_same_store(store),
             Definition::HostFunc(_func) => true,
         }
     }
 
     fn update_size(&mut self, store: &StoreOpaque) {
         match self {
-            Definition::Extern(Extern::Memory(m), DefinitionType::Memory(_, size)) => {
+            Definition::Extern {
+                item: Extern::Memory(m),
+                ty: DefinitionType::Memory(_, size),
+                ..
+            } => {
                 *size = m.internal_size(store);
             }
-            Definition::Extern(Extern::SharedMemory(m), DefinitionType::Memory(_, size)) => {
+            Definition::Extern {
+                item: Extern::SharedMemory(m),
+                ty: DefinitionType::Memory(_, size),
+                ..
+            } => {
                 *size = m.size();
             }
-            Definition::Extern(Extern::Table(m), DefinitionType::Table(_, size)) => {
+            Definition::Extern {
+                item: Extern::Table(m),
+                ty: DefinitionType::Table(_, size),
+                ..
+            } => {
                 *size = m.size_(store);
             }
             _ => {}

--- a/crates/wasmtime/src/runtime/module/registry.rs
+++ b/crates/wasmtime/src/runtime/module/registry.rs
@@ -139,6 +139,16 @@ enum ModuleOrComponent<'a> {
     Component(&'a Component),
 }
 
+impl<'a> ModuleOrComponent<'a> {
+    fn engine(&self) -> &'a Engine {
+        match self {
+            ModuleOrComponent::Module(module) => module.engine(),
+            #[cfg(feature = "component-model")]
+            ModuleOrComponent::Component(component) => component.engine(),
+        }
+    }
+}
+
 impl ModuleRegistry {
     /// Get a previously-registered module by id.
     pub fn module_by_id(&self, id: RegisteredModuleId) -> Option<&Module> {
@@ -216,6 +226,8 @@ impl ModuleRegistry {
     }
 
     /// Registers a new module with the registry.
+    ///
+    /// Returns an error if `module` was not compiled by `engine`.
     pub fn register_module(
         &mut self,
         module: &Module,
@@ -226,6 +238,9 @@ impl ModuleRegistry {
             .map(|id| id.unwrap())
     }
 
+    /// Registers a new component with the registry.
+    ///
+    /// Returns an error if `component` was not compiled by `engine`.
     #[cfg(feature = "component-model")]
     pub fn register_component(
         &mut self,
@@ -242,12 +257,24 @@ impl ModuleRegistry {
     }
 
     /// Registers a new module with the registry.
+    ///
+    /// Returns an error if `module_or_component` was not compiled by `engine`.
+    /// All code and metadata enters a store through here, so callers
+    /// registering on a store's behalf pass that store's engine to keep foreign
+    /// code out of it.
     fn register(
         &mut self,
         module_or_component: ModuleOrComponent<'_>,
         engine: &Engine,
         breakpoint_state: RegisterBreakpointState,
     ) -> Result<Option<RegisteredModuleId>> {
+        // Nothing below here may run for a foreign module or component: the
+        // type indices it carries mean something else entirely in this
+        // engine.
+        ensure!(
+            Engine::same(engine, module_or_component.engine()),
+            "cross-`Engine` usage is not supported"
+        );
         let compiled_id = match module_or_component {
             ModuleOrComponent::Module(module) => module.id(),
             #[cfg(feature = "component-model")]

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -1225,6 +1225,11 @@ impl<T> Store<T> {
     /// instantiated. This is useful for guest-debug workflows where
     /// the debugger needs to see modules to set breakpoints before
     /// the first Wasm instruction executes.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `module` was not compiled by this store's
+    /// [`Engine`].
     #[cfg(feature = "debug")]
     pub fn debug_register_module(&mut self, module: &crate::Module) -> crate::Result<()> {
         let (modules, engine, breakpoints) = self.inner.modules_and_engine_and_breakpoints_mut();
@@ -1235,11 +1240,18 @@ impl<T> Store<T> {
     /// Register all inner modules of a [`Component`](crate::component::Component)
     /// with this store's module registry for debugging, without instantiating
     /// the component.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `component` was not compiled by this store's
+    /// [`Engine`].
     #[cfg(all(feature = "debug", feature = "component-model"))]
     pub fn debug_register_component(
         &mut self,
         component: &crate::component::Component,
     ) -> crate::Result<()> {
+        let (modules, engine, breakpoints) = self.inner.modules_and_engine_and_breakpoints_mut();
+        modules.register_component(component, engine, breakpoints)?;
         for module in component.static_modules() {
             self.debug_register_module(module)?;
         }
@@ -1550,10 +1562,10 @@ impl StoreOpaque {
     }
 
     #[cfg(feature = "debug")]
-    pub(crate) fn breakpoints_and_registry_mut(
+    pub(crate) fn breakpoints_and_registry_and_engine_mut(
         &mut self,
-    ) -> (&mut BreakpointState, &mut ModuleRegistry) {
-        (&mut self.breakpoints, &mut self.modules)
+    ) -> (&mut BreakpointState, &mut ModuleRegistry, &Engine) {
+        (&mut self.breakpoints, &mut self.modules, &self.engine)
     }
 
     #[cfg(feature = "debug")]

--- a/crates/wasmtime/src/runtime/store/gc.rs
+++ b/crates/wasmtime/src/runtime/store/gc.rs
@@ -13,7 +13,8 @@ use crate::vm::{
     SendSyncPtr, StoreGcHostAllocTypes, TraceInfo, VMGcRef,
 };
 use crate::{
-    ExnRef, GcHeapOutOfMemory, Result, Rooted, Store, StoreContextMut, ThrownException, bail,
+    Engine, ExnRef, GcHeapOutOfMemory, Result, Rooted, Store, StoreContextMut, ThrownException,
+    bail,
 };
 use core::fmt;
 use core::mem::ManuallyDrop;
@@ -876,7 +877,17 @@ impl StoreOpaque {
     /// type in this store, and we don't have to worry about the type being
     /// reclaimed (since it is possible that none of the Wasm modules in this
     /// store are holding it alive).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `ty` was not registered with this store's engine. The types
+    /// here are keyed by their `VMSharedTypeIndex`, which only means anything
+    /// within the engine that assigned it.
     pub(crate) fn insert_gc_host_alloc_type(&mut self, ty: RegisteredType) {
+        assert!(
+            Engine::same(self.engine(), ty.engine()),
+            "type used with wrong engine"
+        );
         let trace_info = ty.layout().map(TraceInfo::new);
         self.gc_data
             .gc_host_alloc_types

--- a/crates/wasmtime/src/runtime/trampoline/table.rs
+++ b/crates/wasmtime/src/runtime/trampoline/table.rs
@@ -30,20 +30,22 @@ pub async fn create_table(
 
     let imports = Imports::default();
 
+    let runtime_info = ModuleRuntimeInfo::bare_with_registered_type(
+        try_new::<Arc<_>>(module)?,
+        store.engine(),
+        table.element().clone().into_registered_type(),
+    )?;
+
     unsafe {
         let allocator =
             OnDemandInstanceAllocator::new(store.engine().config().mem_creator.clone(), 0, false);
-        let module = try_new::<Arc<_>>(module)?;
         store
             .allocate_instance(
                 limiter,
                 AllocateInstanceKind::Dummy {
                     allocator: &allocator,
                 },
-                &ModuleRuntimeInfo::bare_with_registered_type(
-                    module,
-                    table.element().clone().into_registered_type(),
-                )?,
+                &runtime_info,
                 imports,
             )
             .await

--- a/crates/wasmtime/src/runtime/trampoline/tag.rs
+++ b/crates/wasmtime/src/runtime/trampoline/tag.rs
@@ -33,10 +33,19 @@ pub fn create_tag(store: &mut StoreOpaque, ty: &TagType) -> Result<InstanceId> {
 
     let imports = Imports::default();
 
+    // The tag's signature type is referred to by engine-level type index from
+    // the dummy module's `Tag`, so its `RegisteredType` must be handed to the
+    // instance's runtime info to keep that index rooted in the engine's type
+    // registry for as long as the instance (and thus the store) is alive.
+    let runtime_info = ModuleRuntimeInfo::bare_with_registered_type(
+        try_new::<Arc<_>>(module)?,
+        store.engine(),
+        Some(func_ty),
+    )?;
+
     unsafe {
         let allocator =
             OnDemandInstanceAllocator::new(store.engine().config().mem_creator.clone(), 0, false);
-        let module = try_new::<Arc<_>>(module)?;
 
         // Note that `assert_ready` should be valid here because this module
         // doesn't allocate tables or memories meaning it shouldn't need a
@@ -47,7 +56,7 @@ pub fn create_tag(store: &mut StoreOpaque, ty: &TagType) -> Result<InstanceId> {
             AllocateInstanceKind::Dummy {
                 allocator: &allocator,
             },
-            &ModuleRuntimeInfo::bare_with_registered_type(module, Some(func_ty))?,
+            &runtime_info,
             imports,
         ))
     }

--- a/crates/wasmtime/src/runtime/vm.rs
+++ b/crates/wasmtime/src/runtime/vm.rs
@@ -305,10 +305,31 @@ pub struct BareModuleInfo {
 
 impl ModuleRuntimeInfo {
     pub(crate) fn bare(module: Arc<wasmtime_environ::Module>) -> Result<Self, OutOfMemory> {
-        ModuleRuntimeInfo::bare_with_registered_type(module, None)
+        ModuleRuntimeInfo::new_bare(module, None)
     }
 
+    /// Same as [`ModuleRuntimeInfo::bare`], but additionally keeps
+    /// `registered_type` alive for as long as the resulting instance.
+    ///
+    /// This is the choke point at which a host-allocated table or tag holds a
+    /// `VMSharedTypeIndex` alive on behalf of a store, so it is where we check
+    /// that the type belongs to that store's engine. Returns an error if
+    /// `registered_type` was not registered with `engine`.
     pub(crate) fn bare_with_registered_type(
+        module: Arc<wasmtime_environ::Module>,
+        engine: &crate::Engine,
+        registered_type: Option<RegisteredType>,
+    ) -> Result<Self> {
+        if let Some(ty) = registered_type.as_ref() {
+            crate::ensure!(
+                crate::Engine::same(engine, ty.engine()),
+                "type used with wrong engine"
+            );
+        }
+        Ok(ModuleRuntimeInfo::new_bare(module, registered_type)?)
+    }
+
+    fn new_bare(
         module: Arc<wasmtime_environ::Module>,
         registered_type: Option<RegisteredType>,
     ) -> Result<Self, OutOfMemory> {

--- a/tests/all/arrays.rs
+++ b/tests/all/arrays.rs
@@ -1,6 +1,6 @@
 use crate::ErrorExt;
 
-use super::gc_store;
+use super::{gc_engine, gc_store};
 use wasmtime::*;
 
 #[test]
@@ -72,11 +72,12 @@ fn array_new_cross_store_initial_elem() {
 #[test]
 #[should_panic = "wrong store"]
 fn array_new_cross_store_pre() {
-    let mut store1 = gc_store().unwrap();
-    let mut store2 = gc_store().unwrap();
+    let engine = gc_engine().unwrap();
+    let mut store1 = Store::new(&engine, ());
+    let mut store2 = Store::new(&engine, ());
 
     let array_ty = ArrayType::new(
-        store1.engine(),
+        &engine,
         FieldType::new(Mutability::Var, StorageType::ValType(ValType::ANYREF)),
     );
     let pre = ArrayRefPre::new(&mut store2, array_ty);
@@ -157,11 +158,12 @@ fn array_new_fixed_cross_store_initial_elem() {
 #[test]
 #[should_panic = "wrong store"]
 fn array_new_fixed_cross_store_pre() {
-    let mut store1 = gc_store().unwrap();
-    let mut store2 = gc_store().unwrap();
+    let engine = gc_engine().unwrap();
+    let mut store1 = Store::new(&engine, ());
+    let mut store2 = Store::new(&engine, ());
 
     let array_ty = ArrayType::new(
-        store1.engine(),
+        &engine,
         FieldType::new(Mutability::Var, StorageType::ValType(ValType::ANYREF)),
     );
     let pre = ArrayRefPre::new(&mut store2, array_ty);

--- a/tests/all/cross_engine.rs
+++ b/tests/all/cross_engine.rs
@@ -1,0 +1,427 @@
+//! Tests that objects belonging to one `Engine` cannot be admitted into a
+//! `Store` that belongs to a different `Engine`.
+//!
+//! Type indices (`VMSharedTypeIndex`) are unique only within a single
+//! `Engine`. Two engines will happily hand out the same index for two
+//! completely unrelated types. When an object from one engine reaches a store
+//! from another, those numerically-equal-but-semantically-different indices
+//! collide:
+//!
+//! * A host function's `wasm_call` field gets patched with a Wasm-to-array
+//!   trampoline compiled for a different signature, so the trampoline reads
+//!   and writes the wrong number of `ValRaw` slots in a stack buffer.
+//!
+//! * The garbage collector traces a Wasm object using a foreign type's
+//!   layout.
+//!
+//! Every API that lets an object into a store must therefore check that the
+//! object comes from the store's engine.
+
+use crate::ErrorExt;
+use std::sync::{Arc, Mutex};
+use wasmtime::component::{Component, Linker as ComponentLinker};
+use wasmtime::*;
+
+/// The value that [`observe_i64_in_host`] sends from Wasm to the host.
+const SENTINEL: i64 = 0x1122334455667788;
+
+/// A module whose only function type is `(func (param f64))`.
+///
+/// In a freshly created engine that type gets the same `VMSharedTypeIndex` as
+/// the `(func (param i64))` type used by [`observe_i64_in_host`], so if this
+/// module is registered with a store belonging to a different engine then its
+/// trampoline is what the host function ends up calling.
+const COLLIDING_MODULE: &str = r#"(module (func (export "f") (param f64)))"#;
+
+/// [`COLLIDING_MODULE`] wrapped up in a component.
+///
+/// The core module is deliberately left uninstantiated so that instantiating
+/// this component does not itself instantiate any core module.
+const COLLIDING_COMPONENT: &str = r#"
+    (component
+        (core module (func (export "f") (param f64)))
+    )
+"#;
+
+/// Two separate engines that assign the same type indices to different types.
+fn engine_pair() -> (Engine, Engine) {
+    (Engine::default(), Engine::default())
+}
+
+/// Same as [`engine_pair`], but with a customized configuration.
+fn engine_pair_with(f: impl Fn(&mut Config)) -> Result<(Engine, Engine)> {
+    let mut config = Config::new();
+    f(&mut config);
+    Ok((Engine::new(&config)?, Engine::new(&config)?))
+}
+
+/// Calls a host function that takes an `i64` and returns the value that the
+/// host actually observed, which should always be [`SENTINEL`].
+///
+/// This is the canary for cross-engine corruption: if a foreign module has
+/// been registered with `store`, then filling in this host function's
+/// `VMFuncRef::wasm_call` finds the foreign engine's `(param f64)` trampoline
+/// and the host sees a garbage value instead.
+fn observe_i64_in_host(store: &mut Store<()>) -> Result<i64> {
+    let observed = Arc::new(Mutex::new(0));
+    let host = Func::wrap(&mut *store, {
+        let observed = Arc::clone(&observed);
+        move |x: i64| *observed.lock().unwrap() = x
+    });
+    let engine = store.engine().clone();
+    let module = Module::new(
+        &engine,
+        r#"
+            (module
+                (import "" "" (func $host (param i64)))
+                (func (export "go")
+                    i64.const 0x1122334455667788
+                    call $host))
+        "#,
+    )?;
+    let instance = Instance::new(&mut *store, &module, &[host.into()])?;
+    instance
+        .get_typed_func::<(), ()>(&mut *store, "go")?
+        .call(&mut *store, ())?;
+    let observed = *observed.lock().unwrap();
+    Ok(observed)
+}
+
+/// Asserts that `store` is still usable and that nothing in it confuses one
+/// engine's type indices for another's.
+fn assert_store_is_uncorrupted(store: &mut Store<()>) -> Result<()> {
+    assert_eq!(observe_i64_in_host(store)?, SENTINEL);
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn instance_new_rejects_foreign_module() -> Result<()> {
+    let (a, b) = engine_pair();
+    let mut store = Store::new(&a, ());
+    let foreign = Module::new(&b, COLLIDING_MODULE)?;
+
+    Instance::new(&mut store, &foreign, &[])
+        .unwrap_err()
+        .assert_contains("cross-`Engine`");
+
+    assert_store_is_uncorrupted(&mut store)
+}
+
+/// A foreign module's imports must be rejected as cross-engine rather than
+/// type checked, since type checking would compare this engine's indices
+/// against the foreign engine's.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn instance_new_rejects_foreign_module_with_imports() -> Result<()> {
+    let (a, b) = engine_pair();
+    let mut store = Store::new(&a, ());
+
+    // Register an unrelated type first so that the host function below does not
+    // land on the same index in `a` that the module's imported type lands on in
+    // `b`.
+    let _ = Func::wrap(&mut store, |_: i32| {});
+    let host = Func::wrap(&mut store, |_: i64| {});
+
+    let foreign = Module::new(&b, r#"(module (import "" "" (func (param i64))))"#)?;
+
+    Instance::new(&mut store, &foreign, &[host.into()])
+        .unwrap_err()
+        .assert_contains("cross-`Engine`");
+
+    assert_store_is_uncorrupted(&mut store)
+}
+
+/// A linker and the module it instantiates can belong to the same engine while
+/// an individual item defined in that linker came from a store belonging to a
+/// different one, so each item has to be checked on its own.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn instantiate_pre_rejects_foreign_definition() -> Result<()> {
+    let (a, b) = engine_pair();
+
+    // Register an unrelated type first so that the function below does not land
+    // on the same index in `b` that the module's imported type lands on in `a`.
+    let mut foreign_store = Store::new(&b, ());
+    let _ = Func::wrap(&mut foreign_store, |_: i32| {});
+    let foreign = Func::wrap(&mut foreign_store, |_: f64| {});
+
+    let mut linker = Linker::<()>::new(&a);
+    linker.define(&foreign_store, "", "", foreign)?;
+
+    let module = Module::new(&a, r#"(module (import "" "" (func (param i64))))"#)?;
+
+    linker
+        .instantiate_pre(&module)
+        .err()
+        .expect("should reject an item defined from a different engine's store")
+        .assert_contains("cross-`Engine`");
+
+    let mut store = Store::new(&a, ());
+    assert_store_is_uncorrupted(&mut store)
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn instance_pre_instantiate_rejects_foreign_store() -> Result<()> {
+    let (a, b) = engine_pair();
+    let mut store = Store::new(&a, ());
+    let foreign = Module::new(&b, COLLIDING_MODULE)?;
+    let pre = Linker::<()>::new(&b).instantiate_pre(&foreign)?;
+
+    pre.instantiate(&mut store)
+        .unwrap_err()
+        .assert_contains("cross-`Engine`");
+
+    assert_store_is_uncorrupted(&mut store)
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn linker_instantiate_pre_rejects_foreign_module() -> Result<()> {
+    let (a, b) = engine_pair();
+    let foreign = Module::new(&b, COLLIDING_MODULE)?;
+
+    Linker::<()>::new(&a)
+        .instantiate_pre(&foreign)
+        .err()
+        .expect("should reject a module from a different engine")
+        .assert_contains("cross-`Engine`");
+
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn debug_register_module_rejects_foreign_module() -> Result<()> {
+    let (a, b) = engine_pair();
+    let mut store = Store::new(&a, ());
+    let foreign = Module::new(&b, COLLIDING_MODULE)?;
+
+    store
+        .debug_register_module(&foreign)
+        .unwrap_err()
+        .assert_contains("cross-`Engine`");
+
+    assert_store_is_uncorrupted(&mut store)
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn debug_register_component_rejects_foreign_component() -> Result<()> {
+    let (a, b) = engine_pair();
+    let mut store = Store::new(&a, ());
+    let foreign = Component::new(&b, COLLIDING_COMPONENT)?;
+
+    store
+        .debug_register_component(&foreign)
+        .unwrap_err()
+        .assert_contains("cross-`Engine`");
+
+    assert_store_is_uncorrupted(&mut store)
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn add_breakpoint_rejects_foreign_module() -> Result<()> {
+    let (a, b) = engine_pair_with(|config| {
+        config.guest_debug(true);
+    })?;
+    let mut store = Store::new(&a, ());
+    let foreign = Module::new(&b, r#"(module (func (export "f") (param f64)))"#)?;
+
+    store
+        .edit_breakpoints()
+        .unwrap()
+        .add_breakpoint(&foreign, ModulePC::new(0))
+        .unwrap_err()
+        .assert_contains("cross-`Engine`");
+
+    assert_store_is_uncorrupted(&mut store)
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn remove_breakpoint_rejects_foreign_module() -> Result<()> {
+    let (a, b) = engine_pair_with(|config| {
+        config.guest_debug(true);
+    })?;
+    let mut store = Store::new(&a, ());
+    let foreign = Module::new(&b, r#"(module (func (export "f") (param f64)))"#)?;
+
+    store
+        .edit_breakpoints()
+        .unwrap()
+        .remove_breakpoint(&foreign, ModulePC::new(0))
+        .unwrap_err()
+        .assert_contains("cross-`Engine`");
+
+    assert_store_is_uncorrupted(&mut store)
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn component_linker_instantiate_pre_rejects_foreign_component() -> Result<()> {
+    let (a, b) = engine_pair();
+    let foreign = Component::new(&b, COLLIDING_COMPONENT)?;
+
+    ComponentLinker::<()>::new(&a)
+        .instantiate_pre(&foreign)
+        .err()
+        .expect("should reject a component from a different engine")
+        .assert_contains("cross-`Engine`");
+
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn component_instance_pre_instantiate_rejects_foreign_store() -> Result<()> {
+    let (a, b) = engine_pair();
+    let mut store = Store::new(&a, ());
+    let foreign = Component::new(&b, COLLIDING_COMPONENT)?;
+    let pre = ComponentLinker::<()>::new(&b).instantiate_pre(&foreign)?;
+
+    pre.instantiate(&mut store)
+        .unwrap_err()
+        .assert_contains("cross-`Engine`");
+
+    assert_store_is_uncorrupted(&mut store)
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn tag_new_rejects_foreign_type() -> Result<()> {
+    let (a, b) = engine_pair_with(|config| {
+        config.wasm_exceptions(true);
+    })?;
+    let mut store = Store::new(&a, ());
+    let foreign_ty = TagType::new(FuncType::new(&b, [ValType::I32], []));
+
+    Tag::new(&mut store, &foreign_ty)
+        .unwrap_err()
+        .assert_contains("wrong engine");
+
+    assert_store_is_uncorrupted(&mut store)
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn table_new_rejects_foreign_type() -> Result<()> {
+    let (a, b) = engine_pair_with(|config| {
+        config.wasm_gc(true);
+    })?;
+    let mut store = Store::new(&a, ());
+    let foreign_struct = StructType::new(
+        &b,
+        [FieldType::new(
+            Mutability::Const,
+            StorageType::ValType(ValType::I32),
+        )],
+    )?;
+    let foreign_heap_ty = HeapType::ConcreteStruct(foreign_struct);
+    let foreign_ty = TableType::new(RefType::new(true, foreign_heap_ty.clone()), 0, None);
+
+    Table::new(&mut store, foreign_ty, Ref::null(&foreign_heap_ty))
+        .unwrap_err()
+        .assert_contains("wrong engine");
+
+    assert_store_is_uncorrupted(&mut store)
+}
+
+/// Same as [`table_new_rejects_foreign_type`], but for the async variant, which
+/// reaches the same check by a different path.
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn table_new_async_rejects_foreign_type() -> Result<()> {
+    let (a, b) = engine_pair_with(|config| {
+        config.wasm_gc(true);
+    })?;
+    let mut store = Store::new(&a, ());
+    let foreign_struct = StructType::new(
+        &b,
+        [FieldType::new(
+            Mutability::Const,
+            StorageType::ValType(ValType::I32),
+        )],
+    )?;
+    let foreign_heap_ty = HeapType::ConcreteStruct(foreign_struct);
+    let foreign_ty = TableType::new(RefType::new(true, foreign_heap_ty.clone()), 0, None);
+
+    Table::new_async(&mut store, foreign_ty, Ref::null(&foreign_heap_ty))
+        .await
+        .unwrap_err()
+        .assert_contains("wrong engine");
+
+    assert_store_is_uncorrupted(&mut store)
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn global_new_rejects_foreign_type() -> Result<()> {
+    let (a, b) = engine_pair_with(|config| {
+        config.wasm_gc(true);
+    })?;
+    let mut store = Store::new(&a, ());
+    let foreign_struct = StructType::new(
+        &b,
+        [FieldType::new(
+            Mutability::Const,
+            StorageType::ValType(ValType::I32),
+        )],
+    )?;
+    let foreign_heap_ty = HeapType::ConcreteStruct(foreign_struct);
+    let foreign_ty = GlobalType::new(
+        ValType::Ref(RefType::new(true, foreign_heap_ty.clone())),
+        Mutability::Const,
+    );
+
+    Global::new(&mut store, foreign_ty, Ref::null(&foreign_heap_ty).into())
+        .unwrap_err()
+        .assert_contains("wrong engine");
+
+    assert_store_is_uncorrupted(&mut store)
+}
+
+#[test]
+#[should_panic = "wrong engine"]
+fn struct_ref_pre_rejects_foreign_type() {
+    let (a, b) = engine_pair();
+    let mut store = Store::new(&a, ());
+    let foreign_ty = StructType::new(
+        &b,
+        [FieldType::new(
+            Mutability::Const,
+            StorageType::ValType(ValType::I32),
+        )],
+    )
+    .unwrap();
+
+    let _ = StructRefPre::new(&mut store, foreign_ty);
+}
+
+#[test]
+#[should_panic = "wrong engine"]
+fn array_ref_pre_rejects_foreign_type() {
+    let (a, b) = engine_pair();
+    let mut store = Store::new(&a, ());
+    let foreign_ty = ArrayType::new(
+        &b,
+        FieldType::new(Mutability::Const, StorageType::ValType(ValType::I32)),
+    );
+
+    let _ = ArrayRefPre::new(&mut store, foreign_ty);
+}
+
+#[test]
+#[should_panic = "wrong engine"]
+fn exn_ref_pre_rejects_foreign_type() {
+    let (a, b) = engine_pair_with(|config| {
+        config.wasm_exceptions(true);
+    })
+    .unwrap();
+    let mut store = Store::new(&a, ());
+    let foreign_ty = ExnType::new(&b, [ValType::I32]).unwrap();
+
+    let _ = ExnRefPre::new(&mut store, foreign_ty);
+}

--- a/tests/all/epoch_interruption.rs
+++ b/tests/all/epoch_interruption.rs
@@ -496,3 +496,130 @@ async fn drop_future_on_epoch_yield(config: &mut Config) -> Result<()> {
     assert_eq!(true, alive_flag.load(Ordering::Acquire));
     Ok(())
 }
+
+#[test]
+fn memory_grow_in_epoch_callback() -> Result<()> {
+    let mut config = Config::new();
+    config.epoch_interruption(true);
+    config.memory_reservation(0);
+    config.memory_reservation_for_growth(0);
+    config.memory_guard_size(0);
+    config.memory_may_move(true);
+    config.memory_init_cow(false);
+    let engine = Engine::new(&config)?;
+    let module = Module::new(
+        &engine,
+        r#"
+            (module
+              (memory (export "mem") 1)
+              (func (export "go")
+                (memory.fill (i32.const 0) (i32.const 0x41) (i32.const 65536))))
+        "#,
+    )?;
+
+    let mut store: Store<Option<Memory>> = Store::new(&engine, None);
+    store.set_epoch_deadline(1);
+    store.epoch_deadline_callback(move |mut cx| {
+        if let Some(mem) = *cx.data() {
+            mem.grow(&mut cx, 5)?;
+        }
+        Ok(UpdateDeadline::Continue(0))
+    });
+
+    let instance = Instance::new(&mut store, &module, &[])?;
+    let mem = instance.get_memory(&mut store, "mem").unwrap();
+    *store.data_mut() = Some(mem);
+    engine.increment_epoch();
+
+    instance
+        .get_typed_func::<(), ()>(&mut store, "go")?
+        .call(&mut store, ())?;
+
+    let data = mem.data(&store);
+    assert_eq!(data[0], 0x41);
+    assert_eq!(data[65535], 0x41);
+    Ok(())
+}
+
+#[test]
+fn table_grow_in_epoch_callback() -> Result<()> {
+    let mut config = Config::new();
+    config.epoch_interruption(true);
+    let engine = Engine::new(&config)?;
+    let module = Module::new(
+        &engine,
+        r#"
+            (module
+              (table $t (export "t") 1 funcref)
+              (func (export "go")
+                (table.fill $t (i32.const 0) (ref.null func) (i32.const 1))))
+        "#,
+    )?;
+
+    let mut store: Store<Option<Table>> = Store::new(&engine, None);
+    store.set_epoch_deadline(1);
+    store.epoch_deadline_callback(move |mut cx| {
+        if let Some(t) = *cx.data() {
+            t.grow(&mut cx, 5, Ref::Func(None))?;
+        }
+        Ok(UpdateDeadline::Continue(0))
+    });
+
+    let instance = Instance::new(&mut store, &module, &[])?;
+    let t = instance.get_table(&mut store, "t").unwrap();
+    *store.data_mut() = Some(t);
+    engine.increment_epoch();
+
+    instance
+        .get_typed_func::<(), ()>(&mut store, "go")?
+        .call(&mut store, ())?;
+    Ok(())
+}
+
+#[test]
+fn gc_during_epoch_callback() -> Result<()> {
+    let mut config = Config::new();
+    config.epoch_interruption(true);
+    let engine = Engine::new(&config)?;
+    let module = Module::new(
+        &engine,
+        r#"
+            (module
+              (type $box (struct (field i32)))
+              (type $arr (array (mut (ref null $box))))
+              (global $sink (mut (ref null $arr)) (ref.null $arr))
+              (func $mk (param $n i32) (result (ref $arr))
+                (array.new_default $arr (local.get $n)))
+              (func (export "run") (param $n i32) (result i32)
+                (local $i i32)
+                (block $done
+                    (loop $l
+                      (br_if $done (i32.ge_u (local.get $i) (i32.const 40)))
+                      (array.fill $arr (call $mk (local.get $n)) (i32.const 0)
+                                  (struct.new $box (i32.const 7)) (local.get $n))
+                      (global.set $sink (call $mk (i32.const 8)))
+                      (local.set $i (i32.add (local.get $i) (i32.const 1)))
+                      (br $l)
+                    )
+                )
+                (i32.mul (local.get $n) (i32.const 7))))
+        "#,
+    )?;
+
+    let mut store = Store::new(&engine, ());
+    store.set_epoch_deadline(1);
+    store.epoch_deadline_callback(|mut caller| {
+        caller.gc(None)?;
+        Ok(UpdateDeadline::Continue(0))
+    });
+    engine.increment_epoch();
+
+    let instance = Instance::new(&mut store, &module, &[])?;
+    let run = instance.get_typed_func::<u32, u32>(&mut store, "run")?;
+    let n = 200;
+    for i in 0..5 {
+        let got = run.call(&mut store, n)?;
+        assert_eq!(got, 7 * n, "iteration {i} read back {got}");
+    }
+    Ok(())
+}

--- a/tests/all/fuel.rs
+++ b/tests/all/fuel.rs
@@ -693,3 +693,86 @@ fn custom_operator_cost(config: &mut Config) -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn huge_table64_grow_cannot_mint_fuel() -> Result<()> {
+    huge_table64_grow_cannot_mint_fuel_impl(
+        r#"
+        (module
+          (table $t i64 0 0x10000 (ref null func))
+          (func (export "run") (param $delta i64)
+            (loop $l
+              (drop (table.grow $t (ref.null func) (local.get $delta)))
+              (br $l))))
+        "#,
+    )
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn huge_table64_grow_cannot_mint_fuel_const() -> Result<()> {
+    huge_table64_grow_cannot_mint_fuel_impl(
+        r#"
+        (module
+          (table $t i64 0 0x10000 (ref null func))
+          (func (export "run") (param $delta i64)
+            (loop $l
+              (drop (table.grow $t (ref.null func) (i64.const -500)))
+              (br $l))))
+        "#,
+    )
+}
+
+fn huge_table64_grow_cannot_mint_fuel_impl(wat: &str) -> Result<()> {
+    let mut config = Config::new();
+    config.consume_fuel(true);
+    let engine = Engine::new(&config)?;
+    let module = Module::new(&engine, wat)?;
+
+    let mut store = Store::new(&engine, ());
+    store.set_fuel(100_000)?;
+    let instance = Instance::new(&mut store, &module, &[])?;
+    let run = instance.get_typed_func::<i64, ()>(&mut store, "run")?;
+
+    let trap = run.call(&mut store, -500).unwrap_err().downcast::<Trap>()?;
+    assert_eq!(trap, Trap::OutOfFuel);
+    assert_eq!(store.get_fuel()?, 0);
+    Ok(())
+}
+
+#[test]
+fn fuel_around_table_grow() -> Result<()> {
+    let mut config = Config::new();
+    config.consume_fuel(true);
+    let engine = Engine::new(&config)?;
+    let module = Module::new(
+        &engine,
+        r#"
+            (module
+              (type $ft (func))
+              (func $f (type $ft))
+              (table $t 1 10000000 (ref $ft) (ref.func $f))
+              (func (export "grow") (result i32)
+                (table.grow $t (ref.func $f) (i32.const 9999999)))
+              (func (export "call") (param i32)
+                (call_indirect $t (type $ft) (local.get 0))))
+        "#,
+    )?;
+
+    let mut store = Store::new(&engine, ());
+    store.set_fuel(2)?;
+    let instance = Instance::new(&mut store, &module, &[])?;
+    let grow = instance.get_typed_func::<(), i32>(&mut store, "grow")?;
+    let trap = grow.call(&mut store, ()).unwrap_err().downcast::<Trap>()?;
+    assert_eq!(trap, Trap::OutOfFuel);
+
+    store.set_fuel(u64::MAX)?;
+    let call = instance.get_typed_func::<i32, ()>(&mut store, "call")?;
+    let trap = call
+        .call(&mut store, 9999999)
+        .unwrap_err()
+        .downcast::<Trap>()?;
+    assert_eq!(trap, Trap::TableOutOfBounds);
+    Ok(())
+}

--- a/tests/all/fuel.rs
+++ b/tests/all/fuel.rs
@@ -742,6 +742,7 @@ fn huge_table64_grow_cannot_mint_fuel_impl(wat: &str) -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn fuel_around_table_grow() -> Result<()> {
     let mut config = Config::new();
     config.consume_fuel(true);

--- a/tests/all/gc.rs
+++ b/tests/all/gc.rs
@@ -3788,3 +3788,107 @@ fn initial_size_larger_than_reservation() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn array_fill_i64_gc_during_epoch() -> Result<()> {
+    gc_during_epoch(
+        r#"
+        (module
+          (type $arr (array (mut i64)))
+          (type $box (struct (field i32)))
+          (func (export "run") (param $n i32) (result i32)
+            (local $a (ref null $arr)) (local $i i32) (local $s i32)
+            (local.set $a (array.new_default $arr (local.get $n)))
+            ;; Keep the collector busy so it has something to move.
+            (drop (struct.new $box (i32.const 1)))
+            (array.fill $arr (local.get $a) (i32.const 0) (i64.const 7) (local.get $n))
+            (block $done (loop $l
+              (br_if $done (i32.ge_u (local.get $i) (local.get $n)))
+              (local.set $s (i32.add (local.get $s)
+                (i32.wrap_i64 (array.get $arr (local.get $a) (local.get $i)))))
+              (local.set $i (i32.add (local.get $i) (i32.const 1)))
+              (br $l)))
+            (local.get $s)))
+    "#,
+    )
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn array_new_gc_during_epoch() -> Result<()> {
+    gc_during_epoch(
+        r#"
+        (module
+          (type $box (struct (field i32)))
+          (type $arr (array (mut (ref null $box))))
+          (func (export "run") (param $n i32) (result i32)
+            (local $a (ref null $arr)) (local $i i32) (local $s i32)
+            (local.set $a (array.new $arr (struct.new $box (i32.const 7)) (local.get $n)))
+            (block $done (loop $l
+              (br_if $done (i32.ge_u (local.get $i) (local.get $n)))
+              (local.set $s (i32.add (local.get $s)
+                (struct.get $box 0 (ref.as_non_null
+                  (array.get $arr (local.get $a) (local.get $i))))))
+              (local.set $i (i32.add (local.get $i) (i32.const 1)))
+              (br $l)))
+            (local.get $s)))
+    "#,
+    )
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn array_copy_gc_during_epoch() -> Result<()> {
+    gc_during_epoch(
+        r#"
+        (module
+          (type $box (struct (field i32)))
+          (type $arr (array (mut (ref null $box))))
+          (func (export "run") (param $n i32) (result i32)
+            (local $a (ref null $arr)) (local $b (ref null $arr))
+            (local $i i32) (local $s i32)
+            (local.set $a (array.new_default $arr (local.get $n)))
+            (local.set $b (array.new_default $arr (local.get $n)))
+            (array.fill $arr (local.get $b) (i32.const 0)
+                        (struct.new $box (i32.const 7)) (local.get $n))
+            (array.copy $arr $arr (local.get $a) (i32.const 0)
+                                  (local.get $b) (i32.const 0) (local.get $n))
+            (block $done (loop $l
+              (br_if $done (i32.ge_u (local.get $i) (local.get $n)))
+              (local.set $s (i32.add (local.get $s)
+                (struct.get $box 0 (ref.as_non_null
+                  (array.get $arr (local.get $a) (local.get $i))))))
+              (local.set $i (i32.add (local.get $i) (i32.const 1)))
+              (br $l)))
+            (local.get $s)))
+    "#,
+    )
+}
+
+fn gc_during_epoch(wat: &str) -> Result<()> {
+    let mut config = Config::new();
+    config.epoch_interruption(true);
+    let engine = Engine::new(&config)?;
+    let module = Module::new(&engine, wat)?;
+
+    let mut store = Store::new(&engine, ());
+    store.set_epoch_deadline(1);
+    store.epoch_deadline_callback(|mut caller| {
+        caller.gc(None)?;
+        Ok(UpdateDeadline::Continue(0))
+    });
+    engine.increment_epoch();
+
+    let instance = Instance::new(&mut store, &module, &[])?;
+    let f = instance.get_typed_func::<u32, u32>(&mut store, "run")?;
+
+    let n = 100;
+    for i in 0..5 {
+        match f.call(&mut store, n) {
+            Ok(got) => assert_eq!(got, 7 * n, "iteration {i} read back {got}"),
+            Err(e) => panic!("iteration {i} failed: {e:?}"),
+        }
+    }
+    Ok(())
+}

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -9,6 +9,7 @@ mod cli_tests;
 mod compile_time_builtins;
 mod component_model;
 mod coredump;
+mod cross_engine;
 mod custom_code_memory;
 mod debug;
 mod debug_component;
@@ -125,14 +126,18 @@ pub(crate) fn small_pool_config() -> wasmtime::PoolingAllocationConfig {
 }
 
 pub(crate) fn gc_store() -> Result<wasmtime::Store<()>> {
+    Ok(wasmtime::Store::new(&gc_engine()?, ()))
+}
+
+/// A helper to create an engine with GC enabled.
+pub(crate) fn gc_engine() -> Result<wasmtime::Engine> {
     let _ = env_logger::try_init();
 
     let mut config = wasmtime::Config::new();
     config.wasm_function_references(true);
     config.wasm_gc(true);
 
-    let engine = wasmtime::Engine::new(&config)?;
-    Ok(wasmtime::Store::new(&engine, ()))
+    wasmtime::Engine::new(&config)
 }
 
 trait ErrorExt {

--- a/tests/all/structs.rs
+++ b/tests/all/structs.rs
@@ -1,4 +1,4 @@
-use super::gc_store;
+use super::{gc_engine, gc_store};
 use wasmtime::*;
 use wasmtime_test_macros::wasmtime_test;
 
@@ -77,10 +77,11 @@ fn struct_new_cross_store_field() {
 #[test]
 #[should_panic = "wrong store"]
 fn struct_new_cross_store_pre() {
-    let mut store = gc_store().unwrap();
-    let struct_ty = StructType::new(store.engine(), []).unwrap();
+    let engine = gc_engine().unwrap();
+    let mut store = Store::new(&engine, ());
+    let struct_ty = StructType::new(&engine, []).unwrap();
 
-    let mut other_store = gc_store().unwrap();
+    let mut other_store = Store::new(&engine, ());
     let pre = StructRefPre::new(&mut other_store, struct_ty);
 
     // This should panic.

--- a/tests/disas/gc/array-copy-with-fuel.wat
+++ b/tests/disas/gc/array-copy-with-fuel.wat
@@ -28,10 +28,10 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32):
-;;                                     v181 = stack_addr.i64 ss0
-;;                                     store notrap aligned region6 v2, v181
-;;                                     v182 = stack_addr.i64 ss1
-;;                                     store notrap aligned region7 v4, v182
+;;                                     v160 = stack_addr.i64 ss0
+;;                                     store notrap aligned region6 v2, v160
+;;                                     v161 = stack_addr.i64 ss1
+;;                                     store notrap aligned region7 v4, v161
 ;; @0020                               v7 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0020                               v8 = load.i64 notrap aligned region2 v7
 ;; @0020                               v9 = iconst.i64 1
@@ -41,131 +41,108 @@
 ;; @0020                               brif v12, block2, block3(v10)
 ;;
 ;;                                 block2:
-;;                                     v191 = iadd.i64 v8, v9  ; v9 = 1
-;; @0020                               store notrap aligned region2 v191, v7
+;;                                     v170 = iadd.i64 v8, v9  ; v9 = 1
+;; @0020                               store notrap aligned region2 v170, v7
 ;; @0020                               v14 = call fn0(v0), stack_map=[i32 @ ss0+0, i32 @ ss1+0]
 ;; @0020                               v16 = load.i64 notrap aligned region2 v7
 ;; @0020                               jump block3(v16)
 ;;
-;;                                 block3(v89: i64):
-;;                                     v180 = load.i32 notrap aligned region6 v181
-;; @002b                               trapz v180, user16
-;; @002b                               v24 = load.i64 notrap aligned readonly can_move region3 v7+32
-;; @002b                               v22 = uextend.i64 v180
-;; @002b                               v25 = iadd v24, v22
-;; @002b                               v26 = iconst.i64 16
-;; @002b                               v27 = iadd v25, v26  ; v26 = 16
-;; @002b                               v28 = load.i32 user2 readonly region5 v27
-;; @002b                               v30 = uextend.i64 v3
-;; @002b                               v31 = uextend.i64 v6
-;; @002b                               v34 = iadd v30, v31
-;; @002b                               v29 = uextend.i64 v28
-;; @002b                               v35 = icmp ugt v34, v29
-;; @002b                               trapnz v35, user17
-;;                                     v174 = load.i32 notrap aligned region7 v182
-;; @002b                               trapz v174, user16
-;; @002b                               v46 = uextend.i64 v174
-;; @002b                               v49 = iadd v24, v46
-;; @002b                               v51 = iadd v49, v26  ; v26 = 16
-;; @002b                               v52 = load.i32 user2 readonly region5 v51
-;; @002b                               v54 = uextend.i64 v5
-;; @002b                               v58 = iadd v54, v31
-;; @002b                               v53 = uextend.i64 v52
-;; @002b                               v59 = icmp ugt v58, v53
-;; @002b                               trapnz v59, user17
-;; @002b                               v78 = load.i64 notrap aligned region4 v7+40
-;; @002b                               v40 = iconst.i64 20
-;; @002b                               v41 = iadd v25, v40  ; v40 = 20
-;;                                     v184 = iconst.i64 2
-;;                                     v185 = ishl v30, v184  ; v184 = 2
-;; @002b                               v45 = iadd v41, v185
-;;                                     v189 = ishl v31, v184  ; v184 = 2
-;; @002b                               v80 = uadd_overflow_trap v45, v189, user2
-;; @002b                               v79 = iadd v24, v78
-;; @002b                               v81 = icmp ugt v80, v79
-;; @002b                               trapnz v81, user2
-;; @002b                               v65 = iadd v49, v40  ; v40 = 20
-;;                                     v187 = ishl v54, v184  ; v184 = 2
-;; @002b                               v69 = iadd v65, v187
-;; @002b                               v87 = uadd_overflow_trap v69, v189, user2
-;; @002b                               v88 = icmp ugt v87, v79
-;; @002b                               trapnz v88, user2
-;; @002b                               v90 = iconst.i64 6
-;; @002b                               v91 = iadd v89, v90  ; v90 = 6
-;; @002b                               brif.i32 v6, block4, block7(v91)
+;;                                 block3(v23: i64):
+;; @002b                               v24 = iconst.i64 6
+;; @002b                               v25 = iadd v23, v24  ; v24 = 6
+;; @002b                               v22 = uextend.i64 v6
+;; @002b                               v26 = iadd v25, v22
+;;                                     v171 = iconst.i64 0
+;;                                     v172 = icmp sge v26, v171  ; v171 = 0
+;; @002b                               brif v172, block4, block5(v26)
 ;;
 ;;                                 block4:
-;;                                     v162 = load.i32 notrap aligned region6 v181
-;;                                     v164 = load.i32 notrap aligned region7 v182
-;; @002b                               v92 = icmp.i64 ult v45, v69
-;;                                     v192 = iadd.i64 v89, v90  ; v90 = 6
-;; @002b                               v97 = iadd.i64 v45, v189
-;; @002b                               v98 = iadd.i64 v69, v189
-;; @002b                               v100 = iadd.i32 v5, v6
-;; @002b                               v43 = iconst.i64 4
-;; @002b                               v141 = iconst.i32 1
-;; @002b                               brif v92, block5(v45, v69, v5, v162, v164, v192), block6(v97, v98, v100, v162, v164, v192)
+;; @002b                               store.i64 notrap aligned region2 v26, v7
+;; @002b                               v30 = call fn0(v0), stack_map=[i32 @ ss0+0, i32 @ ss1+0]
+;; @002b                               v32 = load.i64 notrap aligned region2 v7
+;; @002b                               jump block5(v32)
 ;;
-;;                                 block5(v101: i64, v102: i64, v103: i32, v104: i32, v105: i32, v106: i64):
-;;                                     store notrap aligned region6 v104, v181
-;;                                     store notrap aligned region7 v105, v182
-;;                                     v202 = iconst.i64 1
-;;                                     v203 = iadd v106, v202  ; v202 = 1
-;;                                     v204 = iconst.i64 0
-;;                                     v205 = icmp sge v203, v204  ; v204 = 0
-;; @002b                               brif v205, block8, block9(v203)
+;;                                 block5(v137: i64):
+;;                                     v159 = load.i32 notrap aligned region6 v160
+;; @002b                               trapz v159, user16
+;; @002b                               v35 = load.i64 notrap aligned readonly can_move region3 v7+32
+;; @002b                               v33 = uextend.i64 v159
+;; @002b                               v36 = iadd v35, v33
+;; @002b                               v37 = iconst.i64 16
+;; @002b                               v38 = iadd v36, v37  ; v37 = 16
+;; @002b                               v39 = load.i32 user2 readonly region5 v38
+;; @002b                               v41 = uextend.i64 v3
+;; @002b                               v45 = iadd v41, v22
+;; @002b                               v40 = uextend.i64 v39
+;; @002b                               v46 = icmp ugt v45, v40
+;; @002b                               trapnz v46, user17
+;;                                     v153 = load.i32 notrap aligned region7 v161
+;; @002b                               trapz v153, user16
+;; @002b                               v57 = uextend.i64 v153
+;; @002b                               v60 = iadd v35, v57
+;; @002b                               v62 = iadd v60, v37  ; v37 = 16
+;; @002b                               v63 = load.i32 user2 readonly region5 v62
+;; @002b                               v65 = uextend.i64 v5
+;; @002b                               v69 = iadd v65, v22
+;; @002b                               v64 = uextend.i64 v63
+;; @002b                               v70 = icmp ugt v69, v64
+;; @002b                               trapnz v70, user17
+;; @002b                               v89 = load.i64 notrap aligned region4 v7+40
+;; @002b                               v51 = iconst.i64 20
+;; @002b                               v52 = iadd v36, v51  ; v51 = 20
+;;                                     v163 = iconst.i64 2
+;;                                     v164 = ishl v41, v163  ; v163 = 2
+;; @002b                               v56 = iadd v52, v164
+;;                                     v168 = ishl.i64 v22, v163  ; v163 = 2
+;; @002b                               v91 = uadd_overflow_trap v56, v168, user2
+;; @002b                               v90 = iadd v35, v89
+;; @002b                               v92 = icmp ugt v91, v90
+;; @002b                               trapnz v92, user2
+;; @002b                               v76 = iadd v60, v51  ; v51 = 20
+;;                                     v166 = ishl v65, v163  ; v163 = 2
+;; @002b                               v80 = iadd v76, v166
+;; @002b                               v98 = uadd_overflow_trap v80, v168, user2
+;; @002b                               v99 = icmp ugt v98, v90
+;; @002b                               trapnz v99, user2
+;; @002b                               brif.i32 v6, block6, block9
 ;;
-;;                                 block6(v123: i64, v124: i64, v125: i32, v126: i32, v127: i32, v128: i64):
-;;                                     store notrap aligned region7 v126, v182
-;;                                     store notrap aligned region6 v127, v181
-;;                                     v193 = iconst.i64 1
-;;                                     v194 = iadd v128, v193  ; v193 = 1
-;;                                     v195 = iconst.i64 0
-;;                                     v196 = icmp sge v194, v195  ; v195 = 0
-;; @002b                               brif v196, block10, block11(v194)
+;;                                 block6:
+;;                                     v141 = load.i32 notrap aligned region6 v160
+;;                                     v143 = load.i32 notrap aligned region7 v161
+;; @002b                               v100 = icmp.i64 ult v56, v80
+;; @002b                               v105 = iadd.i64 v56, v168
+;; @002b                               v106 = iadd.i64 v80, v168
+;; @002b                               v108 = iadd.i32 v5, v6
+;; @002b                               v54 = iconst.i64 4
+;; @002b                               v131 = iconst.i32 1
+;; @002b                               brif v100, block7(v56, v80, v5), block8(v105, v106, v108)
 ;;
-;;                                 block7(v148: i64):
+;;                                 block7(v109: i64, v110: i64, v111: i32):
+;; @002b                               v114 = load.i32 user2 little region5 v110
+;; @002b                               store user2 little region5 v114, v109
+;;                                     v178 = iconst.i64 4
+;;                                     v179 = iadd v110, v178  ; v178 = 4
+;; @002b                               v121 = icmp eq v179, v106
+;;                                     v180 = iadd v109, v178  ; v178 = 4
+;;                                     v181 = iconst.i32 1
+;;                                     v182 = iadd v111, v181  ; v181 = 1
+;; @002b                               brif v121, block9, block7(v180, v179, v182)
+;;
+;;                                 block8(v122: i64, v123: i64, v124: i32):
+;;                                     v173 = iconst.i64 4
+;;                                     v174 = isub v123, v173  ; v173 = 4
+;; @002b                               v133 = load.i32 user2 little region5 v174
+;;                                     v175 = isub v122, v173  ; v173 = 4
+;; @002b                               store user2 little region5 v133, v175
+;; @002b                               v134 = icmp eq v174, v80
+;;                                     v176 = iconst.i32 1
+;;                                     v177 = isub v124, v176  ; v176 = 1
+;; @002b                               brif v134, block9, block8(v175, v174, v177)
+;;
+;;                                 block9:
 ;; @002f                               jump block1
 ;;
-;;                                 block8:
-;; @002b                               store.i64 notrap aligned region2 v203, v7
-;; @002b                               v112 = call fn0(v0), stack_map=[i32 @ ss0+0, i32 @ ss1+0]
-;; @002b                               v114 = load.i64 notrap aligned region2 v7
-;; @002b                               jump block9(v114)
-;;
-;;                                 block9(v145: i64):
-;; @002b                               v115 = load.i32 user2 little region5 v102
-;; @002b                               store user2 little region5 v115, v101
-;;                                     v150 = load.i32 notrap aligned region6 v181
-;;                                     v152 = load.i32 notrap aligned region7 v182
-;;                                     v206 = iconst.i64 4
-;;                                     v207 = iadd.i64 v102, v206  ; v206 = 4
-;; @002b                               v122 = icmp eq v207, v98
-;;                                     v208 = iadd.i64 v101, v206  ; v206 = 4
-;;                                     v209 = iconst.i32 1
-;;                                     v210 = iadd.i32 v103, v209  ; v209 = 1
-;; @002b                               brif v122, block7(v145), block5(v208, v207, v210, v150, v152, v145)
-;;
-;;                                 block10:
-;; @002b                               store.i64 notrap aligned region2 v194, v7
-;; @002b                               v134 = call fn0(v0), stack_map=[i32 @ ss1+0, i32 @ ss0+0]
-;; @002b                               v136 = load.i64 notrap aligned region2 v7
-;; @002b                               jump block11(v136)
-;;
-;;                                 block11(v146: i64):
-;;                                     v197 = iconst.i64 4
-;;                                     v198 = isub.i64 v124, v197  ; v197 = 4
-;; @002b                               v143 = load.i32 user2 little region5 v198
-;;                                     v199 = isub.i64 v123, v197  ; v197 = 4
-;; @002b                               store user2 little region5 v143, v199
-;;                                     v156 = load.i32 notrap aligned region7 v182
-;;                                     v158 = load.i32 notrap aligned region6 v181
-;; @002b                               v144 = icmp eq v198, v69
-;;                                     v200 = iconst.i32 1
-;;                                     v201 = isub.i32 v125, v200  ; v200 = 1
-;; @002b                               brif v144, block7(v146), block6(v199, v198, v201, v156, v158, v146)
-;;
 ;;                                 block1:
-;; @002f                               store.i64 notrap aligned region2 v148, v7
+;; @002f                               store.i64 notrap aligned region2 v137, v7
 ;; @002f                               return
 ;; }

--- a/tests/disas/memory-copy-epochs.wat
+++ b/tests/disas/memory-copy-epochs.wat
@@ -37,101 +37,35 @@
 ;; @001e                               v10 = call fn0(v0)
 ;; @001e                               jump block2(v10)
 ;;
-;;                                 block2(v59: i64):
-;; @0025                               v14 = load.i64 notrap aligned region6 v0+64
-;; @0025                               v15 = uextend.i64 v2
-;; @0025                               v16 = uextend.i64 v4
-;; @0025                               v19 = iadd v15, v16
-;; @0025                               v20 = icmp ugt v19, v14
-;; @0025                               trapnz v20, heap_oob
-;; @0025                               v27 = uextend.i64 v3
-;; @0025                               v31 = iadd v27, v16
-;; @0025                               v32 = icmp ugt v31, v14
-;; @0025                               trapnz v32, heap_oob
-;; @0025                               v21 = load.i64 notrap aligned readonly can_move region5 v0+56
-;; @0025                               v37 = iadd v21, v27
-;; @0025                               v25 = iadd v21, v15
-;; @0025                               v40 = icmp ugt v37, v25
-;; @0025                               brif v40, block6, block7
+;;                                 block2(v16: i64):
+;; @0025                               v15 = load.i64 notrap aligned region3 v5
+;; @0025                               v17 = icmp uge v15, v16
+;; @0025                               brif v17, block5, block4
 ;;
-;;                                 block4(v42: i64, v43: i64, v44: i64, v47: i64):
-;; @0025                               v46 = load.i64 notrap aligned region3 v5
-;; @0025                               v48 = icmp uge v46, v47
-;; @0025                               brif v48, block9, block8(v47)
+;;                                 block5 cold:
+;; @0025                               v19 = load.i64 notrap aligned region4 v7+8
+;; @0025                               v20 = icmp.i64 uge v15, v19
+;; @0025                               brif v20, block6, block4
 ;;
-;;                                 block5(v86: i64, v87: i64, v88: i64, v92: i64):
-;; @0025                               v91 = load.i64 notrap aligned region3 v5
-;; @0025                               v94 = icmp uge v91, v92
-;; @0025                               brif v94, block17, block16
+;;                                 block6 cold:
+;; @0025                               v21 = call fn0(v0)
+;; @0025                               jump block4
 ;;
-;;                                 block6:
-;;                                     v108 = iconst.i64 0x0800_0000
-;;                                     v109 = icmp.i64 ugt v16, v108  ; v108 = 0x0800_0000
-;; @0025                               brif v109, block4(v25, v37, v16, v59), block5(v25, v37, v16, v59)
-;;
-;;                                 block9 cold:
-;; @0025                               v50 = load.i64 notrap aligned region4 v7+8
-;; @0025                               v51 = icmp.i64 uge v46, v50
-;; @0025                               brif v51, block10, block8(v50)
-;;
-;;                                 block10 cold:
-;; @0025                               v52 = call fn0(v0)
-;; @0025                               jump block8(v52)
-;;
-;;                                 block8(v60: i64):
-;; @0025                               call fn1(v0, v42, v43, v108)  ; v108 = 0x0800_0000
-;; @0025                               v55 = isub.i64 v44, v108  ; v108 = 0x0800_0000
-;; @0025                               v56 = icmp ugt v55, v108  ; v108 = 0x0800_0000
-;; @0025                               v53 = iadd.i64 v42, v108  ; v108 = 0x0800_0000
-;; @0025                               v54 = iadd.i64 v43, v108  ; v108 = 0x0800_0000
-;; @0025                               brif v56, block4(v53, v54, v55, v60), block5(v53, v54, v55, v60)
-;;
-;;                                 block7:
-;; @0025                               v39 = iconst.i64 0x0800_0000
-;; @0025                               v63 = icmp.i64 ugt v16, v39  ; v39 = 0x0800_0000
-;; @0025                               v61 = iadd.i64 v25, v16
-;; @0025                               v62 = iadd.i64 v37, v16
-;; @0025                               brif v63, block11(v61, v62, v16, v59), block12(v61, v62, v16, v59)
-;;
-;;                                 block11(v64: i64, v65: i64, v66: i64, v71: i64):
-;; @0025                               v70 = load.i64 notrap aligned region3 v5
-;; @0025                               v72 = icmp uge v70, v71
-;; @0025                               brif v72, block14, block13(v71)
-;;
-;;                                 block14 cold:
-;; @0025                               v74 = load.i64 notrap aligned region4 v7+8
-;; @0025                               v75 = icmp.i64 uge v70, v74
-;; @0025                               brif v75, block15, block13(v74)
-;;
-;;                                 block15 cold:
-;; @0025                               v76 = call fn0(v0)
-;; @0025                               jump block13(v76)
-;;
-;;                                 block13(v80: i64):
-;;                                     v103 = iconst.i64 0x0800_0000
-;;                                     v104 = isub.i64 v64, v103  ; v103 = 0x0800_0000
-;;                                     v105 = isub.i64 v65, v103  ; v103 = 0x0800_0000
-;; @0025                               call fn1(v0, v104, v105, v103)  ; v103 = 0x0800_0000
-;;                                     v106 = isub.i64 v66, v103  ; v103 = 0x0800_0000
-;;                                     v107 = icmp ugt v106, v103  ; v103 = 0x0800_0000
-;; @0025                               brif v107, block11(v104, v105, v106, v80), block12(v104, v105, v106, v80)
-;;
-;;                                 block12(v81: i64, v82: i64, v83: i64, v93: i64):
-;; @0025                               v84 = isub v81, v83
-;; @0025                               v85 = isub v82, v83
-;; @0025                               jump block5(v84, v85, v83, v93)
-;;
-;;                                 block17 cold:
-;; @0025                               v96 = load.i64 notrap aligned region4 v7+8
-;; @0025                               v97 = icmp.i64 uge v91, v96
-;; @0025                               brif v97, block18, block16
-;;
-;;                                 block18 cold:
-;; @0025                               v98 = call fn0(v0)
-;; @0025                               jump block16
-;;
-;;                                 block16:
-;; @0025                               call fn1(v0, v86, v87, v88)
+;;                                 block4:
+;; @0025                               v22 = load.i64 notrap aligned region6 v0+64
+;; @0025                               v23 = uextend.i64 v2
+;; @0025                               v24 = uextend.i64 v4
+;; @0025                               v27 = iadd v23, v24
+;; @0025                               v28 = icmp ugt v27, v22
+;; @0025                               trapnz v28, heap_oob
+;; @0025                               v35 = uextend.i64 v3
+;; @0025                               v39 = iadd v35, v24
+;; @0025                               v40 = icmp ugt v39, v22
+;; @0025                               trapnz v40, heap_oob
+;; @0025                               v29 = load.i64 notrap aligned readonly can_move region5 v0+56
+;; @0025                               v33 = iadd v29, v23
+;; @0025                               v45 = iadd v29, v35
+;; @0025                               call fn1(v0, v33, v45, v24)
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/memory-copy-fuel-const-len.wat
+++ b/tests/disas/memory-copy-fuel-const-len.wat
@@ -1,0 +1,184 @@
+;;! target = 'x86_64'
+;;! test = 'optimize'
+;;! flags = '-Wfuel=100'
+
+(module
+  (memory 1)
+  (func $copy_16 (param i32 i32)
+    (memory.copy (local.get 0) (local.get 1) (i32.const 16))
+  )
+  (func $fill_128 (param i32)
+    (memory.fill (local.get 0) (i32.const 0) (i32.const 128))
+  )
+  (func $fill_4096 (param i32)
+    (memory.fill (local.get 0) (i32.const 0) (i32.const 4096))
+  )
+)
+;; function u0:0(i64 vmctx, i64, i32, i32) tail {
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108864 "VMStoreContext+0x0"
+;;     region3 = 603979776 "VMMemoryDefinition+0x0"
+;;     region4 = 603979784 "VMMemoryDefinition+0x8"
+;;     region5 = 201326592 "DefinedMemory(StaticModuleIndex(0), DefinedMemoryIndex(0))"
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
+;;     sig0 = (i64 vmctx) -> i8 tail
+;;     fn0 = colocated u805306368:12 sig0
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32):
+;; @0023                               v4 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0023                               v5 = load.i64 notrap aligned region2 v4
+;; @0023                               v6 = iconst.i64 1
+;; @0023                               v7 = iadd v5, v6  ; v6 = 1
+;; @0023                               v8 = iconst.i64 0
+;; @0023                               v9 = icmp sge v7, v8  ; v8 = 0
+;; @0023                               brif v9, block2, block3(v7)
+;;
+;;                                 block2:
+;;                                     v58 = iadd.i64 v5, v6  ; v6 = 1
+;; @0023                               store notrap aligned region2 v58, v4
+;; @0023                               v11 = call fn0(v0)
+;; @0023                               v13 = load.i64 notrap aligned region2 v4
+;; @0023                               jump block3(v13)
+;;
+;;                                 block3(v43: i64):
+;; @002a                               v17 = load.i64 notrap aligned region4 v0+64
+;; @002a                               v18 = uextend.i64 v2
+;;                                     v47 = iconst.i64 16
+;; @002a                               v22 = iadd v18, v47  ; v47 = 16
+;; @002a                               v23 = icmp ugt v22, v17
+;; @002a                               trapnz v23, heap_oob
+;; @002a                               v30 = uextend.i64 v3
+;; @002a                               v34 = iadd v30, v47  ; v47 = 16
+;; @002a                               v35 = icmp ugt v34, v17
+;; @002a                               trapnz v35, heap_oob
+;; @002a                               v24 = load.i64 notrap aligned readonly can_move region3 v0+56
+;; @002a                               v40 = iadd v24, v30
+;; @002a                               v42 = load.i8x16 notrap aligned little region5 v40
+;; @002a                               v28 = iadd v24, v18
+;; @002a                               store notrap aligned little region5 v42, v28
+;; @002e                               jump block1
+;;
+;;                                 block1:
+;; @002e                               v44 = iconst.i64 20
+;; @002e                               v45 = iadd.i64 v43, v44  ; v44 = 20
+;; @002e                               store notrap aligned region2 v45, v4
+;; @002e                               return
+;; }
+;;
+;; function u0:1(i64 vmctx, i64, i32) tail {
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108864 "VMStoreContext+0x0"
+;;     region3 = 603979776 "VMMemoryDefinition+0x0"
+;;     region4 = 603979784 "VMMemoryDefinition+0x8"
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
+;;     sig0 = (i64 vmctx) -> i8 tail
+;;     sig1 = (i64 vmctx, i64, i32, i64) tail
+;;     fn0 = colocated u805306368:12 sig0
+;;     fn1 = colocated u805306368:2 sig1
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32):
+;; @0030                               v3 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0030                               v4 = load.i64 notrap aligned region2 v3
+;; @0030                               v5 = iconst.i64 1
+;; @0030                               v6 = iadd v4, v5  ; v5 = 1
+;; @0030                               v7 = iconst.i64 0
+;; @0030                               v8 = icmp sge v6, v7  ; v7 = 0
+;; @0030                               brif v8, block2, block3(v6)
+;;
+;;                                 block2:
+;;                                     v43 = iadd.i64 v4, v5  ; v5 = 1
+;; @0030                               store notrap aligned region2 v43, v3
+;; @0030                               v10 = call fn0(v0)
+;; @0030                               v12 = load.i64 notrap aligned region2 v3
+;; @0030                               jump block3(v12)
+;;
+;;                                 block3(v29: i64):
+;; @0038                               v16 = load.i64 notrap aligned region4 v0+64
+;; @0038                               v17 = uextend.i64 v2
+;;                                     v33 = iconst.i64 128
+;; @0038                               v21 = iadd v17, v33  ; v33 = 128
+;; @0038                               v22 = icmp ugt v21, v16
+;; @0038                               trapnz v22, heap_oob
+;; @0038                               v23 = load.i64 notrap aligned readonly can_move region3 v0+56
+;; @0038                               v27 = iadd v23, v17
+;; @0033                               v14 = iconst.i32 0
+;; @0038                               call fn1(v0, v27, v14, v33)  ; v14 = 0, v33 = 128
+;; @003b                               jump block1
+;;
+;;                                 block1:
+;; @003b                               v30 = iconst.i64 132
+;; @003b                               v31 = iadd.i64 v29, v30  ; v30 = 132
+;; @003b                               store notrap aligned region2 v31, v3
+;; @003b                               return
+;; }
+;;
+;; function u0:2(i64 vmctx, i64, i32) tail {
+;;     region0 = 8 "VMContext+0x8"
+;;     region1 = 67108888 "VMStoreContext+0x18"
+;;     region2 = 67108864 "VMStoreContext+0x0"
+;;     region3 = 603979776 "VMMemoryDefinition+0x0"
+;;     region4 = 603979784 "VMMemoryDefinition+0x8"
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
+;;     gv2 = load.i64 notrap aligned region1 gv1+24
+;;     sig0 = (i64 vmctx) -> i8 tail
+;;     sig1 = (i64 vmctx, i64, i32, i64) tail
+;;     fn0 = colocated u805306368:12 sig0
+;;     fn1 = colocated u805306368:2 sig1
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32):
+;; @003d                               v3 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @003d                               v4 = load.i64 notrap aligned region2 v3
+;; @003d                               v5 = iconst.i64 1
+;; @003d                               v6 = iadd v4, v5  ; v5 = 1
+;; @003d                               v7 = iconst.i64 0
+;; @003d                               v8 = icmp sge v6, v7  ; v7 = 0
+;; @003d                               brif v8, block2, block3(v6)
+;;
+;;                                 block2:
+;;                                     v50 = iadd.i64 v4, v5  ; v5 = 1
+;; @003d                               store notrap aligned region2 v50, v3
+;; @003d                               v10 = call fn0(v0)
+;; @003d                               v12 = load.i64 notrap aligned region2 v3
+;; @003d                               jump block3(v12)
+;;
+;;                                 block3(v16: i64):
+;; @0045                               v17 = iconst.i64 4100
+;; @0045                               v18 = iadd v16, v17  ; v17 = 4100
+;;                                     v51 = iconst.i64 0
+;;                                     v52 = icmp sge v18, v51  ; v51 = 0
+;; @0045                               brif v52, block4, block5(v18)
+;;
+;;                                 block4:
+;;                                     v53 = iadd.i64 v16, v17  ; v17 = 4100
+;; @0045                               store notrap aligned region2 v53, v3
+;; @0045                               v22 = call fn0(v0)
+;; @0045                               v24 = load.i64 notrap aligned region2 v3
+;; @0045                               jump block5(v24)
+;;
+;;                                 block5(v39: i64):
+;; @0045                               v25 = load.i64 notrap aligned region4 v0+64
+;; @0045                               v26 = uextend.i64 v2
+;;                                     v40 = iconst.i64 4096
+;; @0045                               v30 = iadd v26, v40  ; v40 = 4096
+;; @0045                               v31 = icmp ugt v30, v25
+;; @0045                               trapnz v31, heap_oob
+;; @0045                               v32 = load.i64 notrap aligned readonly can_move region3 v0+56
+;; @0045                               v36 = iadd v32, v26
+;; @0040                               v14 = iconst.i32 0
+;; @0045                               call fn1(v0, v36, v14, v40)  ; v14 = 0, v40 = 4096
+;; @0048                               jump block1
+;;
+;;                                 block1:
+;; @0048                               store.i64 notrap aligned region2 v39, v3
+;; @0048                               return
+;; }

--- a/tests/disas/memory-copy-fuel.wat
+++ b/tests/disas/memory-copy-fuel.wat
@@ -33,110 +33,44 @@
 ;; @001e                               brif v10, block2, block3(v8)
 ;;
 ;;                                 block2:
-;;                                     v106 = iadd.i64 v6, v7  ; v7 = 1
-;; @001e                               store notrap aligned region2 v106, v5
+;;                                     v59 = iadd.i64 v6, v7  ; v7 = 1
+;; @001e                               store notrap aligned region2 v59, v5
 ;; @001e                               v12 = call fn0(v0)
 ;; @001e                               v14 = load.i64 notrap aligned region2 v5
 ;; @001e                               jump block3(v14)
 ;;
-;;                                 block3(v43: i64):
-;; @0025                               v18 = load.i64 notrap aligned region4 v0+64
-;; @0025                               v19 = uextend.i64 v2
-;; @0025                               v20 = uextend.i64 v4
-;; @0025                               v23 = iadd v19, v20
-;; @0025                               v24 = icmp ugt v23, v18
-;; @0025                               trapnz v24, heap_oob
-;; @0025                               v31 = uextend.i64 v3
-;; @0025                               v35 = iadd v31, v20
-;; @0025                               v36 = icmp ugt v35, v18
-;; @0025                               trapnz v36, heap_oob
-;; @0025                               v25 = load.i64 notrap aligned readonly can_move region3 v0+56
-;; @0025                               v41 = iadd v25, v31
-;; @0025                               v29 = iadd v25, v19
-;; @0025                               v47 = icmp ugt v41, v29
-;; @0025                               brif v47, block6, block7
+;;                                 block3(v19: i64):
+;; @0025                               v20 = iconst.i64 4
+;; @0025                               v21 = iadd v19, v20  ; v20 = 4
+;; @0025                               v18 = uextend.i64 v4
+;; @0025                               v22 = iadd v21, v18
+;;                                     v60 = iconst.i64 0
+;;                                     v61 = icmp sge v22, v60  ; v60 = 0
+;; @0025                               brif v61, block4, block5(v22)
 ;;
-;;                                 block4(v49: i64, v50: i64, v51: i64, v52: i64):
-;; @0025                               v53 = iadd v52, v116  ; v116 = 0x0800_0000
-;;                                     v120 = iconst.i64 0
-;;                                     v121 = icmp sge v53, v120  ; v120 = 0
-;; @0025                               brif v121, block8, block9(v53)
+;;                                 block4:
+;; @0025                               store.i64 notrap aligned region2 v22, v5
+;; @0025                               v26 = call fn0(v0)
+;; @0025                               v28 = load.i64 notrap aligned region2 v5
+;; @0025                               jump block5(v28)
 ;;
-;;                                 block5(v89: i64, v90: i64, v91: i64, v92: i64):
-;; @0025                               v94 = iadd v92, v91
-;;                                     v123 = iconst.i64 0
-;;                                     v124 = icmp sge v94, v123  ; v123 = 0
-;; @0025                               brif v124, block14, block15(v94)
-;;
-;;                                 block6:
-;;                                     v116 = iconst.i64 0x0800_0000
-;;                                     v117 = icmp.i64 ugt v20, v116  ; v116 = 0x0800_0000
-;;                                     v118 = iconst.i64 4
-;;                                     v119 = iadd.i64 v43, v118  ; v118 = 4
-;; @0025                               brif v117, block4(v29, v41, v20, v119), block5(v29, v41, v20, v119)
-;;
-;;                                 block8:
-;;                                     v122 = iadd.i64 v52, v116  ; v116 = 0x0800_0000
-;; @0025                               store notrap aligned region2 v122, v5
-;; @0025                               v57 = call fn0(v0)
-;; @0025                               v59 = load.i64 notrap aligned region2 v5
-;; @0025                               jump block9(v59)
-;;
-;;                                 block9(v64: i64):
-;; @0025                               call fn1(v0, v49, v50, v116)  ; v116 = 0x0800_0000
-;; @0025                               v62 = isub.i64 v51, v116  ; v116 = 0x0800_0000
-;; @0025                               v63 = icmp ugt v62, v116  ; v116 = 0x0800_0000
-;; @0025                               v60 = iadd.i64 v49, v116  ; v116 = 0x0800_0000
-;; @0025                               v61 = iadd.i64 v50, v116  ; v116 = 0x0800_0000
-;; @0025                               brif v63, block4(v60, v61, v62, v64), block5(v60, v61, v62, v64)
-;;
-;;                                 block7:
-;; @0025                               v46 = iconst.i64 0x0800_0000
-;; @0025                               v67 = icmp.i64 ugt v20, v46  ; v46 = 0x0800_0000
-;; @0025                               v65 = iadd.i64 v29, v20
-;; @0025                               v66 = iadd.i64 v41, v20
-;; @0025                               v44 = iconst.i64 4
-;; @0025                               v45 = iadd.i64 v43, v44  ; v44 = 4
-;; @0025                               brif v67, block10(v65, v66, v20, v45), block11(v65, v66, v20, v45)
-;;
-;;                                 block10(v68: i64, v69: i64, v70: i64, v73: i64):
-;;                                     v107 = iconst.i64 0x0800_0000
-;;                                     v108 = iadd v73, v107  ; v107 = 0x0800_0000
-;;                                     v109 = iconst.i64 0
-;;                                     v110 = icmp sge v108, v109  ; v109 = 0
-;; @0025                               brif v110, block12, block13(v108)
-;;
-;;                                 block12:
-;; @0025                               store.i64 notrap aligned region2 v108, v5
-;; @0025                               v78 = call fn0(v0)
-;; @0025                               v80 = load.i64 notrap aligned region2 v5
-;; @0025                               jump block13(v80)
-;;
-;;                                 block13(v83: i64):
-;;                                     v111 = iconst.i64 0x0800_0000
-;;                                     v112 = isub.i64 v68, v111  ; v111 = 0x0800_0000
-;;                                     v113 = isub.i64 v69, v111  ; v111 = 0x0800_0000
-;; @0025                               call fn1(v0, v112, v113, v111)  ; v111 = 0x0800_0000
-;;                                     v114 = isub.i64 v70, v111  ; v111 = 0x0800_0000
-;;                                     v115 = icmp ugt v114, v111  ; v111 = 0x0800_0000
-;; @0025                               brif v115, block10(v112, v113, v114, v83), block11(v112, v113, v114, v83)
-;;
-;;                                 block11(v84: i64, v85: i64, v86: i64, v93: i64):
-;; @0025                               v87 = isub v84, v86
-;; @0025                               v88 = isub v85, v86
-;; @0025                               jump block5(v87, v88, v86, v93)
-;;
-;;                                 block14:
-;; @0025                               store.i64 notrap aligned region2 v94, v5
-;; @0025                               v98 = call fn0(v0)
-;; @0025                               v100 = load.i64 notrap aligned region2 v5
-;; @0025                               jump block15(v100)
-;;
-;;                                 block15(v102: i64):
-;; @0025                               call fn1(v0, v89, v90, v91)
+;;                                 block5(v55: i64):
+;; @0025                               v29 = load.i64 notrap aligned region4 v0+64
+;; @0025                               v30 = uextend.i64 v2
+;; @0025                               v34 = iadd v30, v18
+;; @0025                               v35 = icmp ugt v34, v29
+;; @0025                               trapnz v35, heap_oob
+;; @0025                               v42 = uextend.i64 v3
+;; @0025                               v46 = iadd v42, v18
+;; @0025                               v47 = icmp ugt v46, v29
+;; @0025                               trapnz v47, heap_oob
+;; @0025                               v36 = load.i64 notrap aligned readonly can_move region3 v0+56
+;; @0025                               v40 = iadd v36, v30
+;; @0025                               v52 = iadd v36, v42
+;; @0025                               call fn1(v0, v40, v52, v18)
 ;; @0029                               jump block1
 ;;
 ;;                                 block1:
-;; @0029                               store.i64 notrap aligned region2 v102, v5
+;; @0029                               store.i64 notrap aligned region2 v55, v5
 ;; @0029                               return
 ;; }


### PR DESCRIPTION
Changes for today's security release to address https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-hgjw-h833-99q9 and https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-2hw9-mc66-jc2q