### PR TITLE
winch(x64): Prefer operands in the value stack for atomic operations

### DIFF
--- a/tests/disas/winch/x64/atomic/rmw/and/i32_atomic_rmw16_andu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/and/i32_atomic_rmw16_andu.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x18(%r11), %r11
-;;       addq    $0x14, %r11
+;;       addq    $0x1c, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x8f
+;;       ja      0x91
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,24 +21,26 @@
 ;;       movl    $0, %ecx
 ;;       andl    $1, %ecx
 ;;       cmpl    $0, %ecx
-;;       jne     0x91
+;;       jne     0x93
 ;;   48: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       movl    %ecx, %ecx
 ;;       addq    %rcx, %rdx
+;;       pushq   %rdx
 ;;       subq    $4, %rsp
 ;;       movl    %eax, (%rsp)
 ;;       movl    (%rsp), %ecx
 ;;       addq    $4, %rsp
+;;       popq    %rdx
 ;;       movzwq  (%rdx), %rax
 ;;       movq    %rax, %r11
 ;;       andq    %rcx, %r11
 ;;       lock cmpxchgw %r11w, (%rdx)
-;;       jne     0x71
-;;   83: movzwl  %ax, %eax
+;;       jne     0x73
+;;   85: movzwl  %ax, %eax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   8f: ud2
 ;;   91: ud2
+;;   93: ud2

--- a/tests/disas/winch/x64/atomic/rmw/and/i32_atomic_rmw8_andu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/and/i32_atomic_rmw8_andu.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x18(%r11), %r11
-;;       addq    $0x14, %r11
+;;       addq    $0x1c, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x7a
+;;       ja      0x7c
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -23,17 +23,19 @@
 ;;       movq    (%r11), %rdx
 ;;       movl    %ecx, %ecx
 ;;       addq    %rcx, %rdx
+;;       pushq   %rdx
 ;;       subq    $4, %rsp
 ;;       movl    %eax, (%rsp)
 ;;       movl    (%rsp), %ecx
 ;;       addq    $4, %rsp
+;;       popq    %rdx
 ;;       movzbq  (%rdx), %rax
 ;;       movq    %rax, %r11
 ;;       andq    %rcx, %r11
 ;;       lock cmpxchgb %r11b, (%rdx)
-;;       jne     0x5d
-;;   6e: movzbl  %al, %eax
+;;       jne     0x5f
+;;   70: movzbl  %al, %eax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   7a: ud2
+;;   7c: ud2

--- a/tests/disas/winch/x64/atomic/rmw/and/i32_atomic_rmw_and.wat
+++ b/tests/disas/winch/x64/atomic/rmw/and/i32_atomic_rmw_and.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x18(%r11), %r11
-;;       addq    $0x14, %r11
+;;       addq    $0x1c, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x89
+;;       ja      0x8b
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,23 +21,25 @@
 ;;       movl    $0, %ecx
 ;;       andl    $3, %ecx
 ;;       cmpl    $0, %ecx
-;;       jne     0x8b
+;;       jne     0x8d
 ;;   48: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       movl    %ecx, %ecx
 ;;       addq    %rcx, %rdx
+;;       pushq   %rdx
 ;;       subq    $4, %rsp
 ;;       movl    %eax, (%rsp)
 ;;       movl    (%rsp), %ecx
 ;;       addq    $4, %rsp
+;;       popq    %rdx
 ;;       movl    (%rdx), %eax
 ;;       movq    %rax, %r11
 ;;       andq    %rcx, %r11
 ;;       lock cmpxchgl %r11d, (%rdx)
-;;       jne     0x6f
-;;   80: addq    $0x10, %rsp
+;;       jne     0x71
+;;   82: addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   89: ud2
 ;;   8b: ud2
+;;   8d: ud2

--- a/tests/disas/winch/x64/atomic/rmw/and/i64_atomic_rmw16_andu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/and/i64_atomic_rmw16_andu.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x18(%r11), %r11
-;;       addq    $0x18, %r11
+;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x7e
+;;       ja      0x80
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,22 +21,24 @@
 ;;       movl    $0, %ecx
 ;;       andl    $1, %ecx
 ;;       cmpl    $0, %ecx
-;;       jne     0x80
+;;       jne     0x82
 ;;   48: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       movl    %ecx, %ecx
 ;;       addq    %rcx, %rdx
+;;       pushq   %rdx
 ;;       pushq   %rax
 ;;       popq    %rcx
+;;       popq    %rdx
 ;;       movzwq  (%rdx), %rax
 ;;       movq    %rax, %r11
 ;;       andq    %rcx, %r11
 ;;       lock cmpxchgw %r11w, (%rdx)
-;;       jne     0x5f
-;;   71: movzwq  %ax, %rax
+;;       jne     0x61
+;;   73: movzwq  %ax, %rax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   7e: ud2
 ;;   80: ud2
+;;   82: ud2

--- a/tests/disas/winch/x64/atomic/rmw/and/i64_atomic_rmw32_andu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/and/i64_atomic_rmw32_andu.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x18(%r11), %r11
-;;       addq    $0x18, %r11
+;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x77
+;;       ja      0x79
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,21 +21,23 @@
 ;;       movl    $0, %ecx
 ;;       andl    $3, %ecx
 ;;       cmpl    $0, %ecx
-;;       jne     0x79
+;;       jne     0x7b
 ;;   48: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       movl    %ecx, %ecx
 ;;       addq    %rcx, %rdx
+;;       pushq   %rdx
 ;;       pushq   %rax
 ;;       popq    %rcx
+;;       popq    %rdx
 ;;       movl    (%rdx), %eax
 ;;       movq    %rax, %r11
 ;;       andq    %rcx, %r11
 ;;       lock cmpxchgl %r11d, (%rdx)
-;;       jne     0x5d
-;;   6e: addq    $0x10, %rsp
+;;       jne     0x5f
+;;   70: addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   77: ud2
 ;;   79: ud2
+;;   7b: ud2

--- a/tests/disas/winch/x64/atomic/rmw/and/i64_atomic_rmw8_andu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/and/i64_atomic_rmw8_andu.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x18(%r11), %r11
-;;       addq    $0x18, %r11
+;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x69
+;;       ja      0x6b
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -23,15 +23,17 @@
 ;;       movq    (%r11), %rdx
 ;;       movl    %ecx, %ecx
 ;;       addq    %rcx, %rdx
