### PR TITLE
wasmtime-cache: Reject overflowing duration values

### DIFF
--- a/crates/cache/src/config.rs
+++ b/crates/cache/src/config.rs
@@ -262,9 +262,9 @@ macro_rules! generate_deserializer {
 generate_deserializer!(deserialize_duration(num: u64, unit: &str) -> Duration {
     match unit {
         "s" => Some(Duration::from_secs(num)),
-        "m" => Some(Duration::from_secs(num * 60)),
-        "h" => Some(Duration::from_secs(num * 60 * 60)),
-        "d" => Some(Duration::from_secs(num * 60 * 60 * 24)),
+        "m" => num.checked_mul(60).map(Duration::from_secs),
+        "h" => num.checked_mul(60 * 60).map(Duration::from_secs),
+        "d" => num.checked_mul(60 * 60 * 24).map(Duration::from_secs),
         _ => None,
     }
 });

--- a/crates/cache/src/config/tests.rs
+++ b/crates/cache/src/config/tests.rs
@@ -401,6 +401,27 @@ fn test_duration_settings() {
 }
 
 #[test]
+fn test_duration_overflow() {
+    let (_td, cd, cp) = test_prolog();
+
+    for (num, unit) in [
+        (u64::MAX / 60 + 1, "m"),
+        (u64::MAX / (60 * 60) + 1, "h"),
+        (u64::MAX / (60 * 60 * 24) + 1, "d"),
+    ] {
+        let content = format!(
+            "[cache]\ndirectory = '{}'\ncleanup-interval = '{num}{unit}'",
+            cd.display()
+        );
+        fs::write(&cp, content).expect("Failed to write test config file");
+        assert!(
+            CacheConfig::from_file(Some(&cp)).is_err(),
+            "duration {num}{unit} should overflow"
+        );
+    }
+}
+
+#[test]
 fn test_percent_settings() {
     let (_td, cd, cp) = test_prolog();
     let conf = load_config!(


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

The cache configuration duration deserializer uses unchecked multiplication when converting minutes, hours, and days to seconds. Oversized values therefore panic when overflow checks are enabled and wrap otherwise. For example, `307445734561825861m` wraps to 44 seconds in a release build and is then accepted by configuration validation.

Use `u64::checked_mul` for the affected units so overflow is reported through the existing invalid-configuration path. Add regression coverage for the first overflowing minute, hour, and day values.
