### PR TITLE
x64: Remove an add128 lower rule that turns out just hurts 

### DIFF
--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -134,23 +134,6 @@
           (iadd128 (value_regs_get_gpr x 0) (value_regs_get_gpr x 1)
                    y (gpr_mem_imm_64_imm 0))))
 
-;; Specialized lowering rule for `iadd` of two 64-bit unsigned integers, meaning
-;; that we can skip the `adc` and instead use `setb`. This is in some sense a
-;; way of modeling `uadd_overflow`.
-(rule 4 (lower (iadd $I128 (uextend _ x) (uextend _ y @ (value_type $I64))))
-        (let (
-            (x Gpr (extend_to_gpr x $I64 (ExtendKind.Zero)))
-            (ret ValueRegs (with_flags (x64_add_with_flags_paired $I64 x y)
-                                       (x64_setcc_paired (CC.B))))
-          )
-          ;; FIXME: this `movzx` ideally would happen before the `add` itself to
-          ;; zero out the destination register with `xor %dst,%dst` and then
-          ;; the `setb` would just write to the lower bytes. That would probably
-          ;; require modeling this as a pseudo-inst which isn't quite worth it
-          ;; at this time.
-          (value_regs (value_regs_get ret 0)
-                      (x64_movzx (ExtMode.BQ) (value_regs_get ret 1)))))
-
 ;; Helper for lowering 128-bit addition with the 64-bit halves of the lhs/rhs
 ;; already split. The first two arguments are lo/hi for the lhs and the second
 ;; two are lo/hi for the rhs.

--- a/cranelift/filetests/filetests/isa/x64/i128.clif
+++ b/cranelift/filetests/filetests/isa/x64/i128.clif
@@ -1111,21 +1111,22 @@ block2(v8: i128):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
+;   movq %rdx, %rcx
 ;   uninit  %rax
 ;   xorq %rax, %rax
-;   testb %dl, %dl
+;   uninit  %rdx
+;   xorq %rdx, %rdx
+;   testb %cl, %cl
 ;   jnz     label2; j label1
 ; block1:
 ;   addq $0x2, %rax
-;   setb %r11b
-;   movzbq %r11b, %rdx
+;   adcq $0x0, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
 ; block2:
 ;   addq $0x1, %rax
-;   setb %cl
-;   movzbq %cl, %rdx
+;   adcq $0x0, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -1135,20 +1136,20 @@ block2(v8: i128):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
+;   movq %rdx, %rcx
 ;   xorq %rax, %rax
-;   testb %dl, %dl
-;   jne 0x20
-; block2: ; offset 0xf
+;   xorq %rdx, %rdx
+;   testb %cl, %cl
+;   jne 0x22
+; block2: ; offset 0x15
 ;   addq $2, %rax
-;   setb %r11b
-;   movzbq %r11b, %rdx
+;   adcq $0, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
-; block3: ; offset 0x20
+; block3: ; offset 0x22
 ;   addq $1, %rax
-;   setb %cl
-;   movzbq %cl, %rdx
+;   adcq $0, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -2055,10 +2056,11 @@ block0(v0: i64, v1: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
+;   uninit  %rdx
+;   xorq %rdx, %rdx
 ;   movq %rsi, %rax
 ;   addq (%rdi), %rax
-;   setb %sil
-;   movzbq %sil, %rdx
+;   adcq $0x0, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -2068,10 +2070,10 @@ block0(v0: i64, v1: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
+;   xorq %rdx, %rdx
 ;   movq %rsi, %rax
 ;   addq (%rdi), %rax ; trap: heap_oob
-;   setb %sil
-;   movzbq %sil, %rdx
+;   adcq $0, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -2204,10 +2206,11 @@ block0(v0: i64, v1: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block0:
+;   uninit  %rdx
+;   xorq %rdx, %rdx
 ;   movq %rdi, %rax
 ;   addq %rsi, %rax
-;   setb %sil
-;   movzbq %sil, %rdx
+;   adcq $0x0, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -2217,10 +2220,10 @@ block0(v0: i64, v1: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
+;   xorq %rdx, %rdx
 ;   movq %rdi, %rax
 ;   addq %rsi, %rax
-;   setb %sil
-;   movzbq %sil, %rdx
+;   adcq $0, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq


### PR DESCRIPTION
A local `fib` benchmark shows that without this lowering rule wasm is 8%
slower than native, whereas with this lowering rule it's 24% slower than
native. The "FIXME" comment turns out can be resolved by just deleting
the entire rule.