+;;       pushq   %rdx
 ;;       pushq   %rax
 ;;       popq    %rcx
+;;       popq    %rdx
 ;;       movzbq  (%rdx), %rax
 ;;       movq    %rax, %r11
 ;;       andq    %rcx, %r11
 ;;       lock cmpxchgb %r11b, (%rdx)
-;;       jne     0x4b
-;;   5c: movzbq  %al, %rax
+;;       jne     0x4d
+;;   5e: movzbq  %al, %rax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   69: ud2
+;;   6b: ud2

--- a/tests/disas/winch/x64/atomic/rmw/and/i64_atomic_rmw_and.wat
+++ b/tests/disas/winch/x64/atomic/rmw/and/i64_atomic_rmw_and.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x18(%r11), %r11
-;;       addq    $0x18, %r11
+;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x78
+;;       ja      0x7a
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,21 +21,23 @@
 ;;       movl    $0, %ecx
 ;;       andl    $7, %ecx
 ;;       cmpl    $0, %ecx
-;;       jne     0x7a
+;;       jne     0x7c
 ;;   48: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       movl    %ecx, %ecx
 ;;       addq    %rcx, %rdx
+;;       pushq   %rdx
 ;;       pushq   %rax
 ;;       popq    %rcx
+;;       popq    %rdx
 ;;       movq    (%rdx), %rax
 ;;       movq    %rax, %r11
 ;;       andq    %rcx, %r11
 ;;       lock cmpxchgq %r11, (%rdx)
-;;       jne     0x5e
-;;   6f: addq    $0x10, %rsp
+;;       jne     0x60
+;;   71: addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   78: ud2
 ;;   7a: ud2
+;;   7c: ud2

--- a/tests/disas/winch/x64/atomic/rmw/cmpxchg/i32_atomic_rmw16_cmpxchgu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/cmpxchg/i32_atomic_rmw16_cmpxchgu.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x18(%r11), %r11
-;;       addq    $0x18, %r11
+;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x97
+;;       ja      0x99
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -22,12 +22,13 @@
 ;;       movl    $0, %edx
 ;;       andl    $1, %edx
 ;;       cmpl    $0, %edx
-;;       jne     0x99
+;;       jne     0x9b
 ;;   4d: movl    $0, %edx
 ;;       movq    0x30(%r14), %r11
 ;;       movq    (%r11), %rbx
 ;;       movl    %edx, %edx
 ;;       addq    %rdx, %rbx
+;;       pushq   %rbx
 ;;       subq    $4, %rsp
 ;;       movl    %ecx, (%rsp)
 ;;       subq    $4, %rsp
@@ -36,10 +37,11 @@
 ;;       addq    $4, %rsp
 ;;       movl    (%rsp), %eax
 ;;       addq    $4, %rsp
-;;       lock cmpxchgw %cx, (%rbx)
+;;       popq    %rdx
+;;       lock cmpxchgw %cx, (%rdx)
 ;;       movzwl  %ax, %eax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   97: ud2
 ;;   99: ud2
+;;   9b: ud2

--- a/tests/disas/winch/x64/atomic/rmw/cmpxchg/i32_atomic_rmw8_cmpxchgu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/cmpxchg/i32_atomic_rmw8_cmpxchgu.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x18(%r11), %r11
-;;       addq    $0x18, %r11
+;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x82
+;;       ja      0x84
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -24,6 +24,7 @@
 ;;       movq    (%r11), %rbx
 ;;       movl    %edx, %edx
 ;;       addq    %rdx, %rbx
+;;       pushq   %rbx
 ;;       subq    $4, %rsp
 ;;       movl    %ecx, (%rsp)
 ;;       subq    $4, %rsp
@@ -32,9 +33,10 @@
 ;;       addq    $4, %rsp
 ;;       movl    (%rsp), %eax
 ;;       addq    $4, %rsp
-;;       lock cmpxchgb %cl, (%rbx)
+;;       popq    %rdx
+;;       lock cmpxchgb %cl, (%rdx)
 ;;       movzbl  %al, %eax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   82: ud2
+;;   84: ud2

--- a/tests/disas/winch/x64/atomic/rmw/cmpxchg/i32_atomic_rmw_cmpxchg.wat
+++ b/tests/disas/winch/x64/atomic/rmw/cmpxchg/i32_atomic_rmw_cmpxchg.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x18(%r11), %r11
-;;       addq    $0x18, %r11
+;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x93
+;;       ja      0x95
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -22,12 +22,13 @@
 ;;       movl    $0, %edx
 ;;       andl    $3, %edx
 ;;       cmpl    $0, %edx
-;;       jne     0x95
+;;       jne     0x97
 ;;   4d: movl    $0, %edx
 ;;       movq    0x30(%r14), %r11
 ;;       movq    (%r11), %rbx
 ;;       movl    %edx, %edx
 ;;       addq    %rdx, %rbx
+;;       pushq   %rbx
 ;;       subq    $4, %rsp
 ;;       movl    %ecx, (%rsp)
 ;;       subq    $4, %rsp
@@ -36,9 +37,10 @@
 ;;       addq    $4, %rsp
 ;;       movl    (%rsp), %eax
 ;;       addq    $4, %rsp
-;;       lock cmpxchgl %ecx, (%rbx)
+;;       popq    %rdx
+;;       lock cmpxchgl %ecx, (%rdx)
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   93: ud2
 ;;   95: ud2
+;;   97: ud2

