### PR TITLE
Reword vulnerability runbook a bit

### DIFF
--- a/docs/security-vulnerability-runbook.md
+++ b/docs/security-vulnerability-runbook.md
@@ -114,7 +114,13 @@ is created these steps are followed:
 You'll want to pay close attention to CI on release day. There's likely going to
 be CI failures with the fix for the vulnerability for some build configurations
 or platforms and such. It should be easy to fix though so mostly try to stay on
-top of it. Additionally be sure to carefully watch the publish process to
-crates.io. It's possible to hit rate limits in crate publication which
-necessitates a retry of the job later. You can also try publishing locally too
-from the release branch, but it's best to do it through CI.
+top of it.
+
+Another thing to watch out for is flaky tests or spurious failures that have
+been fixed on `main`. Spurious test failures are generally not proactively
+backported to release branches, so you might need to cherry-pick changes from
+`main` related to test infrastructure in case flaky tests cause problems.
+
+Finally, be sure to carefully watch the publish process to crates.io triggered
+after the version-bump PRs are merged. It's possible to hit rate limits or other
+spurious errors in crate publication which necessitates a retry of the job.


### PR DESCRIPTION
Every time we do a security release I apparently find a tweak I want to make, so here's the tweak for this one.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
