### PR TITLE
Fix core dumps for composed components

### DIFF
--- a/crates/wasmtime/src/runtime/coredump.rs
+++ b/crates/wasmtime/src/runtime/coredump.rs
@@ -1,5 +1,4 @@
 use crate::hash_map::HashMap;
-use crate::hash_set::HashSet;
 use crate::prelude::*;
 use crate::{
     AsContextMut, FrameInfo, Global, HeapType, Instance, Memory, Module, StoreContextMut, Val,
@@ -49,27 +48,8 @@ impl WasmCoreDump {
         let store_memories: Vec<Memory> =
             store.all_memories().filter_map(|m| m.unshared()).collect();
 
-        let mut store_globals = Vec::new();
-        let mut seen_globals = HashSet::new();
-        store.for_each_global(|store, global| {
-            seen_globals.insert(global.hash_key(store));
-            store_globals.push(global);
-        });
-
-        // Component adapters can import synthetic globals that aren't defined
-        // by a core instance and therefore aren't visited above. Include every
-        // global visible to an instance so serialization can reference it.
-        for instance in &instances {
-            let globals = instance
-                .all_globals(store)
-                .map(|(_, global)| global)
-                .collect::<Vec<_>>();
-            for global in globals {
-                if seen_globals.insert(global.hash_key(store)) {
-                    store_globals.push(global);
-                }
-            }
-        }
+        let mut store_globals: Vec<Global> = vec![];
+        store.for_each_global(|_store, global| store_globals.push(global));
 
         WasmCoreDump {
             name: String::from("store_name"),
@@ -304,7 +284,12 @@ impl WasmCoreDump {
                     .all_globals(store.0)
                     .collect::<Vec<_>>()
                     .into_iter()
-                    .map(|(_i, global)| global_to_idx[&global.hash_key(&store.0)])
+                    .map(|(_i, global)| {
+                        global_to_idx
+                            .get(&global.hash_key(&store.0))
+                            .copied()
+                            .unwrap_or(u32::MAX)
+                    })
                     .collect::<Vec<_>>();
 
                 instances.instance(module_index, memories, globals);

--- a/crates/wasmtime/src/runtime/coredump.rs
+++ b/crates/wasmtime/src/runtime/coredump.rs
@@ -1,4 +1,5 @@
 use crate::hash_map::HashMap;
+use crate::hash_set::HashSet;
 use crate::prelude::*;
 use crate::{
     AsContextMut, FrameInfo, Global, HeapType, Instance, Memory, Module, StoreContextMut, Val,
@@ -48,8 +49,27 @@ impl WasmCoreDump {
         let store_memories: Vec<Memory> =
             store.all_memories().filter_map(|m| m.unshared()).collect();
 
-        let mut store_globals: Vec<Global> = vec![];
-        store.for_each_global(|_store, global| store_globals.push(global));
+        let mut store_globals = Vec::new();
+        let mut seen_globals = HashSet::new();
+        store.for_each_global(|store, global| {
+            seen_globals.insert(global.hash_key(store));
+            store_globals.push(global);
+        });
+
+        // Component adapters can import synthetic globals that aren't defined
+        // by a core instance and therefore aren't visited above. Include every
+        // global visible to an instance so serialization can reference it.
+        for instance in &instances {
+            let globals = instance
+                .all_globals(store)
+                .map(|(_, global)| global)
+                .collect::<Vec<_>>();
+            for global in globals {
+                if seen_globals.insert(global.hash_key(store)) {
+                    store_globals.push(global);
+                }
+            }
+        }
 
         WasmCoreDump {
             name: String::from("store_name"),

--- a/crates/wasmtime/src/runtime/coredump.rs
+++ b/crates/wasmtime/src/runtime/coredump.rs
@@ -269,6 +269,11 @@ impl WasmCoreDump {
 
                 let module_index = module_to_index[&module.id()];
 
+                // Core dumps are best-effort and may not capture every memory
+                // referenced by an instance. In particular, shared memories
+                // are intentionally omitted because their data cannot be
+                // safely read through `Memory`. Use an invalid index for any
+                // absent memory instead of panicking while serializing.
                 let memories = instance
                     .all_memories(store.0)
                     .filter_map(|(_, m)| m.unshared())
@@ -280,6 +285,12 @@ impl WasmCoreDump {
                     })
                     .collect::<Vec<_>>();
 
+                // Component adapter modules can import runtime-managed globals,
+                // such as component instance flags, whose definitions are not
+                // enumerated by `StoreOpaque::for_each_global`. These globals
+                // are visible through `Instance::all_globals` but absent from
+                // the dump's globals section, so use an invalid index rather
+                // than panicking while serializing.
                 let globals = instance
                     .all_globals(store.0)
                     .collect::<Vec<_>>()

--- a/tests/all/coredump.rs
+++ b/tests/all/coredump.rs
@@ -293,3 +293,52 @@ fn core_dump_with_shared_memory() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn coredump_with_composed_component_adapters() -> Result<()> {
+    use wasmtime::component::{Component, Linker};
+
+    let mut config = Config::new();
+    config.coredump_on_trap(true);
+    let engine = Engine::new(&config)?;
+    let component = Component::new(
+        &engine,
+        r#"
+            (component
+              (component $A
+                (core module $m
+                  (func (export "f") (param i32) (result i32) unreachable)
+                )
+                (core instance $i (instantiate $m))
+                (func (export "f") (param "x" u32) (result u32)
+                  (canon lift (core func $i "f")))
+              )
+              (component $B
+                (import "f" (func $f (param "x" u32) (result u32)))
+                (core func $fl (canon lower (func $f)))
+                (core module $m
+                  (import "" "f" (func $f (param i32) (result i32)))
+                  (func (export "run") (call $f (i32.const 1)) drop)
+                )
+                (core instance $i (instantiate $m
+                  (with "" (instance (export "f" (func $fl))))))
+                (func (export "run") (canon lift (core func $i "run")))
+              )
+              (instance $a (instantiate $A))
+              (instance $b (instantiate $B (with "f" (func $a "f"))))
+              (func (export "run") (alias export $b "run"))
+            )
+        "#,
+    )?;
+    let mut store = Store::new(&engine, ());
+    let instance = Linker::new(&engine).instantiate(&mut store, &component)?;
+    let run = instance.get_typed_func::<(), ()>(&mut store, "run")?;
+
+    let err = run.call(&mut store, ()).unwrap_err();
+    let coredump = err.downcast_ref::<WasmCoreDump>().unwrap();
+    let bytes = coredump.serialize(&mut store, "composed-component-adapters");
+    wasmparser::Validator::new().validate_all(&bytes)?;
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes #13983.

  Core dumps from composed components can reference runtime-managed adapter
  globals that are absent from the dump's global section, causing serialization
  to panic.

  Treat globals missing from the serialized section as unavailable by using
  `u32::MAX`, matching the existing best-effort handling for missing memories.
  Document why coredumps can omit both memories and globals, and add a regression
  test that serializes and validates a dump from the reported composed-component
  case.

  Tests:
  - `cargo test --test all coredump::`