--- a/tests/disas/winch/x64/atomic/rmw/cmpxchg/i32_atomic_rmw_cmpxchg_computed_address.wat
+++ b/tests/disas/winch/x64/atomic/rmw/cmpxchg/i32_atomic_rmw_cmpxchg_computed_address.wat
@@ -1,0 +1,55 @@
+;;! target = "x86_64"
+;;! test = "winch"
+
+(module
+  (memory 1)
+  (func (export "_start") (param i32) (result i32)
+    (i32.atomic.rmw.cmpxchg
+      (i32.add (i32.const 1) (local.get 0))
+      (i32.xor (i32.const 1) (local.get 0))
+      (i32.xor (i32.const 2) (local.get 0)))))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x18(%r11), %r11
+;;       addq    $0x30, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0xa5
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x20, %rsp
+;;       movq    %rdi, 0x18(%rsp)
+;;       movq    %rsi, 0x10(%rsp)
+;;       movl    %edx, 0xc(%rsp)
+;;       movl    0xc(%rsp), %eax
+;;       movl    $1, %ecx
+;;       addl    %eax, %ecx
+;;       movl    0xc(%rsp), %eax
+;;       movl    $1, %edx
+;;       xorl    %eax, %edx
+;;       movl    0xc(%rsp), %eax
+;;       movl    $2, %ebx
+;;       xorl    %eax, %ebx
+;;       movl    %ecx, %eax
+;;       andl    $3, %eax
+;;       cmpl    $0, %eax
+;;       jne     0xa7
+;;   65: movq    0x38(%r14), %rax
+;;       movl    %ecx, %ecx
+;;       addq    %rcx, %rax
+;;       pushq   %rax
+;;       subq    $4, %rsp
+;;       movl    %edx, (%rsp)
+;;       subq    $4, %rsp
+;;       movl    %ebx, (%rsp)
+;;       movl    (%rsp), %ecx
+;;       addq    $4, %rsp
+;;       movl    (%rsp), %eax
+;;       addq    $4, %rsp
+;;       popq    %rdx
+;;       lock cmpxchgl %ecx, (%rdx)
+;;       addq    $0x20, %rsp
+;;       popq    %rbp
+;;       retq
+;;   a5: ud2
+;;   a7: ud2

--- a/tests/disas/winch/x64/atomic/rmw/cmpxchg/i64_atomic_rmw16_cmpxchgu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/cmpxchg/i64_atomic_rmw16_cmpxchgu.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x18(%r11), %r11
-;;       addq    $0x20, %r11
+;;       addq    $0x28, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x74
+;;       ja      0x76
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -22,20 +22,22 @@
 ;;       movl    $0, %edx
 ;;       andl    $1, %edx
 ;;       cmpl    $0, %edx
-;;       jne     0x76
+;;       jne     0x78
 ;;   4d: movl    $0, %edx
 ;;       movq    0x30(%r14), %r11
 ;;       movq    (%r11), %rbx
 ;;       movl    %edx, %edx
 ;;       addq    %rdx, %rbx
+;;       pushq   %rbx
 ;;       pushq   %rcx
 ;;       pushq   %rax
 ;;       popq    %rcx
 ;;       popq    %rax
-;;       lock cmpxchgw %cx, (%rbx)
+;;       popq    %rdx
+;;       lock cmpxchgw %cx, (%rdx)
 ;;       movzwq  %ax, %rax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   74: ud2
 ;;   76: ud2
+;;   78: ud2

--- a/tests/disas/winch/x64/atomic/rmw/cmpxchg/i64_atomic_rmw32_cmpxchgu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/cmpxchg/i64_atomic_rmw32_cmpxchgu.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x18(%r11), %r11
-;;       addq    $0x20, %r11
+;;       addq    $0x28, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x71
+;;       ja      0x73
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -22,20 +22,22 @@
 ;;       movl    $0, %edx
 ;;       andl    $3, %edx
 ;;       cmpl    $0, %edx
-;;       jne     0x73
+;;       jne     0x75
 ;;   4d: movl    $0, %edx
 ;;       movq    0x30(%r14), %r11
 ;;       movq    (%r11), %rbx
 ;;       movl    %edx, %edx
 ;;       addq    %rdx, %rbx
+;;       pushq   %rbx
 ;;       pushq   %rcx
 ;;       pushq   %rax
 ;;       popq    %rcx
 ;;       popq    %rax
-;;       lock cmpxchgl %ecx, (%rbx)
+;;       popq    %rdx
+;;       lock cmpxchgl %ecx, (%rdx)
 ;;       movl    %eax, %eax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   71: ud2
 ;;   73: ud2
+;;   75: ud2

--- a/tests/disas/winch/x64/atomic/rmw/cmpxchg/i64_atomic_rmw32_cmpxchgu_extend.wat
+++ b/tests/disas/winch/x64/atomic/rmw/cmpxchg/i64_atomic_rmw32_cmpxchgu_extend.wat
@@ -13,9 +13,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x18(%r11), %r11
-;;       addq    $0x20, %r11
+;;       addq    $0x28, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x76
+;;       ja      0x78
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -25,20 +25,22 @@
 ;;       movl    $0, %edx
 ;;       andl    $3, %edx
 ;;       cmpl    $0, %edx
-;;       jne     0x78
+;;       jne     0x7a
 ;;   52: movl    $0, %edx
 ;;       movq    0x30(%r14), %r11
 ;;       movq    (%r11), %rbx
 ;;       movl    %edx, %edx
 ;;       addq    %rdx, %rbx
+;;       pushq   %rbx
 ;;       pushq   %rcx
 ;;       pushq   %rax
 ;;       popq    %rcx
 ;;       popq    %rax
-;;       lock cmpxchgl %ecx, (%rbx)
+;;       popq    %rdx
+;;       lock cmpxchgl %ecx, (%rdx)
 ;;       movl    %eax, %eax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   76: ud2
 ;;   78: ud2
+;;   7a: ud2

--- a/tests/disas/winch/x64/atomic/rmw/cmpxchg/i64_atomic_rmw8_cmpxchgu.wat
+++ b/tests/disas/winch/x64/atomic/rmw/cmpxchg/i64_atomic_rmw8_cmpxchgu.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x18(%r11), %r11
-;;       addq    $0x20, %r11
+;;       addq    $0x28, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x5f
+;;       ja      0x61
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -24,13 +24,15 @@
 ;;       movq    (%r11), %rbx
 ;;       movl    %edx, %edx
 ;;       addq    %rdx, %rbx
+;;       pushq   %rbx
 ;;       pushq   %rcx
 ;;       pushq   %rax
 ;;       popq    %rcx
 ;;       popq    %rax
-;;       lock cmpxchgb %cl, (%rbx)
+;;       popq    %rdx
+;;       lock cmpxchgb %cl, (%rdx)
 ;;       movzbq  %al, %rax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   5f: ud2
