### PR TITLE
[stack-switching] Codegen for `resume_throw` and `resume_throw_ref`.

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -5511,13 +5511,51 @@ impl FuncEnvironment<'_> {
         )
     }
 
+    pub fn translate_resume_throw_ref(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        type_index: u32,
+        exnref: ir::Value,
+        contobj: ir::Value,
+        resumetable: &[(u32, Option<ir::Block>)],
+    ) -> WasmResult<Vec<ir::Value>> {
+        stack_switching::instructions::translate_resume_throw_ref(
+            self,
+            builder,
+            type_index,
+            exnref,
+            contobj,
+            resumetable,
+        )
+    }
+
+    pub fn translate_resume_throw(
+        &mut self,
+        builder: &mut FunctionBuilder<'_>,
+        type_index: u32,
+        tag_index: TagIndex,
+        exception_args: &[ir::Value],
+        contobj: ir::Value,
+        resumetable: &[(u32, Option<ir::Block>)],
+    ) -> WasmResult<Vec<ir::Value>> {
+        stack_switching::instructions::translate_resume_throw(
+            self,
+            builder,
+            type_index,
+            tag_index,
+            exception_args,
+            contobj,
+            resumetable,
+        )
+    }
+
     pub fn translate_suspend(
         &mut self,
         builder: &mut FunctionBuilder<'_>,
         tag_index: u32,
         suspend_args: &[ir::Value],
         tag_return_types: &[ir::Type],
-    ) -> Vec<ir::Value> {
+    ) -> WasmResult<Vec<ir::Value>> {
         stack_switching::instructions::translate_suspend(
             self,
             builder,

--- a/crates/cranelift/src/func_environ/gc.rs
+++ b/crates/cranelift/src/func_environ/gc.rs
@@ -711,16 +711,25 @@ pub fn translate_exn_throw(
     tag_index: TagIndex,
     args: &[ir::Value],
 ) -> WasmResult<()> {
+    let exnref = translate_exn_new(func_env, builder, tag_index, args)?;
+    translate_exn_throw_ref(func_env, builder, exnref)
+}
+
+pub fn translate_exn_new(
+    func_env: &mut FuncEnvironment<'_>,
+    builder: &mut FunctionBuilder<'_>,
+    tag_index: TagIndex,
+    args: &[ir::Value],
+) -> WasmResult<ir::Value> {
     let (instance_id, defined_tag_id) = func_env.get_instance_and_tag(builder, tag_index);
-    let exnref = gc_compiler(func_env)?.alloc_exn(
+    gc_compiler(func_env)?.alloc_exn(
         func_env,
         builder,
         tag_index,
         args,
         instance_id,
         defined_tag_id,
-    )?;
-    translate_exn_throw_ref(func_env, builder, exnref)
+    )
 }
 
 pub fn translate_exn_throw_ref(
@@ -729,15 +738,36 @@ pub fn translate_exn_throw_ref(
     exnref: ir::Value,
 ) -> WasmResult<()> {
     let builtin = func_env.builtin_functions.throw_ref(builder.func);
+    let vmctx = func_env.vmctx_val(&mut builder.cursor());
+    translate_throwing_builtin(func_env, builder, builtin, &[vmctx, exnref])
+}
+
+/// Re-raise the exception currently pending in the VM context.
+///
+/// Continuation stacks catch native unwinding at their array-call boundary.
+/// When control returns to a parent continuation, this emits a new throwing
+/// callsite with that parent's Wasm exception handlers attached.
+pub fn translate_raise(
+    func_env: &mut FuncEnvironment<'_>,
+    builder: &mut FunctionBuilder<'_>,
+) -> WasmResult<()> {
+    let builtin = func_env.builtin_functions.raise(builder.func);
+    let vmctx = func_env.vmctx_val(&mut builder.cursor());
+    translate_throwing_builtin(func_env, builder, builtin, &[vmctx])
+}
+
+fn translate_throwing_builtin(
+    func_env: &mut FuncEnvironment<'_>,
+    builder: &mut FunctionBuilder<'_>,
+    builtin: ir::FuncRef,
+    args: &[ir::Value],
+) -> WasmResult<()> {
     let sig = builder.func.dfg.ext_funcs[builtin].signature;
     let vmctx = func_env.vmctx_val(&mut builder.cursor());
 
-    // Generate a `try_call` with handlers from the current
-    // stack. This libcall is unique among libcall implementations of
-    // opcodes: we know the others will not throw, but `throw_ref`'s
-    // entire purpose is to throw. So if there are any handlers in the
-    // local function body, we need to attach them to this callsite
-    // like any other.
+    // Generate a `try_call` with handlers from the current stack. Both
+    // `throw_ref` and `raise` deliberately throw, so local Wasm handlers must
+    // be attached to these callsites like they are to ordinary throwing calls.
     let continuation = builder.create_block();
     let current_block = builder.current_block().unwrap();
     builder.insert_block_after(continuation, current_block);
@@ -756,7 +786,7 @@ pub fn translate_exn_throw_ref(
     let etd = ExceptionTableData::new(sig, continuation_call, table_items);
     let et = builder.func.dfg.exception_tables.push(etd);
 
-    builder.ins().try_call(builtin, &[vmctx, exnref], et);
+    builder.ins().try_call(builtin, args, et);
 
     builder.switch_to_block(continuation);
     builder.seal_block(continuation);

--- a/crates/cranelift/src/func_environ/stack_switching/control_effect.rs
+++ b/crates/cranelift/src/func_environ/stack_switching/control_effect.rs
@@ -36,6 +36,16 @@ impl ControlEffect {
         Self(val)
     }
 
+    pub fn encode_resume_throw(builder: &mut FunctionBuilder) -> Self {
+        let discriminant = builder.ins().iconst(
+            I64,
+            i64::from(wasmtime_environ::CONTROL_EFFECT_RESUME_THROW_DISCRIMINANT),
+        );
+        let val = builder.ins().ishl_imm_u(discriminant, 32);
+
+        Self(val)
+    }
+
     pub fn encode_switch(builder: &mut FunctionBuilder) -> Self {
         let discriminant = builder.ins().iconst(
             I64,
@@ -64,6 +74,15 @@ impl ControlEffect {
             ir::condcodes::IntCC::Equal,
             signal,
             i64::from(wasmtime_environ::CONTROL_EFFECT_TRAP_DISCRIMINANT),
+        )
+    }
+
+    pub fn is_resume_throw(self, builder: &mut FunctionBuilder) -> ir::Value {
+        let signal = self.signal(builder);
+        builder.ins().icmp_imm_u(
+            ir::condcodes::IntCC::Equal,
+            signal,
+            i64::from(wasmtime_environ::CONTROL_EFFECT_RESUME_THROW_DISCRIMINANT),
         )
     }
 

--- a/crates/cranelift/src/func_environ/stack_switching/instructions.rs
+++ b/crates/cranelift/src/func_environ/stack_switching/instructions.rs
@@ -1,3 +1,4 @@
+use crate::func_environ::gc;
 use crate::translate::set_block_params;
 use crate::trap::TranslateTrap;
 use cranelift_codegen::ir::BlockArg;
@@ -1316,12 +1317,80 @@ pub(crate) fn translate_cont_new<'a>(
     Ok(contobj)
 }
 
+#[derive(Clone, Copy)]
+enum ResumePayload<'a> {
+    Values(&'a [ir::Value]),
+    Throw {
+        tag_index: TagIndex,
+        args: &'a [ir::Value],
+    },
+    ThrowRef(ir::Value),
+}
+
 pub(crate) fn translate_resume<'a>(
     env: &mut crate::func_environ::FuncEnvironment<'a>,
     builder: &mut FunctionBuilder,
     type_index: u32,
     resume_contobj: ir::Value,
     resume_args: &[ir::Value],
+    resumetable: &[(u32, Option<ir::Block>)],
+) -> WasmResult<Vec<ir::Value>> {
+    translate_resume_impl(
+        env,
+        builder,
+        type_index,
+        resume_contobj,
+        ResumePayload::Values(resume_args),
+        resumetable,
+    )
+}
+
+pub(crate) fn translate_resume_throw_ref<'a>(
+    env: &mut crate::func_environ::FuncEnvironment<'a>,
+    builder: &mut FunctionBuilder,
+    type_index: u32,
+    exnref: ir::Value,
+    resume_contobj: ir::Value,
+    resumetable: &[(u32, Option<ir::Block>)],
+) -> WasmResult<Vec<ir::Value>> {
+    translate_resume_impl(
+        env,
+        builder,
+        type_index,
+        resume_contobj,
+        ResumePayload::ThrowRef(exnref),
+        resumetable,
+    )
+}
+
+pub(crate) fn translate_resume_throw<'a>(
+    env: &mut crate::func_environ::FuncEnvironment<'a>,
+    builder: &mut FunctionBuilder,
+    type_index: u32,
+    tag_index: TagIndex,
+    exception_args: &[ir::Value],
+    resume_contobj: ir::Value,
+    resumetable: &[(u32, Option<ir::Block>)],
+) -> WasmResult<Vec<ir::Value>> {
+    translate_resume_impl(
+        env,
+        builder,
+        type_index,
+        resume_contobj,
+        ResumePayload::Throw {
+            tag_index,
+            args: exception_args,
+        },
+        resumetable,
+    )
+}
+
+fn translate_resume_impl<'a>(
+    env: &mut crate::func_environ::FuncEnvironment<'a>,
+    builder: &mut FunctionBuilder,
+    type_index: u32,
+    resume_contobj: ir::Value,
+    resume_payload: ResumePayload<'_>,
     resumetable: &[(u32, Option<ir::Block>)],
 ) -> WasmResult<Vec<ir::Value>> {
     // The resume instruction is the most involved instruction to
@@ -1361,8 +1430,14 @@ pub(crate) fn translate_resume<'a>(
     let return_block = builder.create_block();
     let suspend_block = builder.create_block();
     let trap_block = builder.create_block();
-    let nontrap_block = builder.create_block();
+    let nonreturn_block = builder.create_block();
     let dispatch_block = builder.create_block();
+    let throw_blocks = match resume_payload {
+        ResumePayload::Throw { .. } | ResumePayload::ThrowRef(_) => {
+            Some((builder.create_block(), builder.create_block()))
+        }
+        ResumePayload::Values(_) => None,
+    };
 
     let vmctx = env.vmctx_val(&mut builder.cursor());
 
@@ -1400,11 +1475,59 @@ pub(crate) fn translate_resume<'a>(
         builder
             .ins()
             .trapz(evidence, crate::TRAP_CONTINUATION_ALREADY_CONSUMED);
-        let _next_revision = vmcontref.incr_revision(env, builder, revision);
 
-        if resume_args.len() > 0 {
-            // We store the arguments in the `VMContRef` to be resumed.
-            vmcontref_store_payloads(env, builder, resume_args, resume_contref);
+        match resume_payload {
+            ResumePayload::Values(resume_args) => {
+                let _next_revision = vmcontref.incr_revision(env, builder, revision);
+                if resume_args.len() > 0 {
+                    // We store the arguments in the `VMContRef` to be resumed.
+                    vmcontref_store_payloads(env, builder, resume_args, resume_contref);
+                }
+            }
+            ResumePayload::Throw { .. } | ResumePayload::ThrowRef(_) => {
+                // Materializing an exception can allocate and fail. Do it
+                // after validating the continuation, but before consuming it.
+                let exnref = match resume_payload {
+                    ResumePayload::Throw { tag_index, args } => {
+                        gc::translate_exn_new(env, builder, tag_index, args)?
+                    }
+                    ResumePayload::ThrowRef(exnref) => {
+                        // Validate both operands before consuming the
+                        // continuation.
+                        builder.ins().trapz(exnref, crate::TRAP_NULL_REFERENCE);
+                        exnref
+                    }
+                    ResumePayload::Values(_) => unreachable!(),
+                };
+                let csi = vmcontref.common_stack_information(env, builder);
+                let was_invoked = csi.was_invoked(env, builder);
+                let _next_revision = vmcontref.incr_revision(env, builder, revision);
+
+                let (invoked_throw_block, fresh_throw_block) = throw_blocks.unwrap();
+                builder.ins().brif(
+                    was_invoked,
+                    invoked_throw_block,
+                    &[],
+                    fresh_throw_block,
+                    &[],
+                );
+
+                // A fresh continuation has not entered its Wasm function yet.
+                // Throwing into its initial suspension point therefore
+                // terminates it without executing any of its body.
+                builder.switch_to_block(fresh_throw_block);
+                builder.seal_block(fresh_throw_block);
+                builder.set_cold_block(fresh_throw_block);
+                csi.set_state_trapped(env, builder);
+                vmcontref.args(env, builder).clear(env, builder, true);
+                vmcontref.values(env, builder).clear(env, builder, true);
+                gc::translate_exn_throw_ref(env, builder, exnref)?;
+
+                builder.switch_to_block(invoked_throw_block);
+                builder.seal_block(invoked_throw_block);
+                let values = vmcontref.values(env, builder);
+                values.store_data_entries(env, builder, &[exnref]);
+            }
         }
 
         // Splice together stack chains:
@@ -1495,7 +1618,13 @@ pub(crate) fn translate_resume<'a>(
             parent_csi.set_first_switch_handler_index(env, builder, first_switch_handler_index);
         }
 
-        let resume_payload = ControlEffect::encode_resume(builder).to_u64();
+        let resume_payload = match resume_payload {
+            ResumePayload::Values(_) => ControlEffect::encode_resume(builder),
+            ResumePayload::Throw { .. } | ResumePayload::ThrowRef(_) => {
+                ControlEffect::encode_resume_throw(builder)
+            }
+        }
+        .to_u64();
 
         // Note that the control context we use for switching is not the one in
         // (the stack of) resume_contref, but in (the stack of) last_ancestor!
@@ -1521,20 +1650,23 @@ pub(crate) fn translate_resume<'a>(
         handler_list.clear(env, builder, true);
         parent_csi.set_first_switch_handler_index(env, builder, zero);
 
-        // First distinguish terminal traps from ordinary returns and
-        // suspensions.
+        // An ordinary return is encoded as zero, so make it the fast path with
+        // a single branch. Only the nonreturn path needs to distinguish a
+        // terminal trap from a suspension.
+        // TODO(dhil): We may want to make suspension the fast path
+        // instead, as I hypothesise suspensions occur more often than
+        // normal returns in a stack-switching application.
         let result = ControlEffect::from_u64(result);
+        builder
+            .ins()
+            .brif(result.to_u64(), nonreturn_block, &[], return_block, &[]);
+
+        builder.switch_to_block(nonreturn_block);
+        builder.seal_block(nonreturn_block);
         let is_trap = result.is_trap(builder);
         builder
             .ins()
-            .brif(is_trap, trap_block, &[], nontrap_block, &[]);
-
-        builder.switch_to_block(nontrap_block);
-        builder.seal_block(nontrap_block);
-        let signal = result.signal(builder);
-        builder
-            .ins()
-            .brif(signal, suspend_block, &[], return_block, &[]);
+            .brif(is_trap, trap_block, &[], suspend_block, &[]);
 
         (
             result,
@@ -1568,14 +1700,7 @@ pub(crate) fn translate_resume<'a>(
         let values = trapped_continuation.values(env, builder);
         values.clear(env, builder, true);
 
-        let raise = env.builtin_functions.raise(&mut builder.func);
-        builder.ins().call(raise, &[vmctx]);
-        // We do not anticipate the call to `raise`
-        // returning. However, viewed through cranelift's lens it is
-        // not a block terminating instruction, therefore we insert a
-        // trap to make the current block structurally complete and
-        // catch any unexpected returns from `raise`.
-        builder.ins().trap(crate::TRAP_INTERNAL_ASSERT);
+        gc::translate_raise(env, builder)?;
     }
 
     // The suspend block: Only used when we suspended, not for returns.
@@ -1621,7 +1746,7 @@ pub(crate) fn translate_resume<'a>(
 
     // For technical reasons, the jump table needs to have a default
     // block. In our case, it should be unreachable, since the handler
-    // index we dispatch on should correspond to a an actual handler
+    // index we dispatch on should correspond to an actual handler
     // block in the jump table.
     let jt_default_block = builder.create_block();
     {
@@ -1659,7 +1784,6 @@ pub(crate) fn translate_resume<'a>(
 
             // We clear the suspend args. This is mostly for consistency. Note
             // that we don't zero out the data buffer, we still need it for the
-
             values.clear(env, builder, false);
 
             set_block_params(env, builder, target_block, &suspend_args);
@@ -1725,13 +1849,45 @@ pub(crate) fn translate_resume<'a>(
     }
 }
 
+fn load_resume_values_or_throw<'a>(
+    env: &mut crate::func_environ::FuncEnvironment<'a>,
+    builder: &mut FunctionBuilder,
+    result: ControlEffect,
+    continuation: helpers::VMContRef,
+    return_types: &[ir::Type],
+) -> WasmResult<Vec<ir::Value>> {
+    let throw_block = builder.create_block();
+    let values_block = builder.create_block();
+    let is_resume_throw = result.is_resume_throw(builder);
+    builder
+        .ins()
+        .brif(is_resume_throw, throw_block, &[], values_block, &[]);
+
+    builder.switch_to_block(throw_block);
+    builder.seal_block(throw_block);
+    builder.set_cold_block(throw_block);
+    let values = continuation.values(env, builder);
+    // Exception references use Wasmtime's compressed, 32-bit GC-reference
+    // representation.
+    let exnref = values.load_data_entries(env, builder, &[I32])[0];
+    values.clear(env, builder, true);
+    gc::translate_exn_throw_ref(env, builder, exnref)?;
+
+    builder.switch_to_block(values_block);
+    builder.seal_block(values_block);
+    let values = continuation.values(env, builder);
+    let return_values = values.load_data_entries(env, builder, return_types);
+    values.clear(env, builder, true);
+    Ok(return_values)
+}
+
 pub(crate) fn translate_suspend<'a>(
     env: &mut crate::func_environ::FuncEnvironment<'a>,
     builder: &mut FunctionBuilder,
     tag_index: u32,
     suspend_args: &[ir::Value],
     tag_return_types: &[ir::Type],
