### PR TITLE
riscv64: Implement f16 conversion instructions

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -445,8 +445,12 @@
   (FcvtFmtLu) ;; fcvt.{fmt}.lu
   (FmvXFmt) ;; fmv.x.{fmt}
   (FmvFmtX) ;; fmv.{fmt}.x
+  (FcvtSH) ;; fcvt.s.h
+  (FcvtHS) ;; fcvt.h.s
   (FcvtSD) ;; fcvt.s.d
   (FcvtDS) ;; fcvt.d.s
+  (FcvtDH) ;; fcvt.d.h
+  (FcvtHD) ;; fcvt.h.d
 
   ;; Zfa Extension
   (Fround) ;; fround.{fmt}
@@ -1422,13 +1426,29 @@
 (decl rv_fmvdx (XReg) FReg)
 (rule (rv_fmvdx r) (fpu_rr (FpuOPRR.FmvFmtX) $F64 (FRM.RNE) r))
 
-;; Helper for emitting the `fcvt.d.s` ("Float Convert Double to Single") instruction.
+;; Helper for emitting the `fcvt.s.h` ("Float Convert Half to Single") instruction.
+(decl rv_fcvtsh (FReg) FReg)
+(rule (rv_fcvtsh rs1) (fpu_rr (FpuOPRR.FcvtSH) $F32 (FRM.RNE) rs1))
+
+;; Helper for emitting the `fcvt.h.s` ("Float Convert Single to Half") instruction.
+(decl rv_fcvths (FRM FReg) FReg)
+(rule (rv_fcvths frm rs1) (fpu_rr (FpuOPRR.FcvtHS) $F16 frm rs1))
+
+;; Helper for emitting the `fcvt.d.s` ("Float Convert Single to Double") instruction.
 (decl rv_fcvtds (FReg) FReg)
 (rule (rv_fcvtds rs1) (fpu_rr (FpuOPRR.FcvtDS) $F64 (FRM.RNE) rs1))
 
-;; Helper for emitting the `fcvt.s.d` ("Float Convert Single to Double") instruction.
+;; Helper for emitting the `fcvt.s.d` ("Float Convert Double to Single") instruction.
 (decl rv_fcvtsd (FRM FReg) FReg)
 (rule (rv_fcvtsd frm rs1) (fpu_rr (FpuOPRR.FcvtSD) $F32 frm rs1))
+
+;; Helper for emitting the `fcvt.d.h` ("Float Convert Half to Double") instruction.
+(decl rv_fcvtdh (FReg) FReg)
+(rule (rv_fcvtdh rs1) (fpu_rr (FpuOPRR.FcvtDH) $F64 (FRM.RNE) rs1))
+
+;; Helper for emitting the `fcvt.h.d` ("Float Convert Double to Half") instruction.
+(decl rv_fcvthd (FRM FReg) FReg)
+(rule (rv_fcvthd frm rs1) (fpu_rr (FpuOPRR.FcvtHD) $F16 frm rs1))
 
 ;; Helper for emitting the `fcvt.s.w` instruction.
 (decl rv_fcvtsw (FRM XReg) FReg)

--- a/cranelift/codegen/src/isa/riscv64/inst/args.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/args.rs
@@ -501,8 +501,12 @@ impl FpuOPRR {
             Self::FmvXFmt => format!("fmv.x.{fmv_width}"),
             Self::FmvFmtX => format!("fmv.{fmv_width}.x"),
 
+            Self::FcvtSH => "fcvt.s.h".to_string(),
+            Self::FcvtHS => "fcvt.h.s".to_string(),
             Self::FcvtSD => "fcvt.s.d".to_string(),
             Self::FcvtDS => "fcvt.d.s".to_string(),
+            Self::FcvtDH => "fcvt.d.h".to_string(),
+            Self::FcvtHD => "fcvt.h.d".to_string(),
         }
     }
 
@@ -540,8 +544,12 @@ impl FpuOPRR {
             Self::FcvtFmtLu => 0b00011,
             Self::FmvXFmt => 0b00000,
             Self::FmvFmtX => 0b00000,
+            Self::FcvtSH => 0b00010,
+            Self::FcvtHS => 0b00000,
             Self::FcvtSD => 0b00001,
             Self::FcvtDS => 0b00000,
+            Self::FcvtDH => 0b00010,
+            Self::FcvtHD => 0b00001,
         }
     }
 