+;;   61: ud2

--- a/tests/disas/winch/x64/atomic/rmw/cmpxchg/i64_atomic_rmw_cmpxchg.wat
+++ b/tests/disas/winch/x64/atomic/rmw/cmpxchg/i64_atomic_rmw_cmpxchg.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x18(%r11), %r11
-;;       addq    $0x20, %r11
+;;       addq    $0x28, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x70
+;;       ja      0x72
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -22,19 +22,21 @@
 ;;       movl    $0, %edx
 ;;       andl    $7, %edx
 ;;       cmpl    $0, %edx
-;;       jne     0x72
+;;       jne     0x74
 ;;   4d: movl    $0, %edx
 ;;       movq    0x30(%r14), %r11
 ;;       movq    (%r11), %rbx
 ;;       movl    %edx, %edx
 ;;       addq    %rdx, %rbx
+;;       pushq   %rbx
 ;;       pushq   %rcx
 ;;       pushq   %rax
 ;;       popq    %rcx
 ;;       popq    %rax
-;;       lock cmpxchgq %rcx, (%rbx)
+;;       popq    %rdx
+;;       lock cmpxchgq %rcx, (%rdx)
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   70: ud2
 ;;   72: ud2
+;;   74: ud2

--- a/tests/disas/winch/x64/atomic/rmw/or/i32_atomic_rmw16_oru.wat
+++ b/tests/disas/winch/x64/atomic/rmw/or/i32_atomic_rmw16_oru.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x18(%r11), %r11
-;;       addq    $0x14, %r11
+;;       addq    $0x1c, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x8f
+;;       ja      0x91
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,24 +21,26 @@
 ;;       movl    $0, %ecx
 ;;       andl    $1, %ecx
 ;;       cmpl    $0, %ecx
-;;       jne     0x91
+;;       jne     0x93
 ;;   48: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       movl    %ecx, %ecx
 ;;       addq    %rcx, %rdx
+;;       pushq   %rdx
 ;;       subq    $4, %rsp
 ;;       movl    %eax, (%rsp)
 ;;       movl    (%rsp), %ecx
 ;;       addq    $4, %rsp
+;;       popq    %rdx
 ;;       movzwq  (%rdx), %rax
 ;;       movq    %rax, %r11
 ;;       orq     %rcx, %r11
 ;;       lock cmpxchgw %r11w, (%rdx)
-;;       jne     0x71
-;;   83: movzwl  %ax, %eax
+;;       jne     0x73
+;;   85: movzwl  %ax, %eax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   8f: ud2
 ;;   91: ud2
+;;   93: ud2

--- a/tests/disas/winch/x64/atomic/rmw/or/i32_atomic_rmw8_oru.wat
+++ b/tests/disas/winch/x64/atomic/rmw/or/i32_atomic_rmw8_oru.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x18(%r11), %r11
-;;       addq    $0x14, %r11
+;;       addq    $0x1c, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x7a
+;;       ja      0x7c
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -23,17 +23,19 @@
 ;;       movq    (%r11), %rdx
 ;;       movl    %ecx, %ecx
 ;;       addq    %rcx, %rdx
+;;       pushq   %rdx
 ;;       subq    $4, %rsp
 ;;       movl    %eax, (%rsp)
 ;;       movl    (%rsp), %ecx
 ;;       addq    $4, %rsp
+;;       popq    %rdx
 ;;       movzbq  (%rdx), %rax
 ;;       movq    %rax, %r11
 ;;       orq     %rcx, %r11
 ;;       lock cmpxchgb %r11b, (%rdx)
-;;       jne     0x5d
-;;   6e: movzbl  %al, %eax
+;;       jne     0x5f
+;;   70: movzbl  %al, %eax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   7a: ud2
+;;   7c: ud2

--- a/tests/disas/winch/x64/atomic/rmw/or/i32_atomic_rmw_or.wat
+++ b/tests/disas/winch/x64/atomic/rmw/or/i32_atomic_rmw_or.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x18(%r11), %r11
-;;       addq    $0x14, %r11
+;;       addq    $0x1c, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x89
+;;       ja      0x8b
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,23 +21,25 @@
 ;;       movl    $0, %ecx
 ;;       andl    $3, %ecx
 ;;       cmpl    $0, %ecx
-;;       jne     0x8b
+;;       jne     0x8d
 ;;   48: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       movl    %ecx, %ecx
 ;;       addq    %rcx, %rdx
+;;       pushq   %rdx
 ;;       subq    $4, %rsp
 ;;       movl    %eax, (%rsp)
 ;;       movl    (%rsp), %ecx
 ;;       addq    $4, %rsp
+;;       popq    %rdx
 ;;       movl    (%rdx), %eax
 ;;       movq    %rax, %r11
 ;;       orq     %rcx, %r11
 ;;       lock cmpxchgl %r11d, (%rdx)
-;;       jne     0x6f
-;;   80: addq    $0x10, %rsp
+;;       jne     0x71
+;;   82: addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   89: ud2
 ;;   8b: ud2
+;;   8d: ud2

--- a/tests/disas/winch/x64/atomic/rmw/or/i32_atomic_rmw_or_computed_address.wat
+++ b/tests/disas/winch/x64/atomic/rmw/or/i32_atomic_rmw_or_computed_address.wat
@@ -1,0 +1,51 @@
+;;! target = "x86_64"
+;;! test = "winch"
+
+(module
+  (memory 1)
+  (func (export "_start") (param i32) (result i32)
+    (i32.atomic.rmw.or
+      (i32.add (i32.const 1) (local.get 0))
+      (i32.xor (i32.const 1) (local.get 0)))))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x18(%r11), %r11
+;;       addq    $0x2c, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x95
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x20, %rsp
+;;       movq    %rdi, 0x18(%rsp)
+;;       movq    %rsi, 0x10(%rsp)
+;;       movl    %edx, 0xc(%rsp)
+;;       movl    0xc(%rsp), %eax
+;;       movl    $1, %ecx
+;;       addl    %eax, %ecx
+;;       movl    0xc(%rsp), %eax
+;;       movl    $1, %edx
+;;       xorl    %eax, %edx
+;;       movl    %ecx, %eax
+;;       andl    $3, %eax
+;;       cmpl    $0, %eax
+;;       jne     0x97
+;;   5a: movq    0x38(%r14), %rax
+;;       movl    %ecx, %ecx
+;;       addq    %rcx, %rax
+;;       pushq   %rax
+;;       subq    $4, %rsp
+;;       movl    %edx, (%rsp)
+;;       movl    (%rsp), %ecx
+;;       addq    $4, %rsp
+;;       popq    %rdx
+;;       movl    (%rdx), %eax
+;;       movq    %rax, %r11
+;;       orq     %rcx, %r11
+;;       lock cmpxchgl %r11d, (%rdx)
+;;       jne     0x7b
+;;   8c: addq    $0x20, %rsp
+;;       popq    %rbp
+;;       retq
+;;   95: ud2
+;;   97: ud2