-) -> Vec<ir::Value> {
+) -> WasmResult<Vec<ir::Value>> {
     let tag_addr = tag_address(env, builder, tag_index);
 
     let vmctx = env.vmctx_val(&mut builder.cursor());
@@ -1749,23 +1905,21 @@ pub(crate) fn translate_suspend<'a>(
 
     active_contref.set_last_ancestor(env, builder, end_of_chain_contref.address);
 
-    // In the active_contref's `values` buffer, stack-allocate enough room so that we can
-    // later store the following:
-    // 1. The suspend arguments
-    // 2. Afterwards, the tag return values
+    // We stack allocate enough room for the suspend arguments and the
+    // return values including the possible exception reference.
     let values = active_contref.values(env, builder);
-    let required_capacity =
-        u32::try_from(std::cmp::max(suspend_args.len(), tag_return_types.len()))
-            .expect("Number of stack switching payloads should fit in u32");
+    let required_capacity = u32::try_from(std::cmp::max(
+        1, // This account for the possible exception reference.
+        std::cmp::max(suspend_args.len(), tag_return_types.len()),
+    ))
+    .expect("Number of stack switching payloads should fit in u32");
 
-    if required_capacity > 0 {
-        env.stack_switching_values_buffer = Some(values.allocate_or_reuse_stack_slot(
-            env,
-            builder,
-            required_capacity,
-            env.stack_switching_values_buffer,
-        ));
-    }
+    env.stack_switching_values_buffer = Some(values.allocate_or_reuse_stack_slot(
+        env,
+        builder,
+        required_capacity,
+        env.stack_switching_values_buffer,
+    ));
 
     if suspend_args.len() > 0 {
         values.store_data_entries(env, builder, suspend_args);
@@ -1787,17 +1941,20 @@ pub(crate) fn translate_suspend<'a>(
     let fiber_stack = end_of_chain_contref.get_fiber_stack(env, builder);
     let control_context_ptr = fiber_stack.load_control_context(env, builder);
 
-    builder
-        .ins()
-        .stack_switch(control_context_ptr, control_context_ptr, suspend_payload);
+    let result =
+        builder
+            .ins()
+            .stack_switch(control_context_ptr, control_context_ptr, suspend_payload);
 
-    // The return values of the suspend instruction are the tag return values, saved in the `args` buffer.
-    let values = active_contref.values(env, builder);
-    let return_values = values.load_data_entries(env, builder, tag_return_types);
-    // We effectively consume the values and discard the stack allocated buffer.
-    values.clear(env, builder, true);
-
-    return_values
+    // A normal resume supplies the tag's return values. `resume_throw_ref`
+    // supplies an exception reference and throws it at this suspension point.
+    load_resume_values_or_throw(
+        env,
+        builder,
+        ControlEffect::from_u64(result),
+        active_contref,
+        tag_return_types,
+    )
 }
 
 pub(crate) fn translate_switch<'a>(
@@ -1861,18 +2018,17 @@ pub(crate) fn translate_switch<'a>(
 
         switcher_contref.set_last_ancestor(env, builder, last_ancestor.address);
 
-        // In the switcher_contref's `values` buffer, stack-allocate enough room so that we can
-        // later store `tag_return_types.len()` when resuming the continuation.
+        // We stack allocate enough room for the switch arguments and
+        // the return values including the possible exception
+        // reference.
         let values = switcher_contref.values(env, builder);
-        let required_capacity = u32::try_from(return_types.len()).unwrap();
-        if required_capacity > 0 {
-            env.stack_switching_values_buffer = Some(values.allocate_or_reuse_stack_slot(
-                env,
-                builder,
-                required_capacity,
-                env.stack_switching_values_buffer,
-            ));
-        }
+        let required_capacity = u32::try_from(std::cmp::max(1, return_types.len())).unwrap();
+        env.stack_switching_values_buffer = Some(values.allocate_or_reuse_stack_slot(
+            env,
+            builder,
+            required_capacity,
+            env.stack_switching_values_buffer,
+        ));
 
         let switcher_contref_csi = switcher_contref.common_stack_information(env, builder);
         switcher_contref_csi.set_state_suspended(env, builder);
@@ -1937,7 +2093,7 @@ pub(crate) fn translate_switch<'a>(
     }
 
     // Perform actual stack switch
-    {
+    let result = {
         let switcher_last_ancestor_fs =
             switcher_contref_last_ancestor.get_fiber_stack(env, builder);
         let switcher_last_ancestor_cc =
@@ -2035,22 +2191,20 @@ pub(crate) fn translate_switch<'a>(
 
         let switch_payload = ControlEffect::encode_switch(builder).to_u64();
 
-        let _result = builder.ins().stack_switch(
+        builder.ins().stack_switch(
             switcher_last_ancestor_cc,
             tmp_control_context,
             switch_payload,
-        );
-    }
-
-    // After switching back to the original stack: Load return values, they are
-    // stored on the switcher continuation.
-    let return_values = {
-        let payloads = switcher_contref.values(env, builder);
-        let return_values = payloads.load_data_entries(env, builder, return_types);
-        // We consume the values and discard the buffer (allocated on this stack)
-        payloads.clear(env, builder, true);
-        return_values
+        )
     };
 
-    Ok(return_values)
+    // After switching back to the original stack, either load the values
+    // supplied by an ordinary resume or throw the injected exception.
+    load_resume_values_or_throw(
+        env,
+        builder,
+        ControlEffect::from_u64(result),
+        switcher_contref,
+        return_types,
+    )
 }

