### PR TITLE
Print fixed-length lists with WAVE

### DIFF
--- a/crates/wasmtime/src/runtime/wave/component.rs
+++ b/crates/wasmtime/src/runtime/wave/component.rs
@@ -261,7 +261,10 @@ impl WasmValue for component::Val {
         unwrap_val!(self, Self::String, "string").into()
     }
     fn unwrap_list(&self) -> Box<dyn Iterator<Item = Cow<'_, Self>> + '_> {
-        let list = unwrap_val!(self, Self::List, "list");
+        let list = match self {
+            Self::List(list) | Self::FixedLengthList(list) => list,
+            _ => panic!("called unwrap_list on non-list value"),
+        };
         Box::new(list.iter().map(cow))
     }
     fn unwrap_record(&self) -> Box<dyn Iterator<Item = (Cow<'_, str>, Cow<'_, Self>)> + '_> {

--- a/tests/all/component_model/fixed_length_list.rs
+++ b/tests/all/component_model/fixed_length_list.rs
@@ -298,3 +298,30 @@ fn fixed_length_list_length_mismatch_rejected() -> Result<()> {
     assert_eq!(out, 0x1234_5678);
     Ok(())
 }
+
+#[test]
+fn fixed_length_list_wave() -> Result<()> {
+    let wat = r#"
+(component
+  (core module $m
+    (func (export "f") (result i32) (i32.const 7))
+  )
+  (core instance $i (instantiate $m))
+  (func (export "f") (result (list u32 1)) (canon lift (core func $i "f")))
+)
+"#;
+
+    let mut config = Config::new();
+    config.wasm_component_model_fixed_length_lists(true);
+    let engine = Engine::new(&config)?;
+    let component = Component::new(&engine, wat)?;
+    let mut store = Store::new(&engine, ());
+    let instance = Linker::new(&engine).instantiate(&mut store, &component)?;
+    let func = instance.get_func(&mut store, "f").unwrap();
+    let mut results = [Val::Bool(false)];
+
+    func.call(&mut store, &[], &mut results)?;
+    assert_eq!(results[0].to_wave()?, "[7]");
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes #13984.

  `wasm-wave` treats fixed-length lists as list-like values when formatting, but Wasmtime's `WasmValue::unwrap_list` only accepted `Val::List`. This caused the CLI to panic while printing a fixed-length-list result.

  Allow the list unwrapper to iterate over `Val::FixedLengthList` and add a regression using the reported component that verifies the `[7]` output.

  Tests:
  - `cargo test --test all component_model::fixed_length_list::`
  - `cargo test --test all`