--- a/tests/disas/winch/x64/atomic/rmw/or/i64_atomic_rmw16_oru.wat
+++ b/tests/disas/winch/x64/atomic/rmw/or/i64_atomic_rmw16_oru.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x18(%r11), %r11
-;;       addq    $0x18, %r11
+;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x7e
+;;       ja      0x80
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,22 +21,24 @@
 ;;       movl    $0, %ecx
 ;;       andl    $1, %ecx
 ;;       cmpl    $0, %ecx
-;;       jne     0x80
+;;       jne     0x82
 ;;   48: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       movl    %ecx, %ecx
 ;;       addq    %rcx, %rdx
+;;       pushq   %rdx
 ;;       pushq   %rax
 ;;       popq    %rcx
+;;       popq    %rdx
 ;;       movzwq  (%rdx), %rax
 ;;       movq    %rax, %r11
 ;;       orq     %rcx, %r11
 ;;       lock cmpxchgw %r11w, (%rdx)
-;;       jne     0x5f
-;;   71: movzwq  %ax, %rax
+;;       jne     0x61
+;;   73: movzwq  %ax, %rax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   7e: ud2
 ;;   80: ud2
+;;   82: ud2

--- a/tests/disas/winch/x64/atomic/rmw/or/i64_atomic_rmw32_oru.wat
+++ b/tests/disas/winch/x64/atomic/rmw/or/i64_atomic_rmw32_oru.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x18(%r11), %r11
-;;       addq    $0x18, %r11
+;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x77
+;;       ja      0x79
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,21 +21,23 @@
 ;;       movl    $0, %ecx
 ;;       andl    $3, %ecx
 ;;       cmpl    $0, %ecx
-;;       jne     0x79
+;;       jne     0x7b
 ;;   48: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       movl    %ecx, %ecx
 ;;       addq    %rcx, %rdx
+;;       pushq   %rdx
 ;;       pushq   %rax
 ;;       popq    %rcx
+;;       popq    %rdx
 ;;       movl    (%rdx), %eax
 ;;       movq    %rax, %r11
 ;;       orq     %rcx, %r11
 ;;       lock cmpxchgl %r11d, (%rdx)
-;;       jne     0x5d
-;;   6e: addq    $0x10, %rsp
+;;       jne     0x5f
+;;   70: addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   77: ud2
 ;;   79: ud2
+;;   7b: ud2

--- a/tests/disas/winch/x64/atomic/rmw/or/i64_atomic_rmw8_oru.wat
+++ b/tests/disas/winch/x64/atomic/rmw/or/i64_atomic_rmw8_oru.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x18(%r11), %r11
-;;       addq    $0x18, %r11
+;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x69
+;;       ja      0x6b
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -23,15 +23,17 @@
 ;;       movq    (%r11), %rdx
 ;;       movl    %ecx, %ecx
 ;;       addq    %rcx, %rdx
+;;       pushq   %rdx
 ;;       pushq   %rax
 ;;       popq    %rcx
+;;       popq    %rdx
 ;;       movzbq  (%rdx), %rax
 ;;       movq    %rax, %r11
 ;;       orq     %rcx, %r11
 ;;       lock cmpxchgb %r11b, (%rdx)
-;;       jne     0x4b
-;;   5c: movzbq  %al, %rax
+;;       jne     0x4d
+;;   5e: movzbq  %al, %rax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   69: ud2
+;;   6b: ud2

--- a/tests/disas/winch/x64/atomic/rmw/or/i64_atomic_rmw_or.wat
+++ b/tests/disas/winch/x64/atomic/rmw/or/i64_atomic_rmw_or.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x18(%r11), %r11
-;;       addq    $0x18, %r11
+;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x78
+;;       ja      0x7a
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,21 +21,23 @@
 ;;       movl    $0, %ecx
 ;;       andl    $7, %ecx
 ;;       cmpl    $0, %ecx
-;;       jne     0x7a
+;;       jne     0x7c
 ;;   48: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       movl    %ecx, %ecx
 ;;       addq    %rcx, %rdx
+;;       pushq   %rdx
 ;;       pushq   %rax
 ;;       popq    %rcx
+;;       popq    %rdx
 ;;       movq    (%rdx), %rax
 ;;       movq    %rax, %r11
 ;;       orq     %rcx, %r11
 ;;       lock cmpxchgq %r11, (%rdx)
-;;       jne     0x5e
-;;   6f: addq    $0x10, %rsp
+;;       jne     0x60
+;;   71: addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   78: ud2
 ;;   7a: ud2
+;;   7c: ud2

--- a/tests/disas/winch/x64/atomic/rmw/xor/i32_atomic_rmw16_xoru.wat
+++ b/tests/disas/winch/x64/atomic/rmw/xor/i32_atomic_rmw16_xoru.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x18(%r11), %r11
-;;       addq    $0x14, %r11
+;;       addq    $0x1c, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x8f
+;;       ja      0x91
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,24 +21,26 @@
 ;;       movl    $0, %ecx
 ;;       andl    $1, %ecx
 ;;       cmpl    $0, %ecx
-;;       jne     0x91
+;;       jne     0x93
 ;;   48: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       movl    %ecx, %ecx
 ;;       addq    %rcx, %rdx
+;;       pushq   %rdx
 ;;       subq    $4, %rsp
 ;;       movl    %eax, (%rsp)
 ;;       movl    (%rsp), %ecx
 ;;       addq    $4, %rsp