@@ -560,8 +568,12 @@ impl FpuOPRR {
             Self::FcvtFmtLu => 0b11010,
             Self::FmvXFmt => 0b11100,
             Self::FmvFmtX => 0b11110,
-            Self::FcvtSD => 0b01000,
-            Self::FcvtDS => 0b01000,
+            Self::FcvtSH
+            | Self::FcvtHS
+            | Self::FcvtSD
+            | Self::FcvtDS
+            | Self::FcvtDH
+            | Self::FcvtHD => 0b01000,
         }
     }
 

--- a/cranelift/codegen/src/isa/riscv64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit_tests.rs
@@ -1646,6 +1646,28 @@ fn test_riscv64_binemit() {
 
     insns.push(TestUnit::new(
         Inst::FpuRR {
+            frm: FRM::RNE,
+            width: FpuOPWidth::S,
+            alu_op: FpuOPRR::FcvtSH,
+            rd: writable_fa0(),
+            rs: fa0(),
+        },
+        "fcvt.s.h fa0,fa0,rne",
+        0x40250553,
+    ));
+    insns.push(TestUnit::new(
+        Inst::FpuRR {
+            frm: FRM::RNE,
+            width: FpuOPWidth::H,
+            alu_op: FpuOPRR::FcvtHS,
+            rd: writable_fa0(),
+            rs: fa0(),
+        },
+        "fcvt.h.s fa0,fa0,rne",
+        0x44050553,
+    ));
+    insns.push(TestUnit::new(
+        Inst::FpuRR {
             frm: FRM::Fcsr,
             width: FpuOPWidth::S,
             alu_op: FpuOPRR::FcvtSD,
@@ -1654,6 +1676,39 @@ fn test_riscv64_binemit() {
         },
         "fcvt.s.d fa0,fa0,fcsr",
         0x40157553,
+    ));
+    insns.push(TestUnit::new(
+        Inst::FpuRR {
+            frm: FRM::RNE,
+            width: FpuOPWidth::D,
+            alu_op: FpuOPRR::FcvtDS,
+            rd: writable_fa0(),
+            rs: fa0(),
+        },
+        "fcvt.d.s fa0,fa0,rne",
+        0x42050553,
+    ));
+    insns.push(TestUnit::new(
+        Inst::FpuRR {
+            frm: FRM::RNE,
+            width: FpuOPWidth::D,
+            alu_op: FpuOPRR::FcvtDH,
+            rd: writable_fa0(),
+            rs: fa0(),
+        },
+        "fcvt.d.h fa0,fa0,rne",
+        0x42250553,
+    ));
+    insns.push(TestUnit::new(
+        Inst::FpuRR {
+            frm: FRM::RNE,
+            width: FpuOPWidth::H,
+            alu_op: FpuOPRR::FcvtHD,
+            rd: writable_fa0(),
+            rs: fa0(),
+        },
+        "fcvt.h.d fa0,fa0,rne",
+        0x44150553,
     ));
     insns.push(TestUnit::new(
         Inst::FpuRR {

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -1805,7 +1805,16 @@
   (value_regs_get x 0))
 
 ;;;;;  Rules for `fpromote`;;;;;;;;;;;;;;;;;
-(rule (lower (fpromote _ x))
+(rule (lower (fpromote (ty_supported_float_min $F32)
+                       x @ (value_type (ty_supported_float_min $F16))))
+  (rv_fcvtsh x))
+
+(rule (lower (fpromote (ty_supported_float_min $F64)
+                       x @ (value_type (ty_supported_float_min $F16))))
+  (rv_fcvtdh x))
+
+(rule (lower (fpromote (ty_supported_float_min $F64)
+                       x @ (value_type (ty_supported_float_min $F32))))
   (rv_fcvtds x))
 
 ;;;;;  Rules for `fvpromote_low`;;;;;;;;;;;;
@@ -1815,7 +1824,16 @@
   (rv_vfwcvt_f_f_v x (unmasked) (vstate_mf2 half_ty)))
 
 ;;;;;  Rules for `fdemote`;;;;;;;;;;;;;;;;;;
-(rule (lower (fdemote _ x))
+(rule (lower (fdemote (ty_supported_float_min $F16)
+                      x @ (value_type (ty_supported_float_min $F32))))
+  (rv_fcvths (FRM.RNE) x))
+
+(rule (lower (fdemote (ty_supported_float_min $F16)
+                      x @ (value_type (ty_supported_float_min $F64))))
+  (rv_fcvthd (FRM.RNE) x))
+
+(rule (lower (fdemote (ty_supported_float_min $F32)
+                      x @ (value_type (ty_supported_float_min $F64))))
   (rv_fcvtsd (FRM.RNE) x))
 
 ;;;;;  Rules for `fvdemote`;;;;;;;;;;;;;;;;;

--- a/cranelift/filetests/filetests/isa/riscv64/f16-conversions.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/f16-conversions.clif
@@ -1,0 +1,99 @@
+test compile precise-output
+set unwind_info=false
+target riscv64 has_zfhmin
+
+function %fpromote_f16_f32(f16) -> f32 {
+block0(v0: f16):
+  v1 = fpromote.f32 v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   fcvt.s.h fa0,fa0,rne
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0x53, 0x05, 0x25, 0x40
+;   ret
+
+function %fdemote_f32_f16(f32) -> f16 {
+block0(v0: f32):
+  v1 = fdemote.f16 v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   fcvt.h.s fa0,fa0,rne
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0x53, 0x05, 0x05, 0x44
+;   ret
+
+function %fpromote_f16_f64(f16) -> f64 {
+block0(v0: f16):
+  v1 = fpromote.f64 v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   fcvt.d.h fa0,fa0,rne
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0x53, 0x05, 0x25, 0x42
+;   ret
+
+function %fdemote_f64_f16(f64) -> f16 {
+block0(v0: f64):
+  v1 = fdemote.f16 v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   fcvt.h.d fa0,fa0,rne
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   .byte 0x53, 0x05, 0x15, 0x44
+;   ret
+
+function %fpromote_f32_f64(f32) -> f64 {
+block0(v0: f32):
+  v1 = fpromote.f64 v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   fcvt.d.s fa0,fa0,rne
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   fcvt.d.s fa0, fa0
+;   ret
+
+function %fdemote_f64_f32(f64) -> f32 {
+block0(v0: f64):
+  v1 = fdemote.f32 v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   fcvt.s.d fa0,fa0,rne
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   fcvt.s.d fa0, fa0, rne
+;   ret

--- a/cranelift/filetests/filetests/runtests/f16-conversions.clif
+++ b/cranelift/filetests/filetests/runtests/f16-conversions.clif
@@ -1,0 +1,38 @@
+test run
+target riscv64 has_zfhmin
+
+function %fpromote_f16_f32(f16) -> f32 {
+block0(v0: f16):
+  v1 = fpromote.f32 v0
+  return v1
+}
+
+; run: %fpromote_f16_f32(0x1.554p-2) == 0x1.554p-2
+; run: %fpromote_f16_f32(-0x0.0) == -0x0.0
+
+function %fdemote_f32_f16(f32) -> f16 {
+block0(v0: f32):
+  v1 = fdemote.f16 v0
+  return v1
+}
+
+; run: %fdemote_f32_f16(0x1.003p0) == 0x1.004p0
+; run: %fdemote_f32_f16(-Inf) == -Inf
+
+function %fpromote_f16_f64(f16) -> f64 {
+block0(v0: f16):
+  v1 = fpromote.f64 v0
+  return v1
+}
+
+; run: %fpromote_f16_f64(0x1.554p-2) == 0x1.554p-2
+; run: %fpromote_f16_f64(-0x0.0) == -0x0.0
+
+function %fdemote_f64_f16(f64) -> f16 {
+block0(v0: f64):
+  v1 = fdemote.f16 v0
+  return v1
+}
+
+; run: %fdemote_f64_f16(0x1.003p0) == 0x1.004p0
+; run: %fdemote_f64_f16(-Inf) == -Inf


### PR DESCRIPTION
👋 Hey,

This PR implements f16<->f32,f64 instructions for the riscv64 backend. These instructions are defined in `Zfhmin` a subset of the main f16 extension `Zfh`.

`Zfhmin` is the minimal support for f16 package that implements pretty much just conversion, load and store instructions.