### PR TITLE
Cranelift: construct all-zero vectors with vconst

### DIFF
--- a/cranelift/codegen/src/opts.rs
+++ b/cranelift/codegen/src/opts.rs
@@ -201,6 +201,11 @@ where
 impl<'a, 'b, 'c> generated_code::Context for IsleContext<'a, 'b, 'c> {
     isle_common_prelude_methods!();
 
+    fn zero_constant(&mut self, ty: Type) -> Constant {
+        let data = vec![0; ty.bytes() as usize];
+        self.ctx.func.dfg.constants.insert(data.into())
+    }
+
     type inst_data_value_etor_returns = InstDataEtorIter<'a, 'b, 'c>;
 
     fn inst_data_value_etor(&mut self, eclass: Value, returns: &mut InstDataEtorIter<'a, 'b, 'c>) {

--- a/cranelift/codegen/src/opts/bitops.isle
+++ b/cranelift/codegen/src/opts/bitops.isle
@@ -19,8 +19,8 @@
 (rule 0 (all_zero (ty_int ty)) (iconst_u ty 0))
 (rule 1 (all_zero $F32) (f32const $F32 (f32_from_uint 0)))
 (rule 2 (all_zero $F64) (f64const $F64 (f64_from_uint 0)))
-(rule 3 (all_zero (ty_vec64 ty)) (splat ty (all_zero (lane_type ty))))
-(rule 4 (all_zero (ty_vec128 ty)) (splat ty (all_zero (lane_type ty))))
+(rule 3 (all_zero (ty_vec64 ty)) (vconst ty (zero_constant ty)))
+(rule 4 (all_zero (ty_vec128 ty)) (vconst ty (zero_constant ty)))
 
 ;; x ^ x == 0.
 (rule (simplify (bxor ty x x))

--- a/cranelift/codegen/src/prelude_opt.isle
+++ b/cranelift/codegen/src/prelude_opt.isle
@@ -2,6 +2,12 @@
 
 ;; Any `extern` definitions here are generally implemented in `src/opts.rs`.
 
+;;;;; constants ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; Insert an all-zero constant whose size matches `ty` into the constant pool.
+(decl zero_constant (Type) Constant)
+(extern constructor zero_constant zero_constant)
+
 ;;;;; eclass and enode access ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Extract any node(s) for the given eclass ID.

--- a/cranelift/filetests/filetests/egraph/bitops.clif
+++ b/cranelift/filetests/filetests/egraph/bitops.clif
@@ -163,8 +163,8 @@ block0(v0: f32x4):
 }
 
 ; check: const0 = 0x00000000000000000000000000000000
-; check: v4 = vconst.f32x4 const0
-; check: return v4
+; check: v2 = vconst.f32x4 const0
+; check: return v2
 
 function %vector_bxor_x_x_f64x2(f64x2) -> f64x2 {
 block0(v0: f64x2):
@@ -173,8 +173,8 @@ block0(v0: f64x2):
 }
 
 ; check: const0 = 0x00000000000000000000000000000000
-; check: v4 = vconst.f64x2 const0
-; check: return v4
+; check: v2 = vconst.f64x2 const0
+; check: return v2
 
 function %vector_bxor_x_x_f32x2(f32x2) -> f32x2 {
 block0(v0: f32x2):
@@ -182,9 +182,9 @@ block0(v0: f32x2):
     return v1
 }
 
-; check: f32const 0.0
-; check: splat.f32x2
-; check: return
+; check: const0 = 0x0000000000000000
+; check: v2 = vconst.f32x2 const0
+; check: return v2
 
 function %vector_bxor_x_bnot_x(i32x4) -> i32x4 {
 block0(v0: i32x4):
@@ -216,8 +216,8 @@ block0(v0: i32x4):
 }
 
 ; check: const0 = 0x00000000000000000000000000000000
-; check: v5 = vconst.i32x4 const0
-; check: return v5
+; check: v3 = vconst.i32x4 const0
+; check: return v3
 
 function %vector_bor_x_bnot_x(i32x4) -> i32x4 {
 block0(v0: i32x4):

--- a/tests/disas/gc/copying/v128-fields.wat
+++ b/tests/disas/gc/copying/v128-fields.wat
@@ -34,6 +34,6 @@
 ;; @002e                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v20 = vconst.i8x16 const0
-;; @002e                               return v20  ; v20 = const0
+;;                                     v18 = vconst.i8x16 const0
+;; @002e                               return v18  ; v18 = const0
 ;; }

--- a/tests/disas/gc/null/v128-fields.wat
+++ b/tests/disas/gc/null/v128-fields.wat
@@ -35,6 +35,6 @@
 ;; @002e                               jump block1
 ;;
 ;;                                 block1:
-;;                                     v20 = vconst.i8x16 const0
-;; @002e                               return v20  ; v20 = const0
+;;                                     v18 = vconst.i8x16 const0
+;; @002e                               return v18  ; v18 = const0
 ;; }


### PR DESCRIPTION
Add a mid-end helper that creates a zero-filled `ir::Constant`.

Follow-up to #13850