+;;       popq    %rdx
 ;;       movzwq  (%rdx), %rax
 ;;       movq    %rax, %r11
 ;;       xorq    %rcx, %r11
 ;;       lock cmpxchgw %r11w, (%rdx)
-;;       jne     0x71
-;;   83: movzwl  %ax, %eax
+;;       jne     0x73
+;;   85: movzwl  %ax, %eax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   8f: ud2
 ;;   91: ud2
+;;   93: ud2

--- a/tests/disas/winch/x64/atomic/rmw/xor/i32_atomic_rmw8_xoru.wat
+++ b/tests/disas/winch/x64/atomic/rmw/xor/i32_atomic_rmw8_xoru.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x18(%r11), %r11
-;;       addq    $0x14, %r11
+;;       addq    $0x1c, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x7a
+;;       ja      0x7c
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -23,17 +23,19 @@
 ;;       movq    (%r11), %rdx
 ;;       movl    %ecx, %ecx
 ;;       addq    %rcx, %rdx
+;;       pushq   %rdx
 ;;       subq    $4, %rsp
 ;;       movl    %eax, (%rsp)
 ;;       movl    (%rsp), %ecx
 ;;       addq    $4, %rsp
+;;       popq    %rdx
 ;;       movzbq  (%rdx), %rax
 ;;       movq    %rax, %r11
 ;;       xorq    %rcx, %r11
 ;;       lock cmpxchgb %r11b, (%rdx)
-;;       jne     0x5d
-;;   6e: movzbl  %al, %eax
+;;       jne     0x5f
+;;   70: movzbl  %al, %eax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   7a: ud2
+;;   7c: ud2

--- a/tests/disas/winch/x64/atomic/rmw/xor/i32_atomic_rmw_xor.wat
+++ b/tests/disas/winch/x64/atomic/rmw/xor/i32_atomic_rmw_xor.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x18(%r11), %r11
-;;       addq    $0x14, %r11
+;;       addq    $0x1c, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x89
+;;       ja      0x8b
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,23 +21,25 @@
 ;;       movl    $0, %ecx
 ;;       andl    $3, %ecx
 ;;       cmpl    $0, %ecx
-;;       jne     0x8b
+;;       jne     0x8d
 ;;   48: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       movl    %ecx, %ecx
 ;;       addq    %rcx, %rdx
+;;       pushq   %rdx
 ;;       subq    $4, %rsp
 ;;       movl    %eax, (%rsp)
 ;;       movl    (%rsp), %ecx
 ;;       addq    $4, %rsp
+;;       popq    %rdx
 ;;       movl    (%rdx), %eax
 ;;       movq    %rax, %r11
 ;;       xorq    %rcx, %r11
 ;;       lock cmpxchgl %r11d, (%rdx)
-;;       jne     0x6f
-;;   80: addq    $0x10, %rsp
+;;       jne     0x71
+;;   82: addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   89: ud2
 ;;   8b: ud2
+;;   8d: ud2

--- a/tests/disas/winch/x64/atomic/rmw/xor/i64_atomic_rmw16_xoru.wat
+++ b/tests/disas/winch/x64/atomic/rmw/xor/i64_atomic_rmw16_xoru.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x18(%r11), %r11
-;;       addq    $0x18, %r11
+;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x7e
+;;       ja      0x80
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,22 +21,24 @@
 ;;       movl    $0, %ecx
 ;;       andl    $1, %ecx
 ;;       cmpl    $0, %ecx
-;;       jne     0x80
+;;       jne     0x82
 ;;   48: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       movl    %ecx, %ecx
 ;;       addq    %rcx, %rdx
+;;       pushq   %rdx
 ;;       pushq   %rax
 ;;       popq    %rcx
+;;       popq    %rdx
 ;;       movzwq  (%rdx), %rax
 ;;       movq    %rax, %r11
 ;;       xorq    %rcx, %r11
 ;;       lock cmpxchgw %r11w, (%rdx)
-;;       jne     0x5f
-;;   71: movzwq  %ax, %rax
+;;       jne     0x61
+;;   73: movzwq  %ax, %rax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   7e: ud2
 ;;   80: ud2
+;;   82: ud2

--- a/tests/disas/winch/x64/atomic/rmw/xor/i64_atomic_rmw32_xoru.wat
+++ b/tests/disas/winch/x64/atomic/rmw/xor/i64_atomic_rmw32_xoru.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x18(%r11), %r11
-;;       addq    $0x18, %r11
+;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x77
+;;       ja      0x79
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,21 +21,23 @@
 ;;       movl    $0, %ecx
 ;;       andl    $3, %ecx
 ;;       cmpl    $0, %ecx
-;;       jne     0x79
+;;       jne     0x7b
 ;;   48: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       movl    %ecx, %ecx
 ;;       addq    %rcx, %rdx
+;;       pushq   %rdx
 ;;       pushq   %rax
 ;;       popq    %rcx
+;;       popq    %rdx
 ;;       movl    (%rdx), %eax
 ;;       movq    %rax, %r11
 ;;       xorq    %rcx, %r11
 ;;       lock cmpxchgl %r11d, (%rdx)
-;;       jne     0x5d
-;;   6e: addq    $0x10, %rsp
+;;       jne     0x5f
+;;   70: addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   77: ud2
 ;;   79: ud2
+;;   7b: ud2

--- a/tests/disas/winch/x64/atomic/rmw/xor/i64_atomic_rmw8_xoru.wat
+++ b/tests/disas/winch/x64/atomic/rmw/xor/i64_atomic_rmw8_xoru.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x18(%r11), %r11
-;;       addq    $0x18, %r11
+;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x69
+;;       ja      0x6b
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -23,15 +23,17 @@
 ;;       movq    (%r11), %rdx
 ;;       movl    %ecx, %ecx
 ;;       addq    %rcx, %rdx
+;;       pushq   %rdx
 ;;       pushq   %rax
 ;;       popq    %rcx
+;;       popq    %rdx
 ;;       movzbq  (%rdx), %rax
 ;;       movq    %rax, %r11
 ;;       xorq    %rcx, %r11
 ;;       lock cmpxchgb %r11b, (%rdx)