--- a/crates/cranelift/src/translate/code_translator.rs
+++ b/crates/cranelift/src/translate/code_translator.rs
@@ -3191,7 +3191,7 @@ pub fn translate_operator(
             let param_count = params.len();
 
             let return_values =
-                environ.translate_suspend(builder, tag_index.as_u32(), &params, &return_types);
+                environ.translate_suspend(builder, tag_index.as_u32(), &params, &return_types)?;
 
             environ.stacks.popn(param_count);
             environ.stacks.pushn(&return_values);
@@ -3235,14 +3235,78 @@ pub fn translate_operator(
             environ.stacks.pushn(&cont_return_vals);
         }
         Operator::ResumeThrow {
-            cont_type_index: _,
-            tag_index: _,
-            resume_table: _,
+            cont_type_index,
+            tag_index,
+            resume_table: wasm_resume_table,
         } => {
-            // TODO(10248) This depends on exception handling
-            return Err(wasmtime_environ::WasmError::Unsupported(
-                "resume.throw instructions not supported, yet".to_string(),
-            ));
+            let mut clif_resume_table = vec![];
+            for handle in &wasm_resume_table.handlers {
+                match handle {
+                    wasmparser::Handle::OnLabel { tag, label } => {
+                        let i = environ.stacks.control_stack.len() - 1 - (*label as usize);
+                        let frame = &mut environ.stacks.control_stack[i];
+                        frame.set_branched_to_exit();
+                        clif_resume_table.push((*tag, Some(frame.br_destination())));
+                    }
+                    wasmparser::Handle::OnSwitch { tag } => {
+                        clif_resume_table.push((*tag, None));
+                    }
+                }
+            }
+
+            let cont_type_index = TypeIndex::from_u32(*cont_type_index);
+            let tag_index = TagIndex::from_u32(*tag_index);
+            let arity = environ.tag_params(tag_index).len();
+            let (contobj, exception_args) = environ.stacks.peekn(arity + 1).split_last().unwrap();
+            let contobj = *contobj;
+            let exception_args = exception_args.to_vec();
+            let cont_return_vals = environ.translate_resume_throw(
+                builder,
+                cont_type_index.as_u32(),
+                tag_index,
+                &exception_args,
+                contobj,
+                &clif_resume_table,
+            )?;
+
+            environ.stacks.popn(arity + 1);
+            environ.stacks.pushn(&cont_return_vals);
+        }
+        Operator::ResumeThrowRef {
+            cont_type_index,
+            resume_table: wasm_resume_table,
+        } => {
+            let mut clif_resume_table = vec![];
+            for handle in &wasm_resume_table.handlers {
+                match handle {
+                    wasmparser::Handle::OnLabel { tag, label } => {
+                        let i = environ.stacks.control_stack.len() - 1 - (*label as usize);
+                        let frame = &mut environ.stacks.control_stack[i];
+                        frame.set_branched_to_exit();
+                        clif_resume_table.push((*tag, Some(frame.br_destination())));
+                    }
+                    wasmparser::Handle::OnSwitch { tag } => {
+                        clif_resume_table.push((*tag, None));
+                    }
+                }
+            }
+
+            let cont_type_index = TypeIndex::from_u32(*cont_type_index);
+            // The validator leaves the continuation on top of the exception
+            // reference.
+            let operands = environ.stacks.peekn(2);
+            let exnref = operands[0];
+            let contobj = operands[1];
+            let cont_return_vals = environ.translate_resume_throw_ref(
+                builder,
+                cont_type_index.as_u32(),
+                exnref,
+                contobj,
+                &clif_resume_table,
+            )?;
+
+            environ.stacks.popn(2);
+            environ.stacks.pushn(&cont_return_vals);
         }
         Operator::Switch {
             cont_type_index,

--- a/crates/environ/src/stack_switching.rs
+++ b/crates/environ/src/stack_switching.rs
@@ -45,3 +45,6 @@ pub const CONTROL_EFFECT_SWITCH_DISCRIMINANT: u32 = 3;
 /// Discriminant of variant `Trap` in
 /// `runtime::vm::ControlEffect`.
 pub const CONTROL_EFFECT_TRAP_DISCRIMINANT: u32 = 4;
+/// Discriminant used to resume a suspended continuation by throwing an
+/// exception at its suspension point.
+pub const CONTROL_EFFECT_RESUME_THROW_DISCRIMINANT: u32 = 5;

--- a/tests/disas/stack-switching/resume-suspend-data-passing.wat
+++ b/tests/disas/stack-switching/resume-suspend-data-passing.wat
@@ -47,6 +47,8 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
+;;     sig0 = (i64 vmctx, i32) -> i8 tail
+;;     fn0 = colocated u805306368:44 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -58,7 +60,8 @@
 ;; @0044                               v37 = iconst.i64 0
 ;; @0044                               v49 = iconst.i64 96
 ;; @0044                               v52 = iconst.i64 -24
-;;                                     v68 = iconst.i64 0x0002_0000_0000
+;;                                     v79 = iconst.i64 0x0002_0000_0000
+;; @0044                               v57 = iconst.i64 5
 ;; @0040                               jump block2(v3)  ; v3 = 10
 ;;
 ;;                                 block2(v4: i32):
@@ -69,76 +72,97 @@
 ;; @003a                               v2 = iconst.i32 0
 ;; @0044                               jump block4(v8, v9, v4)
 ;;
-;;                                 block4(v10: i64, v11: i64, v62: i32):
-;;                                     v71 = iconst.i64 1
-;;                                     v72 = icmp eq v10, v71  ; v71 = 1
-;; @0044                               trapnz v72, user22
+;;                                 block4(v10: i64, v11: i64, v73: i32):
+;;                                     v82 = iconst.i64 1
+;;                                     v83 = icmp eq v10, v82  ; v82 = 1
+;; @0044                               trapnz v83, user22
 ;; @0044                               jump block5
 ;;
 ;;                                 block5:
 ;; @0044                               v14 = load.i64 notrap aligned region3 v11+64
 ;; @0044                               v15 = load.i64 notrap aligned region3 v11+72
-;;                                     v73 = iconst.i64 40
-;;                                     v74 = iadd v15, v73  ; v73 = 40
-;; @0044                               v18 = load.i64 notrap aligned region3 v74+8
+;;                                     v84 = iconst.i64 40
+;;                                     v85 = iadd v15, v84  ; v84 = 40
+;; @0044                               v18 = load.i64 notrap aligned region3 v85+8
 ;; @0044                               v19 = load.i32 notrap aligned region3 v15+56
-;;                                     v75 = iconst.i32 0
-;;                                     v65 = iconst.i32 3
+;;                                     v86 = iconst.i32 0
+;;                                     v76 = iconst.i32 3
 ;; @0044                               v5 = iconst.i64 48
 ;; @0044                               v6 = iadd.i64 v0, v5  ; v5 = 48
 ;; @0044                               v29 = iconst.i32 1
-;; @0044                               jump block6(v75)  ; v75 = 0
+;; @0044                               jump block6(v86)  ; v86 = 0
 ;;
 ;;                                 block6(v21: i32):
 ;; @0044                               v22 = icmp ult v21, v19
-;; @0044                               brif v22, block7, block4(v14, v15, v62)
+;; @0044                               brif v22, block7, block4(v14, v15, v73)
 ;;
 ;;                                 block7:
-;;                                     v76 = iconst.i32 3
-;;                                     v77 = ishl.i32 v21, v76  ; v76 = 3
-;; @0044                               v25 = uextend.i64 v77
+;;                                     v87 = iconst.i32 3
+;;                                     v88 = ishl.i32 v21, v87  ; v87 = 3
+;; @0044                               v25 = uextend.i64 v88
 ;; @0044                               v26 = iadd.i64 v18, v25
 ;; @0044                               v27 = load.i64 notrap aligned region4 v26
-;;                                     v78 = iadd.i64 v0, v5  ; v5 = 48
-;;                                     v79 = icmp eq v27, v78
-;;                                     v80 = iconst.i32 1
-;;                                     v81 = iadd.i32 v21, v80  ; v80 = 1
-;; @0044                               brif v79, block8, block6(v81)
+;;                                     v89 = iadd.i64 v0, v5  ; v5 = 48
+;;                                     v90 = icmp eq v27, v89
+;;                                     v91 = iconst.i32 1
+;;                                     v92 = iadd.i32 v21, v91  ; v91 = 1
+;; @0044                               brif v90, block8, block6(v92)
 ;;
 ;;                                 block8:
 ;; @0044                               store.i64 notrap aligned region3 v11, v9+80
-;;                                     v82 = iconst.i32 1
-;;                                     v83 = iconst.i64 136
-;;                                     v84 = iadd.i64 v9, v83  ; v83 = 136
-;; @0044                               store notrap aligned region3 v82, v84+4  ; v82 = 1
-;; @0044                               store.i64 notrap aligned region3 v34, v84+8
+;;                                     v93 = iconst.i32 1
+;;                                     v94 = iconst.i64 136
+;;                                     v95 = iadd.i64 v9, v94  ; v94 = 136
+;; @0044                               store notrap aligned region3 v93, v95+4  ; v93 = 1
+;; @0044                               store.i64 notrap aligned region3 v34, v95+8
 ;; @0044                               store.i32 notrap aligned region4 v4, v34
-;; @0044                               store notrap aligned region3 v82, v84  ; v82 = 1
-;;                                     v85 = iconst.i32 3
-;;                                     v86 = iconst.i64 32
-;;                                     v87 = iadd.i64 v9, v86  ; v86 = 32
-;; @0044                               store notrap aligned region3 v85, v87  ; v85 = 3
-;;                                     v88 = iconst.i64 0
-;; @0044                               store notrap aligned region3 v88, v11+64  ; v88 = 0
-;; @0044                               store notrap aligned region3 v88, v11+72  ; v88 = 0
-;;                                     v89 = iconst.i64 96
-;;                                     v90 = iadd.i64 v11, v89  ; v89 = 96
-;; @0044                               v51 = load.i64 notrap aligned region3 v90
-;;                                     v91 = iconst.i64 -24
-;;                                     v92 = iadd v51, v91  ; v91 = -24
+;; @0044                               store notrap aligned region3 v93, v95  ; v93 = 1
+;;                                     v96 = iconst.i32 3
+;;                                     v97 = iconst.i64 32
+;;                                     v98 = iadd.i64 v9, v97  ; v97 = 32
+;; @0044                               store notrap aligned region3 v96, v98  ; v96 = 3
+;;                                     v99 = iconst.i64 0
+;; @0044                               store notrap aligned region3 v99, v11+64  ; v99 = 0
+;; @0044                               store notrap aligned region3 v99, v11+72  ; v99 = 0
+;;                                     v100 = iconst.i64 96
+;;                                     v101 = iadd.i64 v11, v100  ; v100 = 96
+;; @0044                               v51 = load.i64 notrap aligned region3 v101
+;;                                     v102 = iconst.i64 -24
+;;                                     v103 = iadd v51, v102  ; v102 = -24
 ;; @0044                               v47 = uextend.i64 v21
-;;                                     v93 = iconst.i64 0x0002_0000_0000
-;;                                     v94 = bor v47, v93  ; v93 = 0x0002_0000_0000
-;; @0044                               v54 = stack_switch v92, v92, v94
-;; @0044                               v57 = load.i64 notrap aligned region3 v84+8
-;;                                     v95 = iconst.i32 0
-;; @0044                               store notrap aligned region3 v95, v84  ; v95 = 0
-;; @0044                               store notrap aligned region3 v95, v84+4  ; v95 = 0
-;; @0044                               store notrap aligned region3 v88, v84+8  ; v88 = 0
-;;                                     v96 = isub.i32 v62, v82  ; v82 = 1
-;; @004d                               brif v96, block2(v96), block10
+;;                                     v104 = iconst.i64 0x0002_0000_0000
+;;                                     v105 = bor v47, v104  ; v104 = 0x0002_0000_0000
+;; @0044                               v54 = stack_switch v103, v103, v105
+;;                                     v106 = ushr v54, v97  ; v97 = 32
+;;                                     v107 = iconst.i64 5
+;;                                     v108 = icmp eq v106, v107  ; v107 = 5
+;; @0044                               brif v108, block10, block11
 ;;
-;;                                 block10:
+;;                                 block10 cold:
+;; @0044                               v61 = load.i64 notrap aligned region3 v95+8
+;; @0044                               v62 = load.i32 notrap aligned region4 v61
+;;                                     v113 = iconst.i32 0
+;; @0044                               store notrap aligned region3 v113, v95  ; v113 = 0
+;; @0044                               store notrap aligned region3 v113, v95+4  ; v113 = 0
+;;                                     v114 = iconst.i64 0
+;; @0044                               store notrap aligned region3 v114, v95+8  ; v114 = 0
+;; @0044                               try_call fn0(v0, v62), sig0, block12, [ context v0 ]
+;;
+;;                                 block12:
+;; @0044                               trap user12
+;;
+;;                                 block11:
+;; @0044                               v68 = load.i64 notrap aligned region3 v95+8
+;;                                     v109 = iconst.i32 0
+;; @0044                               store notrap aligned region3 v109, v95  ; v109 = 0
+;; @0044                               store notrap aligned region3 v109, v95+4  ; v109 = 0
+;;                                     v110 = iconst.i64 0
+;; @0044                               store notrap aligned region3 v110, v95+8  ; v110 = 0
+;;                                     v111 = iconst.i32 1
+;;                                     v112 = isub.i32 v73, v111  ; v111 = 1
+;; @004d                               brif v112, block2(v112), block13
+;;
+;;                                 block13:
 ;; @004f                               jump block3
 ;;
 ;;                                 block3:
@@ -177,9 +201,9 @@
 ;; @0058                               v7 = load.i64 notrap aligned region2 v6+88
 ;; @0058                               v9 = uextend.i128 v7
 ;; @0058                               v10 = iconst.i64 64
-;;                                     v150 = ishl v9, v10  ; v10 = 64
+;;                                     v148 = ishl v9, v10  ; v10 = 64
 ;; @0058                               v8 = uextend.i128 v6
-;; @0058                               v13 = bor v150, v8
+;; @0058                               v13 = bor v148, v8
 ;; @0062                               v22 = iconst.i64 1
 ;; @0062                               v25 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @0062                               v28 = iconst.i64 0
@@ -193,8 +217,7 @@
 ;; @0062                               v57 = iadd v0, v56  ; v56 = 48
 ;; @0062                               v64 = iconst.i64 96
 ;; @0062                               v67 = iconst.i64 -24
-;;                                     v154 = iconst.i64 0x0001_0000_0000
-;; @0062                               v82 = iconst.i64 4
+;;                                     v152 = iconst.i64 0x0001_0000_0000
 ;; @005c                               jump block2(v13)
 ;;
 ;;                                 block2(v14: i128):
@@ -204,31 +227,31 @@
 ;; @0062                               v15 = ireduce.i64 v14
 ;; @0062                               trapz v15, user16
 ;; @0062                               v20 = load.i64 notrap aligned region2 v15+88
-;;                                     v157 = iconst.i64 64
-;;                                     v158 = ushr.i128 v14, v157  ; v157 = 64
-;; @0062                               v19 = ireduce.i64 v158
+;;                                     v155 = iconst.i64 64
+;;                                     v156 = ushr.i128 v14, v155  ; v155 = 64
+;; @0062                               v19 = ireduce.i64 v156
 ;; @0062                               v21 = icmp eq v20, v19
 ;; @0062                               trapz v21, user23
-;;                                     v159 = iconst.i64 1
-;;                                     v160 = iadd v20, v159  ; v159 = 1
-;; @0062                               store notrap aligned region2 v160, v15+88
+;;                                     v157 = iconst.i64 1
+;;                                     v158 = iadd v20, v157  ; v157 = 1
+;; @0062                               store notrap aligned region2 v158, v15+88
 ;; @0062                               v24 = load.i64 notrap aligned region2 v15+80
 ;; @0062                               v26 = load.i64 notrap aligned region3 v25+88
 ;; @0062                               v27 = load.i64 notrap aligned region3 v25+96
 ;; @0062                               store notrap aligned region2 v26, v24+64
 ;; @0062                               store notrap aligned region2 v27, v24+72
-;;                                     v161 = iconst.i64 0
-;; @0062                               store notrap aligned region2 v161, v15+80  ; v161 = 0
-;;                                     v162 = iconst.i64 2
-;; @0062                               store notrap aligned region3 v162, v25+88  ; v162 = 2
+;;                                     v159 = iconst.i64 0
+;; @0062                               store notrap aligned region2 v159, v15+80  ; v159 = 0
+;;                                     v160 = iconst.i64 2
+;; @0062                               store notrap aligned region3 v160, v25+88  ; v160 = 2
 ;; @0062                               store notrap aligned region3 v15, v25+96
-;;                                     v163 = iconst.i32 1
-;;                                     v164 = iconst.i64 32
-;;                                     v165 = iadd v15, v164  ; v164 = 32
-;; @0062                               store notrap aligned region2 v163, v165  ; v163 = 1
-;;                                     v166 = iconst.i32 2
-;;                                     v167 = iadd v27, v164  ; v164 = 32
-;; @0062                               store notrap aligned region2 v166, v167  ; v166 = 2
+;;                                     v161 = iconst.i32 1
+;;                                     v162 = iconst.i64 32
+;;                                     v163 = iadd v15, v162  ; v162 = 32
+;; @0062                               store notrap aligned region2 v161, v163  ; v161 = 1
+;;                                     v164 = iconst.i32 2
+;;                                     v165 = iadd v27, v162  ; v162 = 32
+;; @0062                               store notrap aligned region2 v164, v165  ; v164 = 2
 ;; @0062                               v42 = load.i64 notrap aligned region4 v25+72
 ;; @0062                               v43 = load.i64 notrap aligned region5 v25+64
 ;; @0062                               v44 = load.i64 notrap aligned region6 v25+80
@@ -245,129 +268,132 @@
 ;; @0062                               store notrap aligned region5 v50, v25+64
 ;; @0062                               v51 = load.i64 notrap aligned region2 v15+24
 ;; @0062                               store notrap aligned region6 v51, v25+80
-;;                                     v168 = iconst.i64 40
-;;                                     v169 = iadd v27, v168  ; v168 = 40
-;; @0062                               store notrap aligned region2 v163, v169+4  ; v163 = 1
-;; @0062                               store.i64 notrap aligned region2 v55, v169+8
-;;                                     v170 = iadd.i64 v0, v56  ; v56 = 48
-;; @0062                               store notrap aligned region7 v170, v55
-;; @0062                               store notrap aligned region2 v163, v169  ; v163 = 1
-;; @0062                               store notrap aligned region2 v163, v27+56  ; v163 = 1
-;;                                     v171 = iconst.i64 96
-;;                                     v172 = iadd v24, v171  ; v171 = 96
-;; @0062                               v66 = load.i64 notrap aligned region2 v172
-;;                                     v173 = iconst.i64 -24
-;;                                     v174 = iadd v66, v173  ; v173 = -24
-;;                                     v175 = iconst.i64 0x0001_0000_0000
-;; @0062                               v69 = stack_switch v174, v174, v175  ; v175 = 0x0001_0000_0000
+;;                                     v166 = iconst.i64 40
+;;                                     v167 = iadd v27, v166  ; v166 = 40
+;; @0062                               store notrap aligned region2 v161, v167+4  ; v161 = 1
+;; @0062                               store.i64 notrap aligned region2 v55, v167+8
+;;                                     v168 = iadd.i64 v0, v56  ; v56 = 48
+;; @0062                               store notrap aligned region7 v168, v55
+;; @0062                               store notrap aligned region2 v161, v167  ; v161 = 1
+;; @0062                               store notrap aligned region2 v161, v27+56  ; v161 = 1
+;;                                     v169 = iconst.i64 96
+;;                                     v170 = iadd v24, v169  ; v169 = 96
+;; @0062                               v66 = load.i64 notrap aligned region2 v170
+;;                                     v171 = iconst.i64 -24
+;;                                     v172 = iadd v66, v171  ; v171 = -24
+;;                                     v173 = iconst.i64 0x0001_0000_0000
+;; @0062                               v69 = stack_switch v172, v172, v173  ; v173 = 0x0001_0000_0000
 ;; @0062                               v71 = load.i64 notrap aligned region3 v25+88
 ;; @0062                               v72 = load.i64 notrap aligned region3 v25+96
 ;; @0062                               store notrap aligned region3 v26, v25+88
 ;; @0062                               store notrap aligned region3 v27, v25+96
-;; @0062                               store notrap aligned region2 v163, v167  ; v163 = 1
-;;                                     v176 = iconst.i32 0
-;; @0062                               store notrap aligned region2 v176, v169  ; v176 = 0
-;; @0062                               store notrap aligned region2 v176, v169+4  ; v176 = 0
-;; @0062                               store notrap aligned region2 v161, v169+8  ; v161 = 0
-;; @0062                               store notrap aligned region2 v161, v27+56  ; v161 = 0
-;;                                     v177 = ushr v69, v164  ; v164 = 32
-;;                                     v178 = iconst.i64 4
-;;                                     v179 = icmp eq v177, v178  ; v178 = 4
-;; @0062                               brif v179, block8, block9
+;; @0062                               store notrap aligned region2 v161, v165  ; v161 = 1
+;;                                     v174 = iconst.i32 0
+;; @0062                               store notrap aligned region2 v174, v167  ; v174 = 0
+;; @0062                               store notrap aligned region2 v174, v167+4  ; v174 = 0
+;; @0062                               store notrap aligned region2 v159, v167+8  ; v159 = 0
+;; @0062                               store notrap aligned region2 v159, v27+56  ; v159 = 0
+;; @0062                               brif v69, block9, block6
 ;;
 ;;                                 block9:
-;; @0062                               brif.i64 v177, block7, block6
+;;                                     v179 = iconst.i64 32
+;;                                     v180 = ushr.i64 v69, v179  ; v179 = 32
+;; @0062                               v82 = iconst.i64 4
+;; @0062                               v83 = icmp eq v180, v82  ; v82 = 4
+;; @0062                               brif v83, block8, block7
 ;;
 ;;                                 block8 cold:
-;; @0062                               v88 = iconst.i32 5
-;;                                     v187 = iconst.i64 32
-;;                                     v188 = iadd.i64 v72, v187  ; v187 = 32
-;; @0062                               store notrap aligned region2 v88, v188  ; v88 = 5
-;; @0062                               v93 = load.i64 notrap aligned region2 v27
-;; @0062                               store notrap aligned region1 v93, v25+24
-;; @0062                               v94 = load.i64 notrap aligned region2 v27+8
-;; @0062                               store notrap aligned region4 v94, v25+72
-;; @0062                               v95 = load.i64 notrap aligned region2 v27+16
-;; @0062                               store notrap aligned region5 v95, v25+64
-;; @0062                               v96 = load.i64 notrap aligned region2 v27+24
-;; @0062                               store notrap aligned region6 v96, v25+80
-;;                                     v189 = iconst.i32 0
-;;                                     v190 = iconst.i64 120
-;;                                     v191 = iadd.i64 v72, v190  ; v190 = 120
-;; @0062                               store notrap aligned region2 v189, v191  ; v189 = 0
-;; @0062                               store notrap aligned region2 v189, v191+4  ; v189 = 0
-;;                                     v192 = iconst.i64 0
-;; @0062                               store notrap aligned region2 v192, v191+8  ; v192 = 0
-;;                                     v193 = iconst.i64 136
-;;                                     v194 = iadd.i64 v72, v193  ; v193 = 136
-;; @0062                               store notrap aligned region2 v189, v194  ; v189 = 0
-;; @0062                               store notrap aligned region2 v189, v194+4  ; v189 = 0
-;; @0062                               store notrap aligned region2 v192, v194+8  ; v192 = 0
-;; @0062                               call fn2(v0)
-;; @0062                               trap user1
+;; @0062                               v86 = iconst.i32 5
+;;                                     v184 = iconst.i64 32
+;;                                     v185 = iadd.i64 v72, v184  ; v184 = 32
+;; @0062                               store notrap aligned region2 v86, v185  ; v86 = 5
+;; @0062                               v91 = load.i64 notrap aligned region2 v27
+;; @0062                               store notrap aligned region1 v91, v25+24
+;; @0062                               v92 = load.i64 notrap aligned region2 v27+8
+;; @0062                               store notrap aligned region4 v92, v25+72
+;; @0062                               v93 = load.i64 notrap aligned region2 v27+16
+;; @0062                               store notrap aligned region5 v93, v25+64
+;; @0062                               v94 = load.i64 notrap aligned region2 v27+24
+;; @0062                               store notrap aligned region6 v94, v25+80
+;;                                     v186 = iconst.i32 0
+;;                                     v187 = iconst.i64 120
+;;                                     v188 = iadd.i64 v72, v187  ; v187 = 120
+;; @0062                               store notrap aligned region2 v186, v188  ; v186 = 0
+;; @0062                               store notrap aligned region2 v186, v188+4  ; v186 = 0
+;;                                     v189 = iconst.i64 0
+;; @0062                               store notrap aligned region2 v189, v188+8  ; v189 = 0
+;;                                     v190 = iconst.i64 136
+;;                                     v191 = iadd.i64 v72, v190  ; v190 = 136
+;; @0062                               store notrap aligned region2 v186, v191  ; v186 = 0
+;; @0062                               store notrap aligned region2 v186, v191+4  ; v186 = 0
+;; @0062                               store notrap aligned region2 v189, v191+8  ; v189 = 0
+;; @0062                               try_call fn2(v0), sig2, block11, [ context v0 ]
 ;;
-;;                                 block7:
-;; @0062                               v111 = load.i64 notrap aligned region4 v25+72
-;; @0062                               v112 = load.i64 notrap aligned region5 v25+64
-;; @0062                               v113 = load.i64 notrap aligned region6 v25+80
-;; @0062                               store notrap aligned region2 v111, v72+8
-;; @0062                               store notrap aligned region2 v112, v72+16
-;; @0062                               store notrap aligned region2 v113, v72+24
-;; @0062                               v116 = load.i64 notrap aligned region2 v27
-;; @0062                               store notrap aligned region1 v116, v25+24
-;; @0062                               v117 = load.i64 notrap aligned region2 v27+8
-;; @0062                               store notrap aligned region4 v117, v25+72
-;; @0062                               v118 = load.i64 notrap aligned region2 v27+16
-;; @0062                               store notrap aligned region5 v118, v25+64
-;; @0062                               v119 = load.i64 notrap aligned region2 v27+24
-;; @0062                               store notrap aligned region6 v119, v25+80
-;; @0062                               v121 = load.i64 notrap aligned region2 v72+88
-;; @0062                               jump block10
-;;
-;;                                 block11 cold:
+;;                                 block11:
 ;; @0062                               trap user12
 ;;
-;;                                 block12:
-;; @0062                               v128 = iconst.i64 136
-;; @0062                               v129 = iadd.i64 v72, v128  ; v128 = 136
-;; @0062                               v130 = load.i64 notrap aligned region2 v129+8
-;; @0062                               v131 = load.i32 notrap aligned region7 v130
-;;                                     v184 = iconst.i32 0
-;; @0062                               store notrap aligned region2 v184, v129  ; v184 = 0
+;;                                 block7:
+;; @0062                               v109 = load.i64 notrap aligned region4 v25+72
+;; @0062                               v110 = load.i64 notrap aligned region5 v25+64
+;; @0062                               v111 = load.i64 notrap aligned region6 v25+80
+;; @0062                               store notrap aligned region2 v109, v72+8
+;; @0062                               store notrap aligned region2 v110, v72+16
+;; @0062                               store notrap aligned region2 v111, v72+24
+;; @0062                               v114 = load.i64 notrap aligned region2 v27
+;; @0062                               store notrap aligned region1 v114, v25+24
+;; @0062                               v115 = load.i64 notrap aligned region2 v27+8
+;; @0062                               store notrap aligned region4 v115, v25+72
+;; @0062                               v116 = load.i64 notrap aligned region2 v27+16
+;; @0062                               store notrap aligned region5 v116, v25+64
+;; @0062                               v117 = load.i64 notrap aligned region2 v27+24
+;; @0062                               store notrap aligned region6 v117, v25+80
+;; @0062                               v119 = load.i64 notrap aligned region2 v72+88
+;; @0062                               jump block10
+;;
+;;                                 block12 cold:
+;; @0062                               trap user12
+;;
+;;                                 block13:
+;; @0062                               v126 = iconst.i64 136
+;; @0062                               v127 = iadd.i64 v72, v126  ; v126 = 136
+;; @0062                               v128 = load.i64 notrap aligned region2 v127+8
+;; @0062                               v129 = load.i32 notrap aligned region7 v128
+;;                                     v181 = iconst.i32 0
+;; @0062                               store notrap aligned region2 v181, v127  ; v181 = 0
 ;; @0062                               jump block4
 ;;
 ;;                                 block10:
-;; @0062                               v120 = ireduce.i32 v69
-;; @0062                               br_table v120, block11, [block12]
+;; @0062                               v118 = ireduce.i32 v69
+;; @0062                               br_table v118, block12, [block13]
 ;;
 ;;                                 block6:
-;; @0062                               v135 = load.i64 notrap aligned region2 v27
-;; @0062                               store notrap aligned region1 v135, v25+24
-;; @0062                               v136 = load.i64 notrap aligned region2 v27+8
-;; @0062                               store notrap aligned region4 v136, v25+72
-;; @0062                               v137 = load.i64 notrap aligned region2 v27+16
-;; @0062                               store notrap aligned region5 v137, v25+64
-;; @0062                               v138 = load.i64 notrap aligned region2 v27+24
-;; @0062                               store notrap aligned region6 v138, v25+80
-;; @0062                               v141 = iconst.i32 4
-;;                                     v180 = iconst.i64 32
-;;                                     v181 = iadd.i64 v72, v180  ; v180 = 32
-;; @0062                               store notrap aligned region2 v141, v181  ; v141 = 4
-;; @0062                               v144 = iconst.i64 120
-;; @0062                               v145 = iadd.i64 v72, v144  ; v144 = 120
-;; @0062                               v146 = load.i64 notrap aligned region2 v145+8
-;;                                     v182 = iconst.i32 0
-;; @0062                               store notrap aligned region2 v182, v145  ; v182 = 0
-;; @0062                               store notrap aligned region2 v182, v145+4  ; v182 = 0
-;;                                     v183 = iconst.i64 0
-;; @0062                               store notrap aligned region2 v183, v145+8  ; v183 = 0
+;; @0062                               v133 = load.i64 notrap aligned region2 v27
+;; @0062                               store notrap aligned region1 v133, v25+24
+;; @0062                               v134 = load.i64 notrap aligned region2 v27+8
+;; @0062                               store notrap aligned region4 v134, v25+72
+;; @0062                               v135 = load.i64 notrap aligned region2 v27+16
+;; @0062                               store notrap aligned region5 v135, v25+64
+;; @0062                               v136 = load.i64 notrap aligned region2 v27+24
+;; @0062                               store notrap aligned region6 v136, v25+80
+;; @0062                               v139 = iconst.i32 4
+;;                                     v175 = iconst.i64 32
+;;                                     v176 = iadd.i64 v72, v175  ; v175 = 32
+;; @0062                               store notrap aligned region2 v139, v176  ; v139 = 4
+;; @0062                               v142 = iconst.i64 120
+;; @0062                               v143 = iadd.i64 v72, v142  ; v142 = 120
+;; @0062                               v144 = load.i64 notrap aligned region2 v143+8
+;;                                     v177 = iconst.i32 0
+;; @0062                               store notrap aligned region2 v177, v143  ; v177 = 0
+;; @0062                               store notrap aligned region2 v177, v143+4  ; v177 = 0
+;;                                     v178 = iconst.i64 0
+;; @0062                               store notrap aligned region2 v178, v143+8  ; v178 = 0
 ;; @0068                               return
 ;;
 ;;                                 block4:
-;; @0062                               v123 = uextend.i128 v121
-;;                                     v185 = iconst.i64 64
-;;                                     v186 = ishl v123, v185  ; v185 = 64
-;; @0062                               v122 = uextend.i128 v72
-;; @0062                               v127 = bor v186, v122
-;; @006d                               jump block2(v127)
+;; @0062                               v121 = uextend.i128 v119
+;;                                     v182 = iconst.i64 64
+;;                                     v183 = ishl v121, v182  ; v182 = 64
+;; @0062                               v120 = uextend.i128 v72
+;; @0062                               v125 = bor v183, v120
+;; @006d                               jump block2(v125)
 ;; }

--- a/tests/disas/stack-switching/resume-suspend.wat
+++ b/tests/disas/stack-switching/resume-suspend.wat
@@ -23,6 +23,7 @@
 )
 
 ;; function u0:0(i64 vmctx, i64) tail {
+;;     ss0 = explicit_slot 16, align = 65536
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 67108952 "VMStoreContext+0x58"
@@ -31,6 +32,8 @@
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
+;;     sig0 = (i64 vmctx, i32) -> i8 tail
+;;     fn0 = colocated u805306368:44 sig0
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -43,66 +46,92 @@
 ;; @003b                               jump block2(v5, v6)
 ;;
 ;;                                 block2(v7: i64, v8: i64):
-;;                                     v60 = iconst.i64 1
-;;                                     v61 = icmp eq v7, v60  ; v60 = 1
-;; @003b                               trapnz v61, user22
+;;                                     v73 = iconst.i64 1
+;;                                     v74 = icmp eq v7, v73  ; v73 = 1
+;; @003b                               trapnz v74, user22
 ;; @003b                               jump block3
 ;;
 ;;                                 block3:
 ;; @003b                               v11 = load.i64 notrap aligned region3 v8+64
 ;; @003b                               v12 = load.i64 notrap aligned region3 v8+72
-;;                                     v62 = iconst.i64 40
-;;                                     v63 = iadd v12, v62  ; v62 = 40
-;; @003b                               v15 = load.i64 notrap aligned region3 v63+8
+;;                                     v75 = iconst.i64 40
+;;                                     v76 = iadd v12, v75  ; v75 = 40
+;; @003b                               v15 = load.i64 notrap aligned region3 v76+8
 ;; @003b                               v16 = load.i32 notrap aligned region3 v12+56
-;;                                     v64 = iconst.i32 0
-;;                                     v54 = iconst.i32 3
+;;                                     v77 = iconst.i32 0
+;;                                     v67 = iconst.i32 3
 ;; @003b                               v2 = iconst.i64 48
 ;; @003b                               v3 = iadd.i64 v0, v2  ; v2 = 48
 ;; @003b                               v26 = iconst.i32 1
-;; @003b                               jump block4(v64)  ; v64 = 0
+;; @003b                               jump block4(v77)  ; v77 = 0
 ;;
 ;;                                 block4(v18: i32):
 ;; @003b                               v19 = icmp ult v18, v16
 ;; @003b                               brif v19, block5, block2(v11, v12)
 ;;
 ;;                                 block5:
-;;                                     v65 = iconst.i32 3
-;;                                     v66 = ishl.i32 v18, v65  ; v65 = 3
-;; @003b                               v22 = uextend.i64 v66
+;;                                     v78 = iconst.i32 3
+;;                                     v79 = ishl.i32 v18, v78  ; v78 = 3
+;; @003b                               v22 = uextend.i64 v79
 ;; @003b                               v23 = iadd.i64 v15, v22
 ;; @003b                               v24 = load.i64 notrap aligned region4 v23
-;;                                     v67 = iadd.i64 v0, v2  ; v2 = 48
-;;                                     v68 = icmp eq v24, v67
-;;                                     v69 = iconst.i32 1
-;;                                     v70 = iadd.i32 v18, v69  ; v69 = 1
-;; @003b                               brif v68, block6, block4(v70)
+;;                                     v80 = iadd.i64 v0, v2  ; v2 = 48
+;;                                     v81 = icmp eq v24, v80
+;;                                     v82 = iconst.i32 1
+;;                                     v83 = iadd.i32 v18, v82  ; v82 = 1
+;; @003b                               brif v81, block6, block4(v83)
 ;;
 ;;                                 block6:
 ;; @003b                               store.i64 notrap aligned region3 v8, v6+80
-;;                                     v71 = iconst.i32 3
-;; @003b                               v33 = iconst.i64 32
-;; @003b                               v34 = iadd.i64 v6, v33  ; v33 = 32
-;; @003b                               store notrap aligned region3 v71, v34  ; v71 = 3
-;; @003b                               v30 = iconst.i64 0
-;; @003b                               store notrap aligned region3 v30, v8+64  ; v30 = 0
-;; @003b                               store notrap aligned region3 v30, v8+72  ; v30 = 0
-;; @003b                               v42 = iconst.i64 96
-;; @003b                               v43 = iadd.i64 v8, v42  ; v42 = 96
-;; @003b                               v44 = load.i64 notrap aligned region3 v43
-;; @003b                               v45 = iconst.i64 -24
-;; @003b                               v46 = iadd v44, v45  ; v45 = -24
-;; @003b                               v40 = uextend.i64 v18
-;;                                     v57 = iconst.i64 0x0002_0000_0000
-;;                                     v58 = bor v40, v57  ; v57 = 0x0002_0000_0000
-;; @003b                               v47 = stack_switch v46, v46, v58
+;;                                     v84 = iconst.i32 1
 ;; @003b                               v28 = iconst.i64 136
 ;; @003b                               v29 = iadd.i64 v6, v28  ; v28 = 136
-;; @003b                               v50 = load.i64 notrap aligned region3 v29+8
-;;                                     v72 = iconst.i32 0
-;; @003b                               store notrap aligned region3 v72, v29  ; v72 = 0
-;; @003b                               store notrap aligned region3 v72, v29+4  ; v72 = 0
-;; @003b                               store notrap aligned region3 v30, v29+8  ; v30 = 0
+;; @003b                               store notrap aligned region3 v84, v29+4  ; v84 = 1
+;; @003b                               v31 = stack_addr.i64 ss0
+;; @003b                               store notrap aligned region3 v31, v29+8
+;;                                     v85 = iconst.i32 3
+;; @003b                               v35 = iconst.i64 32
+;; @003b                               v36 = iadd.i64 v6, v35  ; v35 = 32
+;; @003b                               store notrap aligned region3 v85, v36  ; v85 = 3
+;; @003b                               v32 = iconst.i64 0
+;; @003b                               store notrap aligned region3 v32, v8+64  ; v32 = 0
+;; @003b                               store notrap aligned region3 v32, v8+72  ; v32 = 0
+;; @003b                               v44 = iconst.i64 96
+;; @003b                               v45 = iadd.i64 v8, v44  ; v44 = 96
+;; @003b                               v46 = load.i64 notrap aligned region3 v45
+;; @003b                               v47 = iconst.i64 -24
+;; @003b                               v48 = iadd v46, v47  ; v47 = -24
+;; @003b                               v42 = uextend.i64 v18
+;;                                     v70 = iconst.i64 0x0002_0000_0000
+;;                                     v71 = bor v42, v70  ; v70 = 0x0002_0000_0000
+;; @003b                               v49 = stack_switch v48, v48, v71
+;; @003b                               v51 = ushr v49, v35  ; v35 = 32
+;; @003b                               v52 = iconst.i64 5
+;; @003b                               v53 = icmp eq v51, v52  ; v52 = 5
+;; @003b                               brif v53, block8, block9
+;;
+;;                                 block8 cold:
+;;                                     v89 = iadd.i64 v6, v28  ; v28 = 136
+;; @003b                               v56 = load.i64 notrap aligned region3 v89+8
+;; @003b                               v57 = load.i32 notrap aligned region4 v56
+;;                                     v90 = iconst.i32 0
+;; @003b                               store notrap aligned region3 v90, v89  ; v90 = 0
+;; @003b                               store notrap aligned region3 v90, v89+4  ; v90 = 0
+;;                                     v91 = iconst.i64 0
+;; @003b                               store notrap aligned region3 v91, v89+8  ; v91 = 0
+;; @003b                               try_call fn0(v0, v57), sig0, block10, [ context v0 ]
+;;
+;;                                 block10:
+;; @003b                               trap user12
+;;
+;;                                 block9:
+;;                                     v86 = iadd.i64 v6, v28  ; v28 = 136
+;; @003b                               v63 = load.i64 notrap aligned region3 v86+8
+;;                                     v87 = iconst.i32 0
+;; @003b                               store notrap aligned region3 v87, v86  ; v87 = 0
+;; @003b                               store notrap aligned region3 v87, v86+4  ; v87 = 0
+;;                                     v88 = iconst.i64 0
+;; @003b                               store notrap aligned region3 v88, v86+8  ; v88 = 0
 ;; @003d                               jump block1
 ;;
 ;;                                 block1:
@@ -141,34 +170,34 @@
 ;;                                 block3:
 ;; @0045                               v16 = uextend.i128 v14
 ;; @0040                               v5 = iconst.i64 64
-;;                                     v165 = ishl v16, v5  ; v5 = 64
-;;                                     v167 = ireduce.i64 v165
-;;                                     v169 = bor v167, v13
-;; @004e                               trapz v169, user16
-;; @004e                               v26 = load.i64 notrap aligned region2 v169+88
+;;                                     v163 = ishl v16, v5  ; v5 = 64
+;;                                     v165 = ireduce.i64 v163
+;;                                     v167 = bor v165, v13
+;; @004e                               trapz v167, user16
+;; @004e                               v26 = load.i64 notrap aligned region2 v167+88
 ;; @0045                               v15 = uextend.i128 v13
-;; @0045                               v20 = bor v165, v15
-;;                                     v171 = ushr v20, v5  ; v5 = 64
-;; @004e                               v25 = ireduce.i64 v171
+;; @0045                               v20 = bor v163, v15
+;;                                     v169 = ushr v20, v5  ; v5 = 64
+;; @004e                               v25 = ireduce.i64 v169
 ;; @004e                               v27 = icmp eq v26, v25
 ;; @004e                               trapz v27, user23
 ;; @004e                               v28 = iconst.i64 1
 ;; @004e                               v29 = iadd v26, v28  ; v28 = 1
-;; @004e                               store notrap aligned region2 v29, v169+88
-;; @004e                               v30 = load.i64 notrap aligned region2 v169+80
+;; @004e                               store notrap aligned region2 v29, v167+88
+;; @004e                               v30 = load.i64 notrap aligned region2 v167+80
 ;; @004e                               v31 = load.i64 notrap aligned readonly can_move region0 v0+8
 ;; @004e                               v32 = load.i64 notrap aligned region3 v31+88
 ;; @004e                               v33 = load.i64 notrap aligned region3 v31+96
 ;; @004e                               store notrap aligned region2 v32, v30+64
 ;; @004e                               store notrap aligned region2 v33, v30+72
 ;; @0040                               v2 = iconst.i64 0
-;; @004e                               store notrap aligned region2 v2, v169+80  ; v2 = 0
+;; @004e                               store notrap aligned region2 v2, v167+80  ; v2 = 0
 ;; @004e                               v35 = iconst.i64 2
 ;; @004e                               store notrap aligned region3 v35, v31+88  ; v35 = 2
-;; @004e                               store notrap aligned region3 v169, v31+96
+;; @004e                               store notrap aligned region3 v167, v31+96
 ;; @004e                               v39 = iconst.i32 1
 ;; @004e                               v40 = iconst.i64 32
-;; @004e                               v41 = iadd v169, v40  ; v40 = 32
+;; @004e                               v41 = iadd v167, v40  ; v40 = 32
 ;; @004e                               store notrap aligned region2 v39, v41  ; v39 = 1
 ;; @004e                               v42 = iconst.i32 2
 ;; @004e                               v44 = iadd v33, v40  ; v40 = 32
@@ -181,13 +210,13 @@
 ;; @004e                               store notrap aligned region2 v50, v33+24
 ;; @004e                               v51 = load.i64 notrap aligned region1 v31+24
 ;; @004e                               store notrap aligned region2 v51, v33
-;; @004e                               v54 = load.i64 notrap aligned region2 v169
+;; @004e                               v54 = load.i64 notrap aligned region2 v167
 ;; @004e                               store notrap aligned region1 v54, v31+24
-;; @004e                               v55 = load.i64 notrap aligned region2 v169+8
+;; @004e                               v55 = load.i64 notrap aligned region2 v167+8
 ;; @004e                               store notrap aligned region4 v55, v31+72
-;; @004e                               v56 = load.i64 notrap aligned region2 v169+16
+;; @004e                               v56 = load.i64 notrap aligned region2 v167+16
 ;; @004e                               store notrap aligned region5 v56, v31+64
-;; @004e                               v57 = load.i64 notrap aligned region2 v169+24
+;; @004e                               v57 = load.i64 notrap aligned region2 v167+24
 ;; @004e                               store notrap aligned region6 v57, v31+80
 ;; @004e                               v58 = iconst.i64 40
 ;; @004e                               v59 = iadd v33, v58  ; v58 = 40
@@ -204,39 +233,40 @@
 ;; @004e                               v72 = load.i64 notrap aligned region2 v71
 ;; @004e                               v73 = iconst.i64 -24
 ;; @004e                               v74 = iadd v72, v73  ; v73 = -24
-;;                                     v173 = iconst.i64 0x0001_0000_0000
-;; @004e                               v75 = stack_switch v74, v74, v173  ; v173 = 0x0001_0000_0000
+;;                                     v171 = iconst.i64 0x0001_0000_0000
+;; @004e                               v75 = stack_switch v74, v74, v171  ; v171 = 0x0001_0000_0000
 ;; @004e                               v77 = load.i64 notrap aligned region3 v31+88
 ;; @004e                               v78 = load.i64 notrap aligned region3 v31+96
 ;; @004e                               store notrap aligned region3 v32, v31+88
 ;; @004e                               store notrap aligned region3 v33, v31+96
 ;; @004e                               store notrap aligned region2 v39, v44  ; v39 = 1
-;;                                     v176 = iconst.i32 0
-;; @004e                               store notrap aligned region2 v176, v59  ; v176 = 0
-;; @004e                               store notrap aligned region2 v176, v59+4  ; v176 = 0
+;;                                     v174 = iconst.i32 0
+;; @004e                               store notrap aligned region2 v174, v59  ; v174 = 0
+;; @004e                               store notrap aligned region2 v174, v59+4  ; v174 = 0
 ;; @004e                               store notrap aligned region2 v2, v59+8  ; v2 = 0
 ;; @004e                               store notrap aligned region2 v2, v33+56  ; v2 = 0
-;; @004e                               v87 = ushr v75, v40  ; v40 = 32
-;; @004e                               v88 = iconst.i64 4
-;; @004e                               v89 = icmp eq v87, v88  ; v88 = 4
-;; @004e                               brif v89, block6, block7
+;; @004e                               brif v75, block7, block4
 ;;
 ;;                                 block7:
-;; @004e                               brif.i64 v87, block5, block4
+;;                                     v182 = iconst.i64 32
+;;                                     v183 = ushr.i64 v75, v182  ; v182 = 32
+;; @004e                               v88 = iconst.i64 4
+;; @004e                               v89 = icmp eq v183, v88  ; v88 = 4
+;; @004e                               brif v89, block6, block5
 ;;
 ;;                                 block6 cold:
-;; @004e                               v94 = iconst.i32 5
+;; @004e                               v92 = iconst.i32 5
 ;;                                     v187 = iconst.i64 32
 ;;                                     v188 = iadd.i64 v78, v187  ; v187 = 32
-;; @004e                               store notrap aligned region2 v94, v188  ; v94 = 5
-;; @004e                               v99 = load.i64 notrap aligned region2 v33
-;; @004e                               store notrap aligned region1 v99, v31+24
-;; @004e                               v100 = load.i64 notrap aligned region2 v33+8
-;; @004e                               store notrap aligned region4 v100, v31+72
-;; @004e                               v101 = load.i64 notrap aligned region2 v33+16
-;; @004e                               store notrap aligned region5 v101, v31+64
-;; @004e                               v102 = load.i64 notrap aligned region2 v33+24
-;; @004e                               store notrap aligned region6 v102, v31+80
+;; @004e                               store notrap aligned region2 v92, v188  ; v92 = 5
+;; @004e                               v97 = load.i64 notrap aligned region2 v33
+;; @004e                               store notrap aligned region1 v97, v31+24
+;; @004e                               v98 = load.i64 notrap aligned region2 v33+8
+;; @004e                               store notrap aligned region4 v98, v31+72
+;; @004e                               v99 = load.i64 notrap aligned region2 v33+16
+;; @004e                               store notrap aligned region5 v99, v31+64
+;; @004e                               v100 = load.i64 notrap aligned region2 v33+24
+;; @004e                               store notrap aligned region6 v100, v31+80
 ;;                                     v189 = iconst.i32 0
 ;;                                     v190 = iconst.i64 120
 ;;                                     v191 = iadd.i64 v78, v190  ; v190 = 120
@@ -249,75 +279,77 @@
 ;; @004e                               store notrap aligned region2 v189, v194  ; v189 = 0
 ;; @004e                               store notrap aligned region2 v189, v194+4  ; v189 = 0
 ;; @004e                               store notrap aligned region2 v192, v194+8  ; v192 = 0
-;; @004e                               call fn2(v0)
-;; @004e                               trap user1
+;; @004e                               try_call fn2(v0), sig2, block9, [ context v0 ]
 ;;
-;;                                 block5:
-;; @004e                               v117 = load.i64 notrap aligned region4 v31+72
-;; @004e                               v118 = load.i64 notrap aligned region5 v31+64
-;; @004e                               v119 = load.i64 notrap aligned region6 v31+80
-;; @004e                               store notrap aligned region2 v117, v78+8
-;; @004e                               store notrap aligned region2 v118, v78+16
-;; @004e                               store notrap aligned region2 v119, v78+24
-;; @004e                               v122 = load.i64 notrap aligned region2 v33
-;; @004e                               store notrap aligned region1 v122, v31+24
-;; @004e                               v123 = load.i64 notrap aligned region2 v33+8
-;; @004e                               store notrap aligned region4 v123, v31+72
-;; @004e                               v124 = load.i64 notrap aligned region2 v33+16
-;; @004e                               store notrap aligned region5 v124, v31+64
-;; @004e                               v125 = load.i64 notrap aligned region2 v33+24
-;; @004e                               store notrap aligned region6 v125, v31+80
-;; @004e                               v127 = load.i64 notrap aligned region2 v78+88
-;; @004e                               jump block8
-;;
-;;                                 block9 cold:
+;;                                 block9:
 ;; @004e                               trap user12
 ;;
-;;                                 block10:
-;; @004e                               v134 = iconst.i64 136
-;; @004e                               v135 = iadd.i64 v78, v134  ; v134 = 136
-;; @004e                               v136 = load.i64 notrap aligned region2 v135+8
+;;                                 block5:
+;; @004e                               v115 = load.i64 notrap aligned region4 v31+72
+;; @004e                               v116 = load.i64 notrap aligned region5 v31+64
+;; @004e                               v117 = load.i64 notrap aligned region6 v31+80
+;; @004e                               store notrap aligned region2 v115, v78+8
+;; @004e                               store notrap aligned region2 v116, v78+16
+;; @004e                               store notrap aligned region2 v117, v78+24
+;; @004e                               v120 = load.i64 notrap aligned region2 v33
+;; @004e                               store notrap aligned region1 v120, v31+24
+;; @004e                               v121 = load.i64 notrap aligned region2 v33+8
+;; @004e                               store notrap aligned region4 v121, v31+72
+;; @004e                               v122 = load.i64 notrap aligned region2 v33+16
+;; @004e                               store notrap aligned region5 v122, v31+64
+;; @004e                               v123 = load.i64 notrap aligned region2 v33+24
+;; @004e                               store notrap aligned region6 v123, v31+80
+;; @004e                               v125 = load.i64 notrap aligned region2 v78+88
+;; @004e                               jump block8
+;;
+;;                                 block10 cold:
+;; @004e                               trap user12
+;;
+;;                                 block11:
+;; @004e                               v132 = iconst.i64 136
+;; @004e                               v133 = iadd.i64 v78, v132  ; v132 = 136
+;; @004e                               v134 = load.i64 notrap aligned region2 v133+8
 ;;                                     v184 = iconst.i32 0
-;; @004e                               store notrap aligned region2 v184, v135  ; v184 = 0
-;; @004e                               v129 = uextend.i128 v127
+;; @004e                               store notrap aligned region2 v184, v133  ; v184 = 0
+;; @004e                               v127 = uextend.i128 v125
 ;;                                     v185 = iconst.i64 64
-;;                                     v186 = ishl v129, v185  ; v185 = 64
-;; @004e                               v128 = uextend.i128 v78
-;; @004e                               v133 = bor v186, v128
-;; @004e                               jump block2(v133)
+;;                                     v186 = ishl v127, v185  ; v185 = 64
+;; @004e                               v126 = uextend.i128 v78
+;; @004e                               v131 = bor v186, v126
+;; @004e                               jump block2(v131)
 ;;
 ;;                                 block8:
-;; @004e                               v126 = ireduce.i32 v75
-;; @004e                               br_table v126, block9, [block10]
+;; @004e                               v124 = ireduce.i32 v75
+;; @004e                               br_table v124, block10, [block11]
 ;;
 ;;                                 block4:
-;; @004e                               v140 = load.i64 notrap aligned region2 v33
-;; @004e                               store notrap aligned region1 v140, v31+24
-;; @004e                               v141 = load.i64 notrap aligned region2 v33+8
-;; @004e                               store notrap aligned region4 v141, v31+72
-;; @004e                               v142 = load.i64 notrap aligned region2 v33+16
-;; @004e                               store notrap aligned region5 v142, v31+64
-;; @004e                               v143 = load.i64 notrap aligned region2 v33+24
-;; @004e                               store notrap aligned region6 v143, v31+80
-;; @004e                               v146 = iconst.i32 4
-;;                                     v177 = iconst.i64 32
-;;                                     v178 = iadd.i64 v78, v177  ; v177 = 32
-;; @004e                               store notrap aligned region2 v146, v178  ; v146 = 4
-;; @004e                               v149 = iconst.i64 120
-;; @004e                               v150 = iadd.i64 v78, v149  ; v149 = 120
-;; @004e                               v151 = load.i64 notrap aligned region2 v150+8
-;;                                     v179 = iconst.i32 0
-;; @004e                               store notrap aligned region2 v179, v150  ; v179 = 0
-;; @004e                               store notrap aligned region2 v179, v150+4  ; v179 = 0
-;;                                     v180 = iconst.i64 0
-;; @004e                               store notrap aligned region2 v180, v150+8  ; v180 = 0
-;;                                     v181 = uextend.i128 v180  ; v180 = 0
-;;                                     v182 = iconst.i64 64
-;;                                     v183 = ishl v181, v182  ; v182 = 64
-;; @0040                               v8 = bor v183, v181
+;; @004e                               v138 = load.i64 notrap aligned region2 v33
+;; @004e                               store notrap aligned region1 v138, v31+24
+;; @004e                               v139 = load.i64 notrap aligned region2 v33+8
+;; @004e                               store notrap aligned region4 v139, v31+72
+;; @004e                               v140 = load.i64 notrap aligned region2 v33+16
+;; @004e                               store notrap aligned region5 v140, v31+64
+;; @004e                               v141 = load.i64 notrap aligned region2 v33+24
+;; @004e                               store notrap aligned region6 v141, v31+80
+;; @004e                               v144 = iconst.i32 4
+;;                                     v175 = iconst.i64 32
+;;                                     v176 = iadd.i64 v78, v175  ; v175 = 32
+;; @004e                               store notrap aligned region2 v144, v176  ; v144 = 4
+;; @004e                               v147 = iconst.i64 120
+;; @004e                               v148 = iadd.i64 v78, v147  ; v147 = 120
+;; @004e                               v149 = load.i64 notrap aligned region2 v148+8
+;;                                     v177 = iconst.i32 0
+;; @004e                               store notrap aligned region2 v177, v148  ; v177 = 0
+;; @004e                               store notrap aligned region2 v177, v148+4  ; v177 = 0
+;;                                     v178 = iconst.i64 0
+;; @004e                               store notrap aligned region2 v178, v148+8  ; v178 = 0
+;;                                     v179 = uextend.i128 v178  ; v178 = 0
+;;                                     v180 = iconst.i64 64
+;;                                     v181 = ishl v179, v180  ; v180 = 64
+;; @0040                               v8 = bor v181, v179
 ;; @0056                               jump block2(v8)
 ;;
-;;                                 block2(v162: i128):
+;;                                 block2(v160: i128):
 ;; @0058                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/stack-switching/symmetric-switch.wat
+++ b/tests/disas/stack-switching/symmetric-switch.wat
@@ -26,7 +26,8 @@
 )
 
 ;; function u0:0(i64 vmctx, i64) tail {
-;;     ss0 = explicit_slot 24, align = 256
+;;     ss0 = explicit_slot 16, align = 65536
+;;     ss1 = explicit_slot 24, align = 256
 ;;     region0 = 8 "VMContext+0x8"
 ;;     region1 = 67108888 "VMStoreContext+0x18"
 ;;     region2 = 1073741824 "VMContRef+0x0"
@@ -35,14 +36,16 @@
 ;;     region5 = 67108936 "VMStoreContext+0x48"
 ;;     region6 = 67108928 "VMStoreContext+0x40"
 ;;     region7 = 67108944 "VMStoreContext+0x50"
-;;     region8 = 1543503872 "Stack(ss0)"
+;;     region8 = 1543503873 "Stack(ss1)"
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
 ;;     sig0 = (i64 vmctx, i32) -> i64 tail
 ;;     sig1 = (i64 vmctx, i64, i32, i32) -> i64 tail
+;;     sig2 = (i64 vmctx, i32) -> i8 tail
 ;;     fn0 = colocated u805306368:6 sig0
 ;;     fn1 = colocated u805306368:42 sig1
+;;     fn2 = colocated u805306368:44 sig2
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
@@ -115,130 +118,157 @@
 ;; @003e                               store.i64 notrap aligned region2 v29, v27+80
 ;; @003e                               v49 = iconst.i64 136
 ;; @003e                               v50 = iadd.i64 v27, v49  ; v49 = 136
-;; @003e                               v51 = iconst.i64 0
-;; @003e                               v52 = iadd.i64 v27, v51  ; v51 = 0
-;; @003e                               v53 = iconst.i32 3
-;; @003e                               v54 = iconst.i64 32
-;; @003e                               v55 = iadd v52, v54  ; v54 = 32
-;; @003e                               store notrap aligned region2 v53, v55  ; v53 = 3
-;; @003e                               v56 = iconst.i64 0
-;; @003e                               v57 = iconst.i64 0
-;; @003e                               store notrap aligned region2 v56, v29+64  ; v56 = 0
-;; @003e                               store notrap aligned region2 v57, v29+72  ; v57 = 0
-;; @003e                               v58 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @003e                               v51 = iconst.i32 1
+;; @003e                               v52 = stack_addr.i64 ss0
+;; @003e                               store notrap aligned region2 v51, v50+4  ; v51 = 1
+;; @003e                               store notrap aligned region2 v52, v50+8
+;; @003e                               v53 = iconst.i64 0
+;; @003e                               v54 = iadd.i64 v27, v53  ; v53 = 0
+;; @003e                               v55 = iconst.i32 3
+;; @003e                               v56 = iconst.i64 32
+;; @003e                               v57 = iadd v54, v56  ; v56 = 32
+;; @003e                               store notrap aligned region2 v55, v57  ; v55 = 3
+;; @003e                               v58 = iconst.i64 0
 ;; @003e                               v59 = iconst.i64 0
-;; @003e                               v60 = iadd v52, v59  ; v59 = 0
-;; @003e                               v61 = load.i64 notrap aligned region5 v58+72
-;; @003e                               v62 = load.i64 notrap aligned region6 v58+64
-;; @003e                               v63 = load.i64 notrap aligned region7 v58+80
-;; @003e                               store notrap aligned region2 v61, v60+8
-;; @003e                               store notrap aligned region2 v62, v60+16
-;; @003e                               store notrap aligned region2 v63, v60+24
-;; @003e                               v64 = load.i64 notrap aligned region2 v27+88
-;; @003e                               v65 = uextend.i128 v27
-;; @003e                               v66 = uextend.i128 v64
-;; @003e                               v67 = iconst.i64 64
-;; @003e                               v68 = uextend.i128 v67  ; v67 = 64
-;; @003e                               v69 = ishl v66, v68
-;; @003e                               v70 = bor v69, v65
-;; @003e                               v72 = iconst.i64 0
-;; @003e                               v73 = iadd.i64 v14, v72  ; v72 = 0
-;; @003e                               v74 = iconst.i64 32
-;; @003e                               v75 = iadd v73, v74  ; v74 = 32
-;; @003e                               v76 = load.i32 notrap aligned region2 v75
-;; @003e                               v77 = iconst.i32 0
-;; @003e                               v78 = icmp ne v76, v77  ; v77 = 0
-;; @003e                               brif v78, block9, block8
+;; @003e                               store notrap aligned region2 v58, v29+64  ; v58 = 0
+;; @003e                               store notrap aligned region2 v59, v29+72  ; v59 = 0
+;; @003e                               v60 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @003e                               v61 = iconst.i64 0
+;; @003e                               v62 = iadd v54, v61  ; v61 = 0
+;; @003e                               v63 = load.i64 notrap aligned region5 v60+72
+;; @003e                               v64 = load.i64 notrap aligned region6 v60+64
+;; @003e                               v65 = load.i64 notrap aligned region7 v60+80
+;; @003e                               store notrap aligned region2 v63, v62+8
+;; @003e                               store notrap aligned region2 v64, v62+16
+;; @003e                               store notrap aligned region2 v65, v62+24
+;; @003e                               v66 = load.i64 notrap aligned region2 v27+88
+;; @003e                               v67 = uextend.i128 v27
+;; @003e                               v68 = uextend.i128 v66
+;; @003e                               v69 = iconst.i64 64
+;; @003e                               v70 = uextend.i128 v69  ; v69 = 64
+;; @003e                               v71 = ishl v68, v70
+;; @003e                               v72 = bor v71, v67
+;; @003e                               v74 = iconst.i64 0
+;; @003e                               v75 = iadd.i64 v14, v74  ; v74 = 0
+;; @003e                               v76 = iconst.i64 32
+;; @003e                               v77 = iadd v75, v76  ; v76 = 32
+;; @003e                               v78 = load.i32 notrap aligned region2 v77
+;; @003e                               v79 = iconst.i32 0
+;; @003e                               v80 = icmp ne v78, v79  ; v79 = 0
+;; @003e                               brif v80, block9, block8
 ;;
 ;;                                 block8:
-;; @003e                               v79 = iconst.i64 120
-;; @003e                               v80 = iadd.i64 v14, v79  ; v79 = 120
-;; @003e                               v81 = load.i64 notrap aligned region2 v80+8
-;; @003e                               v82 = load.i32 notrap aligned region2 v80
-;; @003e                               v83 = iconst.i32 1
-;; @003e                               v84 = iadd v82, v83  ; v83 = 1
-;; @003e                               store notrap aligned region2 v84, v80
-;; @003e                               v85 = uextend.i64 v82
-;; @003e                               v86 = iconst.i64 16
-;; @003e                               v87 = imul v85, v86  ; v86 = 16
-;; @003e                               v88 = iadd v81, v87
-;; @003e                               jump block10(v88)
+;; @003e                               v81 = iconst.i64 120
+;; @003e                               v82 = iadd.i64 v14, v81  ; v81 = 120
+;; @003e                               v83 = load.i64 notrap aligned region2 v82+8
+;; @003e                               v84 = load.i32 notrap aligned region2 v82
+;; @003e                               v85 = iconst.i32 1
+;; @003e                               v86 = iadd v84, v85  ; v85 = 1
+;; @003e                               store notrap aligned region2 v86, v82
+;; @003e                               v87 = uextend.i64 v84
+;; @003e                               v88 = iconst.i64 16
+;; @003e                               v89 = imul v87, v88  ; v88 = 16
+;; @003e                               v90 = iadd v83, v89
+;; @003e                               jump block10(v90)
 ;;
 ;;                                 block9:
-;; @003e                               v89 = iconst.i64 136
-;; @003e                               v90 = iadd.i64 v14, v89  ; v89 = 136
-;; @003e                               v91 = load.i64 notrap aligned region2 v90+8
-;; @003e                               v92 = load.i32 notrap aligned region2 v90
-;; @003e                               v93 = iconst.i32 1
-;; @003e                               v94 = iadd v92, v93  ; v93 = 1
-;; @003e                               store notrap aligned region2 v94, v90
-;; @003e                               v95 = uextend.i64 v92
-;; @003e                               v96 = iconst.i64 16
-;; @003e                               v97 = imul v95, v96  ; v96 = 16
-;; @003e                               v98 = iadd v91, v97
-;; @003e                               jump block10(v98)
+;; @003e                               v91 = iconst.i64 136
+;; @003e                               v92 = iadd.i64 v14, v91  ; v91 = 136
+;; @003e                               v93 = load.i64 notrap aligned region2 v92+8
+;; @003e                               v94 = load.i32 notrap aligned region2 v92
+;; @003e                               v95 = iconst.i32 1
+;; @003e                               v96 = iadd v94, v95  ; v95 = 1
+;; @003e                               store notrap aligned region2 v96, v92
+;; @003e                               v97 = uextend.i64 v94
+;; @003e                               v98 = iconst.i64 16
+;; @003e                               v99 = imul v97, v98  ; v98 = 16
+;; @003e                               v100 = iadd v93, v99
+;; @003e                               jump block10(v100)
 ;;
-;;                                 block10(v71: i64):
-;; @003e                               store.i128 notrap aligned region4 v70, v71
-;; @003e                               v99 = iconst.i64 0
-;; @003e                               v100 = iadd.i64 v14, v99  ; v99 = 0
-;; @003e                               v101 = iconst.i32 1
-;; @003e                               v102 = iconst.i64 32
-;; @003e                               v103 = iadd v100, v102  ; v102 = 32
-;; @003e                               store notrap aligned region2 v101, v103  ; v101 = 1
-;; @003e                               v104 = load.i64 notrap aligned region2 v14+80
-;; @003e                               store.i64 notrap aligned region2 v32, v104+64
-;; @003e                               store.i64 notrap aligned region2 v33, v104+72
-;; @003e                               v105 = iconst.i64 2
-;; @003e                               v106 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @003e                               store notrap aligned region3 v105, v106+88  ; v105 = 2
-;; @003e                               store.i64 notrap aligned region3 v14, v106+96
-;; @003e                               v107 = iconst.i64 0
-;; @003e                               v108 = iadd v100, v107  ; v107 = 0
-;; @003e                               v109 = load.i64 notrap aligned region2 v108
-;; @003e                               store notrap aligned region1 v109, v58+24
-;; @003e                               v110 = load.i64 notrap aligned region2 v108+8
-;; @003e                               store notrap aligned region5 v110, v58+72
-;; @003e                               v111 = load.i64 notrap aligned region2 v108+16
-;; @003e                               store notrap aligned region6 v111, v58+64
-;; @003e                               v112 = load.i64 notrap aligned region2 v108+24
-;; @003e                               store notrap aligned region7 v112, v58+80
-;; @003e                               v113 = iconst.i64 96
-;; @003e                               v114 = iadd.i64 v29, v113  ; v113 = 96
-;; @003e                               v115 = load.i64 notrap aligned region2 v114
-;; @003e                               v116 = iconst.i64 -24
-;; @003e                               v117 = iadd v115, v116  ; v116 = -24
-;; @003e                               v118 = iconst.i64 96
-;; @003e                               v119 = iadd v104, v118  ; v118 = 96
-;; @003e                               v120 = load.i64 notrap aligned region2 v119
-;; @003e                               v121 = iconst.i64 -24
-;; @003e                               v122 = iadd v120, v121  ; v121 = -24
-;; @003e                               v123 = stack_addr.i64 ss0
-;; @003e                               v124 = load.i64 notrap aligned region4 v122
-;; @003e                               store notrap aligned region8 v124, v123
-;; @003e                               v125 = load.i64 notrap aligned region4 v117
-;; @003e                               store notrap aligned region4 v125, v122
-;; @003e                               v126 = load.i64 notrap aligned region4 v122+8
-;; @003e                               store notrap aligned region8 v126, v123+8
-;; @003e                               v127 = load.i64 notrap aligned region4 v117+8
-;; @003e                               store notrap aligned region4 v127, v122+8
-;; @003e                               v128 = load.i64 notrap aligned region4 v122+16
-;; @003e                               store notrap aligned region8 v128, v123+16
-;; @003e                               v129 = load.i64 notrap aligned region4 v117+16
-;; @003e                               store notrap aligned region4 v129, v122+16
-;; @003e                               v130 = iconst.i64 3
-;; @003e                               v131 = iconst.i64 32
-;; @003e                               v132 = ishl v130, v131  ; v130 = 3, v131 = 32
-;; @003e                               v133 = stack_switch v117, v123, v132
-;; @003e                               v134 = iconst.i64 136
-;; @003e                               v135 = iadd.i64 v27, v134  ; v134 = 136
-;; @003e                               v136 = load.i64 notrap aligned region2 v135+8
-;; @003e                               v137 = iconst.i32 0
-;; @003e                               store notrap aligned region2 v137, v135  ; v137 = 0
-;; @003e                               v138 = iconst.i32 0
-;; @003e                               store notrap aligned region2 v138, v135+4  ; v138 = 0
-;; @003e                               v139 = iconst.i64 0
-;; @003e                               store notrap aligned region2 v139, v135+8  ; v139 = 0
+;;                                 block10(v73: i64):
+;; @003e                               store.i128 notrap aligned region4 v72, v73
+;; @003e                               v101 = iconst.i64 0
+;; @003e                               v102 = iadd.i64 v14, v101  ; v101 = 0
+;; @003e                               v103 = iconst.i32 1
+;; @003e                               v104 = iconst.i64 32
+;; @003e                               v105 = iadd v102, v104  ; v104 = 32
+;; @003e                               store notrap aligned region2 v103, v105  ; v103 = 1
+;; @003e                               v106 = load.i64 notrap aligned region2 v14+80
+;; @003e                               store.i64 notrap aligned region2 v32, v106+64
+;; @003e                               store.i64 notrap aligned region2 v33, v106+72
+;; @003e                               v107 = iconst.i64 2
+;; @003e                               v108 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @003e                               store notrap aligned region3 v107, v108+88  ; v107 = 2
+;; @003e                               store.i64 notrap aligned region3 v14, v108+96
+;; @003e                               v109 = iconst.i64 0
+;; @003e                               v110 = iadd v102, v109  ; v109 = 0
+;; @003e                               v111 = load.i64 notrap aligned region2 v110
+;; @003e                               store notrap aligned region1 v111, v60+24
+;; @003e                               v112 = load.i64 notrap aligned region2 v110+8
+;; @003e                               store notrap aligned region5 v112, v60+72
+;; @003e                               v113 = load.i64 notrap aligned region2 v110+16
+;; @003e                               store notrap aligned region6 v113, v60+64
+;; @003e                               v114 = load.i64 notrap aligned region2 v110+24
+;; @003e                               store notrap aligned region7 v114, v60+80
+;; @003e                               v115 = iconst.i64 96
+;; @003e                               v116 = iadd.i64 v29, v115  ; v115 = 96
+;; @003e                               v117 = load.i64 notrap aligned region2 v116
+;; @003e                               v118 = iconst.i64 -24
+;; @003e                               v119 = iadd v117, v118  ; v118 = -24
+;; @003e                               v120 = iconst.i64 96
+;; @003e                               v121 = iadd v106, v120  ; v120 = 96
+;; @003e                               v122 = load.i64 notrap aligned region2 v121
+;; @003e                               v123 = iconst.i64 -24
+;; @003e                               v124 = iadd v122, v123  ; v123 = -24
+;; @003e                               v125 = stack_addr.i64 ss1
+;; @003e                               v126 = load.i64 notrap aligned region4 v124
+;; @003e                               store notrap aligned region8 v126, v125
+;; @003e                               v127 = load.i64 notrap aligned region4 v119
+;; @003e                               store notrap aligned region4 v127, v124
+;; @003e                               v128 = load.i64 notrap aligned region4 v124+8
+;; @003e                               store notrap aligned region8 v128, v125+8
+;; @003e                               v129 = load.i64 notrap aligned region4 v119+8
+;; @003e                               store notrap aligned region4 v129, v124+8
+;; @003e                               v130 = load.i64 notrap aligned region4 v124+16
+;; @003e                               store notrap aligned region8 v130, v125+16
+;; @003e                               v131 = load.i64 notrap aligned region4 v119+16
+;; @003e                               store notrap aligned region4 v131, v124+16
+;; @003e                               v132 = iconst.i64 3
+;; @003e                               v133 = iconst.i64 32
+;; @003e                               v134 = ishl v132, v133  ; v132 = 3, v133 = 32
+;; @003e                               v135 = stack_switch v119, v125, v134
+;; @003e                               v136 = iconst.i64 32
+;; @003e                               v137 = ushr v135, v136  ; v136 = 32
+;; @003e                               v138 = iconst.i64 5
+;; @003e                               v139 = icmp eq v137, v138  ; v138 = 5
+;; @003e                               brif v139, block11, block12
+;;
+;;                                 block11 cold:
+;; @003e                               v140 = iconst.i64 136
+;; @003e                               v141 = iadd.i64 v27, v140  ; v140 = 136
+;; @003e                               v142 = load.i64 notrap aligned region2 v141+8
+;; @003e                               v143 = load.i32 notrap aligned region4 v142
+;; @003e                               v144 = iconst.i32 0
+;; @003e                               store notrap aligned region2 v144, v141  ; v144 = 0
+;; @003e                               v145 = iconst.i32 0
+;; @003e                               store notrap aligned region2 v145, v141+4  ; v145 = 0
+;; @003e                               v146 = iconst.i64 0
+;; @003e                               store notrap aligned region2 v146, v141+8  ; v146 = 0
+;; @003e                               try_call fn2(v0, v143), sig2, block13, [ context v0 ]
+;;
+;;                                 block13:
+;; @003e                               trap user12
+;;
+;;                                 block12:
+;; @003e                               v147 = iconst.i64 136
+;; @003e                               v148 = iadd.i64 v27, v147  ; v147 = 136
+;; @003e                               v149 = load.i64 notrap aligned region2 v148+8
+;; @003e                               v150 = iconst.i32 0
+;; @003e                               store notrap aligned region2 v150, v148  ; v150 = 0
+;; @003e                               v151 = iconst.i32 0
+;; @003e                               store notrap aligned region2 v151, v148+4  ; v151 = 0
+;; @003e                               v152 = iconst.i64 0
+;; @003e                               store notrap aligned region2 v152, v148+8  ; v152 = 0
 ;; @0041                               jump block1
 ;;
 ;;                                 block1:
@@ -393,116 +423,116 @@
 ;; @004b                               v78 = iconst.i64 0
 ;; @004b                               store notrap aligned region2 v78, v52+8  ; v78 = 0
 ;; @004b                               store notrap aligned region2 v27, v26+56  ; v27 = 0
-;; @004b                               v79 = iconst.i64 32
-;; @004b                               v80 = ushr v68, v79  ; v79 = 32
-;; @004b                               v81 = iconst.i64 4
-;; @004b                               v82 = icmp eq v80, v81  ; v81 = 4
-;; @004b                               brif v82, block5, block6
+;; @004b                               brif v68, block6, block3
 ;;
 ;;                                 block6:
-;; @004b                               v83 = iconst.i64 32
-;; @004b                               v84 = ushr.i64 v68, v83  ; v83 = 32
-;; @004b                               brif v84, block4, block3
+;; @004b                               v79 = iconst.i64 32
+;; @004b                               v80 = ushr.i64 v68, v79  ; v79 = 32
+;; @004b                               v81 = iconst.i64 4
+;; @004b                               v82 = icmp eq v80, v81  ; v81 = 4
+;; @004b                               brif v82, block5, block4
 ;;
 ;;                                 block5 cold:
-;; @004b                               v85 = iconst.i64 0
-;; @004b                               v86 = iadd.i64 v71, v85  ; v85 = 0
-;; @004b                               v87 = iconst.i32 5
-;; @004b                               v88 = iconst.i64 32
-;; @004b                               v89 = iadd v86, v88  ; v88 = 32
-;; @004b                               store notrap aligned region2 v87, v89  ; v87 = 5
-;; @004b                               v90 = iconst.i64 0
-;; @004b                               v91 = iadd.i64 v26, v90  ; v90 = 0
-;; @004b                               v92 = load.i64 notrap aligned region2 v91
-;; @004b                               store notrap aligned region1 v92, v38+24
-;; @004b                               v93 = load.i64 notrap aligned region2 v91+8
-;; @004b                               store notrap aligned region4 v93, v38+72
-;; @004b                               v94 = load.i64 notrap aligned region2 v91+16
-;; @004b                               store notrap aligned region5 v94, v38+64
-;; @004b                               v95 = load.i64 notrap aligned region2 v91+24
-;; @004b                               store notrap aligned region6 v95, v38+80
-;; @004b                               v96 = iconst.i64 120
-;; @004b                               v97 = iadd.i64 v71, v96  ; v96 = 120
-;; @004b                               v98 = iconst.i32 0
-;; @004b                               store notrap aligned region2 v98, v97  ; v98 = 0
-;; @004b                               v99 = iconst.i32 0
-;; @004b                               store notrap aligned region2 v99, v97+4  ; v99 = 0
-;; @004b                               v100 = iconst.i64 0
-;; @004b                               store notrap aligned region2 v100, v97+8  ; v100 = 0
-;; @004b                               v101 = iconst.i64 136
-;; @004b                               v102 = iadd.i64 v71, v101  ; v101 = 136
-;; @004b                               v103 = iconst.i32 0
-;; @004b                               store notrap aligned region2 v103, v102  ; v103 = 0
-;; @004b                               v104 = iconst.i32 0
-;; @004b                               store notrap aligned region2 v104, v102+4  ; v104 = 0
-;; @004b                               v105 = iconst.i64 0
-;; @004b                               store notrap aligned region2 v105, v102+8  ; v105 = 0
-;; @004b                               call fn2(v0)
-;; @004b                               trap user1
+;; @004b                               v83 = iconst.i64 0
+;; @004b                               v84 = iadd.i64 v71, v83  ; v83 = 0
+;; @004b                               v85 = iconst.i32 5
+;; @004b                               v86 = iconst.i64 32
+;; @004b                               v87 = iadd v84, v86  ; v86 = 32
+;; @004b                               store notrap aligned region2 v85, v87  ; v85 = 5
+;; @004b                               v88 = iconst.i64 0
+;; @004b                               v89 = iadd.i64 v26, v88  ; v88 = 0
+;; @004b                               v90 = load.i64 notrap aligned region2 v89
+;; @004b                               store notrap aligned region1 v90, v38+24
+;; @004b                               v91 = load.i64 notrap aligned region2 v89+8
+;; @004b                               store notrap aligned region4 v91, v38+72
+;; @004b                               v92 = load.i64 notrap aligned region2 v89+16
+;; @004b                               store notrap aligned region5 v92, v38+64
+;; @004b                               v93 = load.i64 notrap aligned region2 v89+24
+;; @004b                               store notrap aligned region6 v93, v38+80
+;; @004b                               v94 = iconst.i64 120
+;; @004b                               v95 = iadd.i64 v71, v94  ; v94 = 120
+;; @004b                               v96 = iconst.i32 0
+;; @004b                               store notrap aligned region2 v96, v95  ; v96 = 0
+;; @004b                               v97 = iconst.i32 0
+;; @004b                               store notrap aligned region2 v97, v95+4  ; v97 = 0
+;; @004b                               v98 = iconst.i64 0
+;; @004b                               store notrap aligned region2 v98, v95+8  ; v98 = 0
+;; @004b                               v99 = iconst.i64 136
+;; @004b                               v100 = iadd.i64 v71, v99  ; v99 = 136
+;; @004b                               v101 = iconst.i32 0
+;; @004b                               store notrap aligned region2 v101, v100  ; v101 = 0
+;; @004b                               v102 = iconst.i32 0
+;; @004b                               store notrap aligned region2 v102, v100+4  ; v102 = 0
+;; @004b                               v103 = iconst.i64 0
+;; @004b                               store notrap aligned region2 v103, v100+8  ; v103 = 0
+;; @004b                               try_call fn2(v0), sig2, block8, [ context v0 ]
+;;
+;;                                 block8:
+;; @004b                               trap user12
 ;;
 ;;                                 block4:
+;; @004b                               v104 = iconst.i64 0
+;; @004b                               v105 = iadd.i64 v71, v104  ; v104 = 0
 ;; @004b                               v106 = iconst.i64 0
-;; @004b                               v107 = iadd.i64 v71, v106  ; v106 = 0
-;; @004b                               v108 = iconst.i64 0
-;; @004b                               v109 = iadd v107, v108  ; v108 = 0
-;; @004b                               v110 = load.i64 notrap aligned region4 v38+72
-;; @004b                               v111 = load.i64 notrap aligned region5 v38+64
-;; @004b                               v112 = load.i64 notrap aligned region6 v38+80
-;; @004b                               store notrap aligned region2 v110, v109+8
-;; @004b                               store notrap aligned region2 v111, v109+16
-;; @004b                               store notrap aligned region2 v112, v109+24
-;; @004b                               v113 = iconst.i64 0
-;; @004b                               v114 = iadd.i64 v26, v113  ; v113 = 0
-;; @004b                               v115 = load.i64 notrap aligned region2 v114
-;; @004b                               store notrap aligned region1 v115, v38+24
-;; @004b                               v116 = load.i64 notrap aligned region2 v114+8
-;; @004b                               store notrap aligned region4 v116, v38+72
-;; @004b                               v117 = load.i64 notrap aligned region2 v114+16
-;; @004b                               store notrap aligned region5 v117, v38+64
-;; @004b                               v118 = load.i64 notrap aligned region2 v114+24
-;; @004b                               store notrap aligned region6 v118, v38+80
-;; @004b                               v119 = ireduce.i32 v68
-;; @004b                               v120 = load.i64 notrap aligned region2 v71+88
-;; @004b                               v121 = uextend.i128 v71
-;; @004b                               v122 = uextend.i128 v120
-;; @004b                               v123 = iconst.i64 64
-;; @004b                               v124 = uextend.i128 v123  ; v123 = 64
-;; @004b                               v125 = ishl v122, v124
-;; @004b                               v126 = bor v125, v121
+;; @004b                               v107 = iadd v105, v106  ; v106 = 0
+;; @004b                               v108 = load.i64 notrap aligned region4 v38+72
+;; @004b                               v109 = load.i64 notrap aligned region5 v38+64
+;; @004b                               v110 = load.i64 notrap aligned region6 v38+80
+;; @004b                               store notrap aligned region2 v108, v107+8
+;; @004b                               store notrap aligned region2 v109, v107+16
+;; @004b                               store notrap aligned region2 v110, v107+24
+;; @004b                               v111 = iconst.i64 0
+;; @004b                               v112 = iadd.i64 v26, v111  ; v111 = 0
+;; @004b                               v113 = load.i64 notrap aligned region2 v112
+;; @004b                               store notrap aligned region1 v113, v38+24
+;; @004b                               v114 = load.i64 notrap aligned region2 v112+8
+;; @004b                               store notrap aligned region4 v114, v38+72
+;; @004b                               v115 = load.i64 notrap aligned region2 v112+16
+;; @004b                               store notrap aligned region5 v115, v38+64
+;; @004b                               v116 = load.i64 notrap aligned region2 v112+24
+;; @004b                               store notrap aligned region6 v116, v38+80
+;; @004b                               v117 = ireduce.i32 v68
+;; @004b                               v118 = load.i64 notrap aligned region2 v71+88
+;; @004b                               v119 = uextend.i128 v71
+;; @004b                               v120 = uextend.i128 v118
+;; @004b                               v121 = iconst.i64 64
+;; @004b                               v122 = uextend.i128 v121  ; v121 = 64
+;; @004b                               v123 = ishl v120, v122
+;; @004b                               v124 = bor v123, v119
 ;; @004b                               jump block7
 ;;
-;;                                 block8 cold:
+;;                                 block9 cold:
 ;; @004b                               trap user12
 ;;
 ;;                                 block7:
-;; @004b                               br_table v119, block8, []
+;; @004b                               br_table v117, block9, []
 ;;
 ;;                                 block3:
-;; @004b                               v127 = iconst.i64 0
-;; @004b                               v128 = iadd.i64 v26, v127  ; v127 = 0
-;; @004b                               v129 = load.i64 notrap aligned region2 v128
-;; @004b                               store notrap aligned region1 v129, v38+24
-;; @004b                               v130 = load.i64 notrap aligned region2 v128+8
-;; @004b                               store notrap aligned region4 v130, v38+72
-;; @004b                               v131 = load.i64 notrap aligned region2 v128+16
-;; @004b                               store notrap aligned region5 v131, v38+64
-;; @004b                               v132 = load.i64 notrap aligned region2 v128+24
-;; @004b                               store notrap aligned region6 v132, v38+80
-;; @004b                               v133 = iconst.i64 0
-;; @004b                               v134 = iadd.i64 v71, v133  ; v133 = 0
-;; @004b                               v135 = iconst.i32 4
-;; @004b                               v136 = iconst.i64 32
-;; @004b                               v137 = iadd v134, v136  ; v136 = 32
-;; @004b                               store notrap aligned region2 v135, v137  ; v135 = 4
-;; @004b                               v138 = iconst.i64 120
-;; @004b                               v139 = iadd.i64 v71, v138  ; v138 = 120
-;; @004b                               v140 = load.i64 notrap aligned region2 v139+8
-;; @004b                               v141 = iconst.i32 0
-;; @004b                               store notrap aligned region2 v141, v139  ; v141 = 0
-;; @004b                               v142 = iconst.i32 0
-;; @004b                               store notrap aligned region2 v142, v139+4  ; v142 = 0
-;; @004b                               v143 = iconst.i64 0
-;; @004b                               store notrap aligned region2 v143, v139+8  ; v143 = 0
+;; @004b                               v125 = iconst.i64 0
+;; @004b                               v126 = iadd.i64 v26, v125  ; v125 = 0
+;; @004b                               v127 = load.i64 notrap aligned region2 v126
+;; @004b                               store notrap aligned region1 v127, v38+24
+;; @004b                               v128 = load.i64 notrap aligned region2 v126+8
+;; @004b                               store notrap aligned region4 v128, v38+72
+;; @004b                               v129 = load.i64 notrap aligned region2 v126+16
+;; @004b                               store notrap aligned region5 v129, v38+64
+;; @004b                               v130 = load.i64 notrap aligned region2 v126+24
+;; @004b                               store notrap aligned region6 v130, v38+80
+;; @004b                               v131 = iconst.i64 0
+;; @004b                               v132 = iadd.i64 v71, v131  ; v131 = 0
+;; @004b                               v133 = iconst.i32 4
+;; @004b                               v134 = iconst.i64 32
+;; @004b                               v135 = iadd v132, v134  ; v134 = 32
+;; @004b                               store notrap aligned region2 v133, v135  ; v133 = 4
+;; @004b                               v136 = iconst.i64 120
+;; @004b                               v137 = iadd.i64 v71, v136  ; v136 = 120
+;; @004b                               v138 = load.i64 notrap aligned region2 v137+8
+;; @004b                               v139 = iconst.i32 0
+;; @004b                               store notrap aligned region2 v139, v137  ; v139 = 0
+;; @004b                               v140 = iconst.i32 0
+;; @004b                               store notrap aligned region2 v140, v137+4  ; v140 = 0
+;; @004b                               v141 = iconst.i64 0
+;; @004b                               store notrap aligned region2 v141, v137+8  ; v141 = 0
 ;; @0050                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/misc_testsuite/stack-switching/resume_throw.wast
+++ b/tests/misc_testsuite/stack-switching/resume_throw.wast
@@ -1,0 +1,130 @@
+;;! bulk_memory = true
+;;! function_references = true
+;;! stack_switching = true
+
+(module
+  (type $ft (func (result i32)))
+  (type $ct (cont $ft))
+
+  (type $ft-1 (func (param i32) (result i32)))
+  (type $ct-1 (cont $ft-1))
+
+  (tag $suspend)
+  (tag $exception (param i32))
+  (global $entered (mut i32) (i32.const 0))
+  (global $stacks-left (mut i32) (i32.const 0))
+
+  ;; Catch an exception injected at the suspension point on the
+  ;; resumed continuation's own stack, including its payload.
+  (func $catch-in-child (result i32)
+    (block $caught (result i32 exnref)
+      (try_table (result i32) (catch_ref $exception $caught)
+        (suspend $suspend)
+        (i32.const 0))
+      (return))
+    (drop))
+
+  (func (export "catch-in-child") (result i32)
+    (local $k (ref null $ct))
+    (block $on-suspend (result (ref $ct))
+      (resume $ct (on $suspend $on-suspend)
+        (cont.new $ct (ref.func $catch-in-child)))
+      (unreachable))
+    (local.set $k)
+    (resume_throw $ct $exception
+      (i32.const 42)
+      (local.get $k)))
+
+  ;; Let the exception escape the resumed stack and catch it in the
+  ;; parent stack around resume_throw.
+  (func $uncaught-in-child (result i32)
+    (suspend $suspend)
+    (i32.const 0))
+
+  (func (export "catch-in-parent") (result i32)
+    (local $k (ref null $ct))
+    (block $on-suspend (result (ref $ct))
+      (resume $ct (on $suspend $on-suspend)
+        (cont.new $ct (ref.func $uncaught-in-child)))
+      (unreachable))
+    (local.set $k)
+    (block $caught (result i32)
+      (try_table (result i32) (catch $exception $caught)
+        (resume_throw $ct $exception
+          (i32.const 43)
+          (local.get $k)))
+      (return)))
+
+  ;; Keep a copy of a continuation reference while throwing into it. Catching
+  ;; the injected exception does not undo consumption of the continuation, so
+  ;; attempting to resume it again through the retained reference must trap.
+  (func (export "resume-after-caught-throw") (result i32)
+    (local $k (ref null $ct))
+    (block $on-suspend (result (ref $ct))
+      (resume $ct (on $suspend $on-suspend)
+        (cont.new $ct (ref.func $uncaught-in-child)))
+      (unreachable))
+    (local.set $k)
+    (block $caught (result i32)
+      (try_table (result i32) (catch $exception $caught)
+        (resume_throw $ct $exception
+          (i32.const 46)
+          (local.get $k))))
+    (drop)
+    (resume $ct (local.get $k)))
+
+  ;; Throwing into a fresh continuation must not enter its function body.
+  (func $fresh-body (result i32)
+    (global.set $entered
+      (i32.add (global.get $entered) (i32.const 1)))
+    (i32.const 0))
+
+  (func (export "throw-into-fresh") (result i32)
+    (block $caught (result i32)
+      (try_table (result i32) (catch $exception $caught)
+        (resume_throw $ct $exception
+          (i32.const 44)
+          (cont.new $ct (ref.func $fresh-body))))
+      (return))
+    (global.get $entered)
+    (i32.const 100)
+    (i32.mul)
+    (i32.add))
+
+  ;; This function builds up a deep nesting of stacks. The leaf stack
+  ;; suspends to its immediate handler, which injects an exception
+  ;; into it, causing it to unwind to the top-most stack, where it is
+  ;; caught.
+  (func $deep-stack (param $stacks-left i32) (result i32)
+    (if (result i32) (i32.gt_u (local.get $stacks-left) (i32.const 0))
+      (then
+        (local.set $stacks-left
+          (i32.sub (local.get $stacks-left) (i32.const 1)))
+        (resume $ct-1 (local.get $stacks-left) (cont.new $ct-1 (ref.func $deep-stack))))
+      (else
+        (suspend $suspend)
+        (i32.const 0))))
+
+  (func (export "catch-eight-stacks-deep") (result i32)
+    (local $k (ref null $ct))
+    ;; The first resume creates one stack and each of these seven iterations
+    ;; creates another.
+    (block $on-suspend (result (ref $ct))
+      (resume $ct-1 (on $suspend $on-suspend)
+        (i32.const 8) (cont.new $ct-1 (ref.func $deep-stack)))
+      (unreachable))
+    (local.set $k)
+    (block $caught (result i32)
+      (try_table (result i32) (catch $exception $caught)
+        (resume_throw $ct $exception
+          (i32.const 45)
+          (local.get $k)))))
+
+  (elem declare func $catch-in-child $uncaught-in-child $fresh-body $deep-stack)
+)
+
+(assert_return (invoke "catch-in-child") (i32.const 42))
+(assert_return (invoke "catch-in-parent") (i32.const 43))
+(assert_return (invoke "throw-into-fresh") (i32.const 44))
+(assert_return (invoke "catch-eight-stacks-deep") (i32.const 45))
+(assert_trap (invoke "resume-after-caught-throw") "continuation already consumed")

--- a/tests/misc_testsuite/stack-switching/resume_throw_ref.wast
+++ b/tests/misc_testsuite/stack-switching/resume_throw_ref.wast
@@ -1,0 +1,120 @@
+;;! bulk_memory = true
+;;! function_references = true
+;;! stack_switching = true
+
+(module
+  (type $ft (func (result i32)))
+  (type $ct (cont $ft))
+
+  (type $ft-1 (func (param i32) (result i32)))
+  (type $ct-1 (cont $ft-1))
+
+  (tag $suspend)
+  (tag $exception)
+  (global $entered (mut i32) (i32.const 0))
+
+  (func $make-exception (result exnref)
+    (block $caught (result exnref)
+      (try_table (catch_ref $exception $caught)
+        (throw $exception))
+      (unreachable)))
+
+  ;; Catch an exception injected at the suspend instruction on the
+  ;; resumed continuation's own stack.
+  (func $catch-in-child (result i32)
+    (block $caught (result exnref)
+      (try_table (result i32) (catch_ref $exception $caught)
+        (suspend $suspend)
+        (i32.const 0))
+      (return))
+    (drop)
+    (i32.const 42))
+
+  (func (export "catch-in-child") (result i32)
+    (local $k (ref null $ct))
+    (block $on-suspend (result (ref $ct))
+      (resume $ct (on $suspend $on-suspend)
+        (cont.new $ct (ref.func $catch-in-child)))
+      (unreachable))
+    (local.set $k)
+    (resume_throw_ref $ct
+      (call $make-exception)
+      (local.get $k)))
+
+  ;; Let the injected exception escape the resumed stack and catch it in the
+  ;; parent stack around resume_throw_ref.
+  (func $uncaught-in-child (result i32)
+    (suspend $suspend)
+    (i32.const 0))
+
+  (func (export "catch-in-parent") (result i32)
+    (local $k (ref null $ct))
+    (block $on-suspend (result (ref $ct))
+      (resume $ct (on $suspend $on-suspend)
+        (cont.new $ct (ref.func $uncaught-in-child)))
+      (unreachable))
+    (local.set $k)
+    (block $caught (result exnref)
+      (try_table (result i32) (catch_ref $exception $caught)
+        (resume_throw_ref $ct
+          (call $make-exception)
+          (local.get $k)))
+      (return))
+    (drop)
+    (i32.const 43))
+
+  ;; Throwing into a fresh continuation must not enter its function body.
+  (func $fresh-body (result i32)
+    (global.set $entered
+      (i32.add (global.get $entered) (i32.const 1)))
+    (i32.const 0))
+
+  (func (export "throw-into-fresh") (result i32)
+    (block $caught (result exnref)
+      (try_table (result i32) (catch_ref $exception $caught)
+        (resume_throw_ref $ct
+          (call $make-exception)
+          (cont.new $ct (ref.func $fresh-body))))
+      (return))
+    (drop)
+    (global.get $entered))
+
+  ;; This function builds up a deep nesting of stacks. The leaf stack
+  ;; suspends to its immediate handler, which injects an exception
+  ;; into it, causing it to unwind to the top-most stack, where it is
+  ;; caught.
+  (func $deep-stack (param $stacks-left i32) (result i32)
+    (if (result i32) (i32.gt_u (local.get $stacks-left) (i32.const 0))
+      (then
+        (local.set $stacks-left
+          (i32.sub (local.get $stacks-left) (i32.const 1)))
+        (resume $ct-1 (local.get $stacks-left) (cont.new $ct-1 (ref.func $deep-stack))))
+      (else
+        (suspend $suspend)
+        (i32.const 0))))
+
+  (func (export "catch-eight-stacks-deep") (result i32)
+    (local $k (ref null $ct))
+    ;; The first resume creates one stack and each of these seven iterations
+    ;; creates another.
+    (block $on-suspend (result (ref $ct))
+      (resume $ct-1 (on $suspend $on-suspend)
+        (i32.const 8) (cont.new $ct-1 (ref.func $deep-stack)))
+      (unreachable))
+    (local.set $k)
+    (block $caught (result exnref)
+      (try_table (result i32) (catch_ref $exception $caught)
+        (resume_throw_ref $ct
+          (call $make-exception)
+          (local.get $k)))
+      (return))
+    (drop)
+    (i32.const 45))
+
+  (elem declare func $catch-in-child $uncaught-in-child $fresh-body $deep-stack)
+)
+
+(assert_return (invoke "catch-in-child") (i32.const 42))
+(assert_return (invoke "catch-in-parent") (i32.const 43))
+(assert_return (invoke "throw-into-fresh") (i32.const 0))
+(assert_return (invoke "catch-eight-stacks-deep") (i32.const 45))


### PR DESCRIPTION
This patch "completes" the implementation of stack switching in the sense that it adds the two missing instructions `resume_throw` and `resume_throw_ref`.

It builds on the previous trap patch. The idea is to "bubble" exceptions up through continuation stacks until they either reach a suitable exception handler or a host/engine boundary.

There is one special case: cancelling a fresh continuation, i.e. a continuation that has never been started. In this case, we inject the exception into the current context, because the Rust-wrapper around the funcref used to create the continuation expects to receive the arguments of the funcref and forward them accordingly.

prtest:full

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