-;;       jne     0x4b
-;;   5c: movzbq  %al, %rax
+;;       jne     0x4d
+;;   5e: movzbq  %al, %rax
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   69: ud2
+;;   6b: ud2

--- a/tests/disas/winch/x64/atomic/rmw/xor/i64_atomic_rmw_xor.wat
+++ b/tests/disas/winch/x64/atomic/rmw/xor/i64_atomic_rmw_xor.wat
@@ -10,9 +10,9 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x18(%r11), %r11
-;;       addq    $0x18, %r11
+;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x78
+;;       ja      0x7a
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
@@ -21,21 +21,23 @@
 ;;       movl    $0, %ecx
 ;;       andl    $7, %ecx
 ;;       cmpl    $0, %ecx
-;;       jne     0x7a
+;;       jne     0x7c
 ;;   48: movl    $0, %ecx
 ;;       movq    0x30(%r14), %r11
 ;;       movq    (%r11), %rdx
 ;;       movl    %ecx, %ecx
 ;;       addq    %rcx, %rdx
+;;       pushq   %rdx
 ;;       pushq   %rax
 ;;       popq    %rcx
+;;       popq    %rdx
 ;;       movq    (%rdx), %rax
 ;;       movq    %rax, %r11
 ;;       xorq    %rcx, %r11
 ;;       lock cmpxchgq %r11, (%rdx)
-;;       jne     0x5e
-;;   6f: addq    $0x10, %rsp
+;;       jne     0x60
+;;   71: addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   78: ud2
 ;;   7a: ud2
+;;   7c: ud2

--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -2337,14 +2337,24 @@ where
         let heap = self.env.resolve_heap(memory_index);
         // We need to pop-push the operand to compute the address before passing control over to
         // masm, because some architectures may have specific requirements for the registers used
-        // in some atomic operations.
+        // in some atomic operations. The computed address is pushed back to the context's stack
+        // too, rather than handed over as a register, since registers that are not tracked by the
+        // value stack can't be spilled, so an untracked address register would make any request
+        // for a fixed register fail if the address happened to be allocated to it. For this
+        // reason, the address is pushed as a register to be dereferenced prior to emission, after
+        // all the ISA-specifc constraints have been solved.
         let operand = self.context.pop_to_reg(self.masm, None)?;
         if let Some(addr) = self.emit_compute_heap_address_align_checked(&heap, arg, size)? {
-            let src = self.masm.address_at_reg(addr, 0)?;
+            self.context
+                .stack
+                .push(TypedReg::new(self.env.ptr_type(), addr).into());
             self.context.stack.push(operand.into());
             self.masm
-                .atomic_rmw(&mut self.context, src, size, op, UNTRUSTED_FLAGS, extend)?;
-            self.context.free_reg(addr);
+                .atomic_rmw(&mut self.context, size, op, UNTRUSTED_FLAGS, extend)?;
+        } else {
+            // Ensure that the operand register is not left allocated if the access was proven to
+            // be out of bounds at compile time.
+            self.context.free_reg(operand);
         }
 
         Ok(())
@@ -2368,10 +2378,15 @@ where
         // with regard to the registers used for some arguments, so we
         // need to pass the context to the masm. To solve this issue,
         // we pop the two first arguments from the stack, compute the
-        // address, push back the arguments, and hand over the control
-        // to masm. The implementer of `atomic_cas` can expect to find
-        // `expected` and `replacement` at the top the context's
-        // stack.
+        // address, push back the address and the arguments, and hand
+        // over the control to masm. The implementer of `atomic_cas`
+        // can expect to find `address`, `expected` and `replacement`
+        // at the top the context's stack.
+        //
+        // The computed address is pushed back to the stack as a
+        // register, rather than handed over directly, so that the
+        // register allocator is able to spill it if the target
+        // requires a fixed register.
 
         let replacement = self.context.pop_to_reg(self.masm, None)?;
         let expected = self.context.pop_to_reg(self.masm, None)?;
@@ -2379,14 +2394,19 @@ where
         let memory_index = MemoryIndex::from_u32(arg.memory);
         let heap = self.env.resolve_heap(memory_index);
         if let Some(addr) = self.emit_compute_heap_address_align_checked(&heap, arg, size)? {
+            self.context
+                .stack
+                .push(TypedReg::new(self.env.ptr_type(), addr).into());
             self.context.stack.push(expected.into());
             self.context.stack.push(replacement.into());
 
-            let src = self.masm.address_at_reg(addr, 0)?;
             self.masm
-                .atomic_cas(&mut self.context, src, size, UNTRUSTED_FLAGS, extend)?;
-
-            self.context.free_reg(addr);
+                .atomic_cas(&mut self.context, size, UNTRUSTED_FLAGS, extend)?;
+        } else {
+            // Ensure that the argument registers are not left allocated if the access was proven
+            // to be out of bounds at compile time.
+            self.context.free_reg(expected);
+            self.context.free_reg(replacement);
         }
         Ok(())
     }

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -1334,7 +1334,6 @@ impl Masm for MacroAssembler {
     fn atomic_rmw(
         &mut self,
         _context: &mut CodeGenContext<Emission>,
-        _addr: Self::Address,
         _size: OperandSize,
         _op: RmwOp,
         _flags: MemFlagsData,
@@ -1366,7 +1365,6 @@ impl Masm for MacroAssembler {
     fn atomic_cas(
         &mut self,
         _context: &mut CodeGenContext<Emission>,
-        _addr: Self::Address,
         _size: OperandSize,
         _flags: MemFlagsData,
         _extend: Option<Extend<Zero>>,

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -1604,29 +1604,31 @@ impl Masm for MacroAssembler {
     fn atomic_rmw(
         &mut self,
         context: &mut CodeGenContext<Emission>,
-        addr: Self::Address,
         size: OperandSize,
         op: RmwOp,
         flags: MemFlagsData,
         extend: Option<Extend<Zero>>,
     ) -> Result<()> {
         let res = match op {
-            RmwOp::Add => {
+            RmwOp::Add | RmwOp::Sub | RmwOp::Xchg => {
                 let operand = context.pop_to_reg(self, None)?;
-                self.asm
-                    .lock_xadd(addr, writable!(operand.reg), size, flags);
-                operand.reg
-            }
-            RmwOp::Sub => {
-                let operand = context.pop_to_reg(self, None)?;
-                self.asm.neg(operand.reg, writable!(operand.reg), size);
-                self.asm
-                    .lock_xadd(addr, writable!(operand.reg), size, flags);
-                operand.reg
-            }
-            RmwOp::Xchg => {
-                let operand = context.pop_to_reg(self, None)?;
-                self.asm.xchg(addr, writable!(operand.reg), size, flags);
+                let base = context.pop_to_reg(self, None)?;
+                let addr = self.address_at_reg(base.reg, 0)?;
+
+                match op {
+                    RmwOp::Add => self
+                        .asm
+                        .lock_xadd(addr, writable!(operand.reg), size, flags),
+                    RmwOp::Sub => {
+                        self.asm.neg(operand.reg, writable!(operand.reg), size);
+                        self.asm
+                            .lock_xadd(addr, writable!(operand.reg), size, flags);
+                    }
+                    RmwOp::Xchg => self.asm.xchg(addr, writable!(operand.reg), size, flags),
+                    _ => unreachable!(),
+                }
+
+                context.free_reg(base.reg);
                 operand.reg
             }
             RmwOp::And | RmwOp::Or | RmwOp::Xor => {
@@ -1638,8 +1640,11 @@ impl Masm for MacroAssembler {
                         "invalid op for atomic_rmw_seq, should be one of `or`, `and` or `xor`"
                     ),
                 };
+
                 let dst = context.reg(regs::rax(), self)?;
                 let operand = context.pop_to_reg(self, None)?;
+                let base = context.pop_to_reg(self, None)?;
+                let addr = self.address_at_reg(base.reg, 0)?;
 
                 self.with_scratch::<IntScratch, _>(|masm, scratch| {
                     masm.asm.atomic_rmw_seq(
@@ -1654,6 +1659,7 @@ impl Masm for MacroAssembler {
                 });
 
                 context.free_reg(operand.reg);
+                context.free_reg(base.reg);
                 dst
             }
         };
@@ -1791,20 +1797,18 @@ impl Masm for MacroAssembler {
     fn atomic_cas(
         &mut self,
         context: &mut CodeGenContext<Emission>,
-        addr: Self::Address,
         size: OperandSize,
         flags: MemFlagsData,
         extend: Option<Extend<Zero>>,
     ) -> Result<()> {
-        // `cmpxchg` expects `expected` to be in the `*a*` register.
-        // reserve rax for the expected argument.
-
         let replacement =
             context.without::<Result<TypedReg>, _, _>(&[regs::rax()], self, |cx, masm| {
                 cx.pop_to_reg(masm, None)
             })??;
 
         let expected = context.pop_to_reg(self, Some(regs::rax()))?;
+        let base = context.pop_to_reg(self, None)?;
+        let addr = self.address_at_reg(base.reg, 0)?;
 
         self.asm
             .cmpxchg(addr, replacement.reg, writable!(expected.reg), size, flags);
@@ -1816,6 +1820,7 @@ impl Masm for MacroAssembler {
 
         context.stack.push(expected.into());
         context.free_reg(replacement);
+        context.free_reg(base.reg);
 
         Ok(())
     }

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -2074,13 +2074,22 @@ pub(crate) trait MacroAssembler {
     /// Performs a swizzle between two 128-bit vectors into a 128-bit result.
     fn swizzle(&mut self, dst: WritableReg, lhs: Reg, rhs: Reg) -> Result<()>;
 
-    /// Performs the RMW `op` operation on the passed `addr`.
+    /// Performs the RMW `op` operation on the address at the top of the
+    /// context's stack.
     ///
-    /// The value *before* the operation was performed is written back to the `operand` register.
+    /// This method takes the `CodeGenContext` as an argument to accommodate
+    /// architectures that expect parameters in specific registers. The context
+    /// stack contains the `address` and the `operand` values, in that order,
+    /// and both are owned by this function. The implementer is expected to
+    /// push the value *before* the operation was performed to the context's
+    /// stack before returning.
+    ///
+    /// Note that the address is passed through the context's stack rather than
+    /// as a register to ensure that any spills can be perfomed when solving
+    /// ISA-specific constraints prior to emission.
     fn atomic_rmw(
         &mut self,
         context: &mut CodeGenContext<Emission>,
-        addr: Self::Address,
         size: OperandSize,
         op: RmwOp,
         flags: MemFlagsData,
@@ -2105,17 +2114,21 @@ pub(crate) trait MacroAssembler {
         kind: ReplaceLaneKind,
     ) -> Result<()>;
 
-    /// Perform an atomic CAS (compare-and-swap) operation with the value at `addr`, and `expected`
-    /// and `replacement` (at the top of the context's stack).
+    /// Perform an atomic CAS (compare-and-swap) operation with the `address`, `expected` and
+    /// `replacement` values at the top of the context's stack.
     ///
     /// This method takes the `CodeGenContext` as an arguments to accommodate architectures that
-    /// expect parameters in specific registers. The context stack contains the `replacement`,
-    /// and `expected` values in that order. The implementer is expected to push the value at
-    /// `addr` before the update to the context's stack before returning.
+    /// expect parameters in specific registers. The context stack contains the `address`,
+    /// `expected` and `replacement` values in that order, and all of them are owned by this
+    /// function. The implementer is expected to push the value at `address` before the update to
+    /// the context's stack before returning.
+    ///
+    /// Like in [`MacroAssembler::atomic_rmw`], the address is passed through the context's stack
+    /// so that it can be spilled; implementations that require fixed registers must request them
+    /// *before* popping any of the values above.
     fn atomic_cas(
         &mut self,
         context: &mut CodeGenContext<Emission>,
-        addr: Self::Address,
         size: OperandSize,
         flags: MemFlagsData,
         extend: Option<Extend<Zero>>,


### PR DESCRIPTION
This patch fixes https://github.com/bytecodealliance/wasmtime/issues/13989

It passes the arguments of the atomic operations through the value stack instead of calculating and holding the address register prior to handing over control to the MacroAssembler. This approach ensures that spills can happen naturally when specific registers are needed when lowering these operations.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
