### PR TITLE
perf: cranelift-codegen-meta: less llvm-lines: `vec![...]` -> `&[...]`

### DIFF
--- a/cranelift/codegen/meta/src/cdsl/instructions.rs
+++ b/cranelift/codegen/meta/src/cdsl/instructions.rs
@@ -166,15 +166,15 @@ impl InstructionBuilder {
         }
     }
 
-    pub fn operands_in(mut self, operands: Vec<Operand>) -> Self {
+    pub fn operands_in(mut self, operands: &[Operand]) -> Self {
         assert!(self.operands_in.is_none());
-        self.operands_in = Some(operands);
+        self.operands_in = Some(operands.to_vec());
         self
     }
 
-    pub fn operands_out(mut self, operands: Vec<Operand>) -> Self {
+    pub fn operands_out(mut self, operands: &[Operand]) -> Self {
         assert!(self.operands_out.is_none());
-        self.operands_out = Some(operands);
+        self.operands_out = Some(operands.to_vec());
         self
     }
 

--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -29,10 +29,8 @@ fn define_control_flow(
         "#,
             &formats.jump,
         )
-        .operands_in(vec![
-            Operand::new("block_call", &entities.block_call)
-                .with_doc("Destination basic block, with its arguments provided"),
-        ])
+        .operands_in(&[Operand::new("block_call", &entities.block_call)
+            .with_doc("Destination basic block, with its arguments provided")])
         .branches(),
     );
 
@@ -52,7 +50,7 @@ fn define_control_flow(
         "#,
             &formats.brif,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("c", ScalarTruthy).with_doc("Controlling value to test"),
             Operand::new("block_then", &entities.block_then).with_doc("Then block"),
             Operand::new("block_else", &entities.block_else).with_doc("Else block"),
@@ -89,7 +87,7 @@ fn define_control_flow(
         "#,
                 &formats.branch_table,
             )
-            .operands_in(vec![
+            .operands_in(&[
                 Operand::new("x", _i32).with_doc("i32 index into jump table"),
                 Operand::new("JT", &entities.jump_table),
             ])
@@ -124,7 +122,7 @@ fn define_control_flow(
         "#,
             &formats.trap,
         )
-        .operands_in(vec![Operand::new("code", &imm.trapcode)])
+        .operands_in(&[Operand::new("code", &imm.trapcode)])
         .can_trap()
         .terminates_block(),
     );
@@ -139,7 +137,7 @@ fn define_control_flow(
         "#,
             &formats.cond_trap,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("c", ScalarTruthy).with_doc("Controlling value to test"),
             Operand::new("code", &imm.trapcode),
         ])
@@ -162,7 +160,7 @@ fn define_control_flow(
         "#,
             &formats.cond_trap,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("c", ScalarTruthy).with_doc("Controlling value to test"),
             Operand::new("code", &imm.trapcode),
         ])
@@ -183,9 +181,7 @@ fn define_control_flow(
         "#,
             &formats.multiary,
         )
-        .operands_in(vec![
-            Operand::new("rvals", &entities.varargs).with_doc("return values"),
-        ])
+        .operands_in(&[Operand::new("rvals", &entities.varargs).with_doc("return values")])
         .returns(),
     );
 
@@ -200,14 +196,12 @@ fn define_control_flow(
         "#,
             &formats.call,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("FN", &entities.func_ref)
                 .with_doc("function to call, declared by `function`"),
             Operand::new("args", &entities.varargs).with_doc("call arguments"),
         ])
-        .operands_out(vec![
-            Operand::new("rvals", &entities.varargs).with_doc("return values"),
-        ])
+        .operands_out(&[Operand::new("rvals", &entities.varargs).with_doc("return values")])
         .call(),
     );
 
@@ -227,14 +221,12 @@ fn define_control_flow(
         "#,
             &formats.call_indirect,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("SIG", &entities.sig_ref).with_doc("function signature"),
             Operand::new("callee", iAddr).with_doc("address of function to call"),
             Operand::new("args", &entities.varargs).with_doc("call arguments"),
         ])
-        .operands_out(vec![
-            Operand::new("rvals", &entities.varargs).with_doc("return values"),
-        ])
+        .operands_out(&[Operand::new("rvals", &entities.varargs).with_doc("return values")])
         .call(),
     );
 
@@ -253,7 +245,7 @@ fn define_control_flow(
         "#,
             &formats.call,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("FN", &entities.func_ref)
                 .with_doc("function to call, declared by `function`"),
             Operand::new("args", &entities.varargs).with_doc("call arguments"),
@@ -282,7 +274,7 @@ fn define_control_flow(
         "#,
             &formats.call_indirect,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("SIG", &entities.sig_ref).with_doc("function signature"),
             Operand::new("callee", iAddr).with_doc("address of function to call"),
             Operand::new("args", &entities.varargs).with_doc("call arguments"),
@@ -305,11 +297,9 @@ fn define_control_flow(
         "#,
             &formats.func_addr,
         )
-        .operands_in(vec![
-            Operand::new("FN", &entities.func_ref)
-                .with_doc("function to call, declared by `function`"),
-        ])
-        .operands_out(vec![Operand::new("addr", iAddr)]),
+        .operands_in(&[Operand::new("FN", &entities.func_ref)
+            .with_doc("function to call, declared by `function`")])
+        .operands_out(&[Operand::new("addr", iAddr)]),
     );
 
     ig.push(
@@ -337,7 +327,7 @@ fn define_control_flow(
         "#,
             &formats.try_call,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("callee", &entities.func_ref)
                 .with_doc("function to call, declared by `function`"),
             Operand::new("args", &entities.varargs).with_doc("call arguments"),
@@ -372,7 +362,7 @@ fn define_control_flow(
         "#,
             &formats.try_call_indirect,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("callee", iAddr).with_doc("address of function to call"),
             Operand::new("args", &entities.varargs).with_doc("call arguments"),
             Operand::new("ET", &entities.exception_table).with_doc("exception table"),
@@ -411,10 +401,8 @@ fn define_simd_lane_access(
         "#,
             &formats.unary,
         )
-        .operands_in(vec![
-            Operand::new("x", &TxN.lane_of()).with_doc("Value to splat to all lanes"),
-        ])
-        .operands_out(vec![Operand::new("a", TxN)]),
+        .operands_in(&[Operand::new("x", &TxN.lane_of()).with_doc("Value to splat to all lanes")])
+        .operands_out(&[Operand::new("a", TxN)]),
     );
 
     let I8x16 = &TypeVar::new(
@@ -440,11 +428,11 @@ fn define_simd_lane_access(
         "#,
             &formats.binary,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("x", I8x16).with_doc("Vector to modify by re-arranging lanes"),
             Operand::new("y", I8x16).with_doc("Mask for re-arranging lanes"),
         ])
-        .operands_out(vec![Operand::new("a", I8x16)]),
+        .operands_out(&[Operand::new("a", I8x16)]),
     );
 
     ig.push(
@@ -464,11 +452,11 @@ fn define_simd_lane_access(
         "#,
             &formats.binary,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("x", I8x16).with_doc("Vector to modify by re-arranging lanes"),
             Operand::new("y", I8x16).with_doc("Mask for re-arranging lanes"),
         ])
-        .operands_out(vec![Operand::new("a", I8x16)]),
+        .operands_out(&[Operand::new("a", I8x16)]),
     );
 
     ig.push(
@@ -482,12 +470,12 @@ fn define_simd_lane_access(
         "#,
             &formats.ternary_imm8,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("x", TxN).with_doc("The vector to modify"),
             Operand::new("y", &TxN.lane_of()).with_doc("New lane value"),
             Operand::new("Idx", &imm.uimm8).with_doc("Lane index"),
         ])
-        .operands_out(vec![Operand::new("a", TxN)]),
+        .operands_out(&[Operand::new("a", TxN)]),
     );
 
     ig.push(
@@ -503,11 +491,11 @@ fn define_simd_lane_access(
         "#,
             &formats.binary_imm8,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("x", TxN),
             Operand::new("Idx", &imm.uimm8).with_doc("Lane index"),
         ])
-        .operands_out(vec![Operand::new("a", &TxN.lane_of())]),
+        .operands_out(&[Operand::new("a", &TxN.lane_of())]),
     );
 }
 
@@ -535,8 +523,8 @@ fn define_simd_arithmetic(
         "#,
             &formats.binary,
         )
-        .operands_in(vec![Operand::new("x", Int), Operand::new("y", Int)])
-        .operands_out(vec![Operand::new("a", Int)]),
+        .operands_in(&[Operand::new("x", Int), Operand::new("y", Int)])
+        .operands_out(&[Operand::new("a", Int)]),
     );
 
     ig.push(
@@ -547,8 +535,8 @@ fn define_simd_arithmetic(
         "#,
             &formats.binary,
         )
-        .operands_in(vec![Operand::new("x", Int), Operand::new("y", Int)])
-        .operands_out(vec![Operand::new("a", Int)]),
+        .operands_in(&[Operand::new("x", Int), Operand::new("y", Int)])
+        .operands_out(&[Operand::new("a", Int)]),
     );
 
     ig.push(
@@ -559,8 +547,8 @@ fn define_simd_arithmetic(
         "#,
             &formats.binary,
         )
-        .operands_in(vec![Operand::new("x", Int), Operand::new("y", Int)])
-        .operands_out(vec![Operand::new("a", Int)]),
+        .operands_in(&[Operand::new("x", Int), Operand::new("y", Int)])
+        .operands_out(&[Operand::new("a", Int)]),
     );
 
     ig.push(
@@ -571,8 +559,8 @@ fn define_simd_arithmetic(
         "#,
             &formats.binary,
         )
-        .operands_in(vec![Operand::new("x", Int), Operand::new("y", Int)])
-        .operands_out(vec![Operand::new("a", Int)]),
+        .operands_in(&[Operand::new("x", Int), Operand::new("y", Int)])
+        .operands_out(&[Operand::new("a", Int)]),
     );
 
     let IxN = &TypeVar::new(
@@ -595,8 +583,8 @@ fn define_simd_arithmetic(
         "#,
             &formats.binary,
         )
-        .operands_in(vec![Operand::new("x", IxN), Operand::new("y", IxN)])
-        .operands_out(vec![Operand::new("a", IxN)]),
+        .operands_in(&[Operand::new("x", IxN), Operand::new("y", IxN)])
+        .operands_out(&[Operand::new("a", IxN)]),
     );
 
     ig.push(
@@ -611,8 +599,8 @@ fn define_simd_arithmetic(
         "#,
             &formats.binary,
         )
-        .operands_in(vec![Operand::new("x", IxN), Operand::new("y", IxN)])
-        .operands_out(vec![Operand::new("a", IxN)]),
+        .operands_in(&[Operand::new("x", IxN), Operand::new("y", IxN)])
+        .operands_out(&[Operand::new("a", IxN)]),
     );
 
     ig.push(
@@ -629,8 +617,8 @@ fn define_simd_arithmetic(
         "#,
             &formats.binary,
         )
-        .operands_in(vec![Operand::new("x", IxN), Operand::new("y", IxN)])
-        .operands_out(vec![Operand::new("a", IxN)]),
+        .operands_in(&[Operand::new("x", IxN), Operand::new("y", IxN)])
+        .operands_out(&[Operand::new("a", IxN)]),
     );
 
     ig.push(
@@ -645,8 +633,8 @@ fn define_simd_arithmetic(
         "#,
             &formats.binary,
         )
-        .operands_in(vec![Operand::new("x", IxN), Operand::new("y", IxN)])
-        .operands_out(vec![Operand::new("a", IxN)]),
+        .operands_in(&[Operand::new("x", IxN), Operand::new("y", IxN)])
+        .operands_out(&[Operand::new("a", IxN)]),
     );
 
     ig.push(
@@ -661,8 +649,8 @@ fn define_simd_arithmetic(
         "#,
             &formats.binary,
         )
-        .operands_in(vec![Operand::new("x", IxN), Operand::new("y", IxN)])
-        .operands_out(vec![Operand::new("a", IxN)]),
+        .operands_in(&[Operand::new("x", IxN), Operand::new("y", IxN)])
+        .operands_out(&[Operand::new("a", IxN)]),
     );
 }
 
@@ -771,12 +759,12 @@ pub(crate) fn define(
         "#,
             &formats.load,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("MemFlags", &imm.memflags),
             Operand::new("p", iAddr),
             Operand::new("Offset", &imm.offset32).with_doc("Byte offset from base address"),
         ])
-        .operands_out(vec![Operand::new("a", Mem).with_doc("Value loaded")])
+        .operands_out(&[Operand::new("a", Mem).with_doc("Value loaded")])
         .can_load(),
     );
 
@@ -791,7 +779,7 @@ pub(crate) fn define(
         "#,
             &formats.store,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("MemFlags", &imm.memflags),
             Operand::new("x", Mem).with_doc("Value to be stored"),
             Operand::new("p", iAddr),
@@ -816,12 +804,12 @@ pub(crate) fn define(
         "#,
             &formats.load,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("MemFlags", &imm.memflags),
             Operand::new("p", iAddr),
             Operand::new("Offset", &imm.offset32).with_doc("Byte offset from base address"),
         ])
-        .operands_out(vec![Operand::new("a", iExt8)])
+        .operands_out(&[Operand::new("a", iExt8)])
         .can_load(),
     );
 
@@ -835,12 +823,12 @@ pub(crate) fn define(
         "#,
             &formats.load,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("MemFlags", &imm.memflags),
             Operand::new("p", iAddr),
             Operand::new("Offset", &imm.offset32).with_doc("Byte offset from base address"),
         ])
-        .operands_out(vec![Operand::new("a", iExt8)])
+        .operands_out(&[Operand::new("a", iExt8)])
         .can_load(),
     );
 
@@ -854,7 +842,7 @@ pub(crate) fn define(
         "#,
             &formats.store,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("MemFlags", &imm.memflags),
             Operand::new("x", iExt8),
             Operand::new("p", iAddr),
@@ -879,12 +867,12 @@ pub(crate) fn define(
         "#,
             &formats.load,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("MemFlags", &imm.memflags),
             Operand::new("p", iAddr),
             Operand::new("Offset", &imm.offset32).with_doc("Byte offset from base address"),
         ])
-        .operands_out(vec![Operand::new("a", iExt16)])
+        .operands_out(&[Operand::new("a", iExt16)])
         .can_load(),
     );
 
@@ -898,12 +886,12 @@ pub(crate) fn define(
         "#,
             &formats.load,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("MemFlags", &imm.memflags),
             Operand::new("p", iAddr),
             Operand::new("Offset", &imm.offset32).with_doc("Byte offset from base address"),
         ])
-        .operands_out(vec![Operand::new("a", iExt16)])
+        .operands_out(&[Operand::new("a", iExt16)])
         .can_load(),
     );
 
@@ -917,7 +905,7 @@ pub(crate) fn define(
         "#,
             &formats.store,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("MemFlags", &imm.memflags),
             Operand::new("x", iExt16),
             Operand::new("p", iAddr),
@@ -942,12 +930,12 @@ pub(crate) fn define(
         "#,
             &formats.load,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("MemFlags", &imm.memflags),
             Operand::new("p", iAddr),
             Operand::new("Offset", &imm.offset32).with_doc("Byte offset from base address"),
         ])
-        .operands_out(vec![Operand::new("a", iExt32)])
+        .operands_out(&[Operand::new("a", iExt32)])
         .can_load(),
     );
 
@@ -961,12 +949,12 @@ pub(crate) fn define(
         "#,
             &formats.load,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("MemFlags", &imm.memflags),
             Operand::new("p", iAddr),
             Operand::new("Offset", &imm.offset32).with_doc("Byte offset from base address"),
         ])
-        .operands_out(vec![Operand::new("a", iExt32)])
+        .operands_out(&[Operand::new("a", iExt32)])
         .can_load(),
     );
 
@@ -980,7 +968,7 @@ pub(crate) fn define(
         "#,
             &formats.store,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("MemFlags", &imm.memflags),
             Operand::new("x", iExt32),
             Operand::new("p", iAddr),
@@ -1037,12 +1025,12 @@ pub(crate) fn define(
         "#,
             &formats.ternary,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("store_context_ptr", iAddr),
             Operand::new("load_context_ptr", iAddr),
             Operand::new("in_payload0", iAddr),
         ])
-        .operands_out(vec![Operand::new("out_payload0", iAddr)])
+        .operands_out(&[Operand::new("out_payload0", iAddr)])
         .other_side_effects()
         .can_load()
         .can_store()
@@ -1068,12 +1056,12 @@ pub(crate) fn define(
         "#,
             &formats.load,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("MemFlags", &imm.memflags),
             Operand::new("p", iAddr),
             Operand::new("Offset", &imm.offset32).with_doc("Byte offset from base address"),
         ])
-        .operands_out(vec![Operand::new("a", I16x8).with_doc("Value loaded")])
+        .operands_out(&[Operand::new("a", I16x8).with_doc("Value loaded")])
         .can_load(),
     );
 
@@ -1086,12 +1074,12 @@ pub(crate) fn define(
         "#,
             &formats.load,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("MemFlags", &imm.memflags),
             Operand::new("p", iAddr),
             Operand::new("Offset", &imm.offset32).with_doc("Byte offset from base address"),
         ])
-        .operands_out(vec![Operand::new("a", I16x8).with_doc("Value loaded")])
+        .operands_out(&[Operand::new("a", I16x8).with_doc("Value loaded")])
         .can_load(),
     );
 
@@ -1114,12 +1102,12 @@ pub(crate) fn define(
         "#,
             &formats.load,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("MemFlags", &imm.memflags),
             Operand::new("p", iAddr),
             Operand::new("Offset", &imm.offset32).with_doc("Byte offset from base address"),
         ])
-        .operands_out(vec![Operand::new("a", I32x4).with_doc("Value loaded")])
+        .operands_out(&[Operand::new("a", I32x4).with_doc("Value loaded")])
         .can_load(),
     );
 
@@ -1132,12 +1120,12 @@ pub(crate) fn define(
         "#,
             &formats.load,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("MemFlags", &imm.memflags),
             Operand::new("p", iAddr),
             Operand::new("Offset", &imm.offset32).with_doc("Byte offset from base address"),
         ])
-        .operands_out(vec![Operand::new("a", I32x4).with_doc("Value loaded")])
+        .operands_out(&[Operand::new("a", I32x4).with_doc("Value loaded")])
         .can_load(),
     );
 
@@ -1160,12 +1148,12 @@ pub(crate) fn define(
         "#,
             &formats.load,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("MemFlags", &imm.memflags),
             Operand::new("p", iAddr),
             Operand::new("Offset", &imm.offset32).with_doc("Byte offset from base address"),
         ])
-        .operands_out(vec![Operand::new("a", I64x2).with_doc("Value loaded")])
+        .operands_out(&[Operand::new("a", I64x2).with_doc("Value loaded")])
         .can_load(),
     );
 
@@ -1178,12 +1166,12 @@ pub(crate) fn define(
         "#,
             &formats.load,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("MemFlags", &imm.memflags),
             Operand::new("p", iAddr),
             Operand::new("Offset", &imm.offset32).with_doc("Byte offset from base address"),
         ])
-        .operands_out(vec![Operand::new("a", I64x2).with_doc("Value loaded")])
+        .operands_out(&[Operand::new("a", I64x2).with_doc("Value loaded")])
         .can_load(),
     );
 
@@ -1199,11 +1187,11 @@ pub(crate) fn define(
         "#,
             &formats.stack_addr,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("SS", &entities.stack_slot),
             Operand::new("Offset", &imm.offset32).with_doc("In-bounds offset into stack slot"),
         ])
-        .operands_out(vec![Operand::new("addr", iAddr)]),
+        .operands_out(&[Operand::new("addr", iAddr)]),
     );
 
     ig.push(
@@ -1216,8 +1204,8 @@ pub(crate) fn define(
         "#,
             &formats.dynamic_stack_addr,
         )
-        .operands_in(vec![Operand::new("DSS", &entities.dynamic_stack_slot)])
-        .operands_out(vec![Operand::new("addr", iAddr)]),
+        .operands_in(&[Operand::new("DSS", &entities.dynamic_stack_slot)])
+        .operands_out(&[Operand::new("addr", iAddr)]),
     );
 
     ig.push(
@@ -1228,8 +1216,8 @@ pub(crate) fn define(
         "#,
             &formats.unary_global_value,
         )
-        .operands_in(vec![Operand::new("GV", &entities.global_value)])
-        .operands_out(vec![Operand::new("a", Mem).with_doc("Value loaded")]),
+        .operands_in(&[Operand::new("GV", &entities.global_value)])
+        .operands_out(&[Operand::new("a", Mem).with_doc("Value loaded")]),
     );
 
     ig.push(
@@ -1240,8 +1228,8 @@ pub(crate) fn define(
         "#,
             &formats.unary_global_value,
         )
-        .operands_in(vec![Operand::new("GV", &entities.global_value)])
-        .operands_out(vec![Operand::new("a", Mem).with_doc("Value loaded")]),
+        .operands_in(&[Operand::new("GV", &entities.global_value)])
+        .operands_out(&[Operand::new("a", Mem).with_doc("Value loaded")]),
     );
 
     // Note this instruction is marked as having other side-effects, so GVN won't try to hoist it,
@@ -1258,7 +1246,7 @@ pub(crate) fn define(
         "#,
             &formats.nullary,
         )
-        .operands_out(vec![Operand::new("addr", iAddr)])
+        .operands_out(&[Operand::new("addr", iAddr)])
         .other_side_effects(),
     );
 
@@ -1270,7 +1258,7 @@ pub(crate) fn define(
         "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("addr", iAddr)])
+        .operands_in(&[Operand::new("addr", iAddr)])
         .other_side_effects(),
     );
 
@@ -1284,7 +1272,7 @@ pub(crate) fn define(
         "#,
             &formats.nullary,
         )
-        .operands_out(vec![Operand::new("addr", iAddr)]),
+        .operands_out(&[Operand::new("addr", iAddr)]),
     );
 
     ig.push(
@@ -1295,7 +1283,7 @@ pub(crate) fn define(
         "#,
             &formats.nullary,
         )
-        .operands_out(vec![Operand::new("addr", iAddr)]),
+        .operands_out(&[Operand::new("addr", iAddr)]),
     );
 
     ig.push(
@@ -1308,7 +1296,7 @@ pub(crate) fn define(
         "#,
             &formats.nullary,
         )
-        .operands_out(vec![Operand::new("addr", iAddr)]),
+        .operands_out(&[Operand::new("addr", iAddr)]),
     );
 
     ig.push(
@@ -1336,11 +1324,11 @@ pub(crate) fn define(
         "#,
             &formats.exception_handler_address,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("block", &entities.raw_block),
             Operand::new("index", &imm.imm64),
         ])
-        .operands_out(vec![Operand::new("addr", iAddr)]),
+        .operands_out(&[Operand::new("addr", iAddr)]),
     );
 
     ig.push(
@@ -1354,9 +1342,9 @@ pub(crate) fn define(
         "#,
             &formats.unary_imm,
         )
-        .operands_in(vec![Operand::new("N", &imm.imm64)])
-        .operands_out(vec![
-            Operand::new("a", NarrowInt).with_doc("A constant integer scalar or vector value"),
+        .operands_in(&[Operand::new("N", &imm.imm64)])
+        .operands_out(&[
+            Operand::new("a", NarrowInt).with_doc("A constant integer scalar or vector value")
         ]),
     );
 
@@ -1370,10 +1358,8 @@ pub(crate) fn define(
         "#,
             &formats.unary_ieee16,
         )
-        .operands_in(vec![Operand::new("N", &imm.ieee16)])
-        .operands_out(vec![
-            Operand::new("a", f16_).with_doc("A constant f16 scalar value"),
-        ]),
+        .operands_in(&[Operand::new("N", &imm.ieee16)])
+        .operands_out(&[Operand::new("a", f16_).with_doc("A constant f16 scalar value")]),
     );
 
     ig.push(
@@ -1386,10 +1372,8 @@ pub(crate) fn define(
         "#,
             &formats.unary_ieee32,
         )
-        .operands_in(vec![Operand::new("N", &imm.ieee32)])
-        .operands_out(vec![
-            Operand::new("a", f32_).with_doc("A constant f32 scalar value"),
-        ]),
+        .operands_in(&[Operand::new("N", &imm.ieee32)])
+        .operands_out(&[Operand::new("a", f32_).with_doc("A constant f32 scalar value")]),
     );
 
     ig.push(
@@ -1402,10 +1386,8 @@ pub(crate) fn define(
         "#,
             &formats.unary_ieee64,
         )
-        .operands_in(vec![Operand::new("N", &imm.ieee64)])
-        .operands_out(vec![
-            Operand::new("a", f64_).with_doc("A constant f64 scalar value"),
-        ]),
+        .operands_in(&[Operand::new("N", &imm.ieee64)])
+        .operands_out(&[Operand::new("a", f64_).with_doc("A constant f64 scalar value")]),
     );
 
     ig.push(
@@ -1418,10 +1400,8 @@ pub(crate) fn define(
         "#,
             &formats.unary_const,
         )
-        .operands_in(vec![Operand::new("N", &entities.pool_constant)])
-        .operands_out(vec![
-            Operand::new("a", f128_).with_doc("A constant f128 scalar value"),
-        ]),
+        .operands_in(&[Operand::new("N", &entities.pool_constant)])
+        .operands_out(&[Operand::new("a", f128_).with_doc("A constant f128 scalar value")]),
     );
 
     ig.push(
@@ -1434,13 +1414,9 @@ pub(crate) fn define(
         "#,
             &formats.unary_const,
         )
-        .operands_in(vec![
-            Operand::new("N", &entities.pool_constant)
-                .with_doc("The 16 immediate bytes of a 128-bit vector"),
-        ])
-        .operands_out(vec![
-            Operand::new("a", TxN).with_doc("A constant vector value"),
-        ]),
+        .operands_in(&[Operand::new("N", &entities.pool_constant)
+            .with_doc("The 16 immediate bytes of a 128-bit vector")])
+        .operands_out(&[Operand::new("a", TxN).with_doc("A constant vector value")]),
     );
 
     let Tx16 = &TypeVar::new(
@@ -1467,13 +1443,13 @@ pub(crate) fn define(
         "#,
             &formats.shuffle,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("a", Tx16).with_doc("A vector value"),
             Operand::new("b", Tx16).with_doc("A vector value"),
             Operand::new("mask", &entities.uimm128)
                 .with_doc("The 16 immediate bytes used for selecting the elements to shuffle"),
         ])
-        .operands_out(vec![Operand::new("a", Tx16).with_doc("A vector value")]),
+        .operands_out(&[Operand::new("a", Tx16).with_doc("A vector value")]),
     );
 
     ig.push(Inst::new(
@@ -1497,12 +1473,12 @@ pub(crate) fn define(
         "#,
             &formats.ternary,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("c", ScalarTruthy).with_doc("Controlling value to test"),
             Operand::new("x", Any).with_doc("Value to use when `c` is true"),
             Operand::new("y", Any).with_doc("Value to use when `c` is false"),
         ])
-        .operands_out(vec![Operand::new("a", Any)]),
+        .operands_out(&[Operand::new("a", Any)]),
     );
 
     ig.push(
@@ -1545,12 +1521,12 @@ pub(crate) fn define(
             "#,
             &formats.ternary,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("c", ScalarTruthy).with_doc("Controlling value to test"),
             Operand::new("x", Any).with_doc("Value to use when `c` is true"),
             Operand::new("y", Any).with_doc("Value to use when `c` is false"),
         ])
-        .operands_out(vec![Operand::new("a", Any)]),
+        .operands_out(&[Operand::new("a", Any)]),
     );
 
     ig.push(
@@ -1565,12 +1541,12 @@ pub(crate) fn define(
         "#,
             &formats.ternary,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("c", Any).with_doc("Controlling value to test"),
             Operand::new("x", Any).with_doc("Value to use when `c` is true"),
             Operand::new("y", Any).with_doc("Value to use when `c` is false"),
         ])
-        .operands_out(vec![Operand::new("a", Any)]),
+        .operands_out(&[Operand::new("a", Any)]),
     );
 
     ig.push(
@@ -1587,12 +1563,12 @@ pub(crate) fn define(
             "#,
             &formats.ternary,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("c", Any).with_doc("Controlling value to test"),
             Operand::new("x", Any).with_doc("Value to use when `c` is true"),
             Operand::new("y", Any).with_doc("Value to use when `c` is false"),
         ])
-        .operands_out(vec![Operand::new("a", Any)]),
+        .operands_out(&[Operand::new("a", Any)]),
     );
 
     ig.push(
@@ -1605,8 +1581,8 @@ pub(crate) fn define(
         "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("a", TxN)])
-        .operands_out(vec![Operand::new("s", i8)]),
+        .operands_in(&[Operand::new("a", TxN)])
+        .operands_out(&[Operand::new("s", i8)]),
     );
 
     ig.push(
@@ -1619,8 +1595,8 @@ pub(crate) fn define(
         "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("a", TxN)])
-        .operands_out(vec![Operand::new("s", i8)]),
+        .operands_in(&[Operand::new("a", TxN)])
+        .operands_out(&[Operand::new("s", i8)]),
     );
 
     ig.push(
@@ -1634,8 +1610,8 @@ pub(crate) fn define(
         "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("a", TxN)])
-        .operands_out(vec![Operand::new("x", NarrowInt)]),
+        .operands_in(&[Operand::new("a", TxN)])
+        .operands_out(&[Operand::new("x", NarrowInt)]),
     );
 
     ig.push(
@@ -1669,12 +1645,12 @@ pub(crate) fn define(
         "#,
             &formats.int_compare,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("Cond", &imm.intcc),
             Operand::new("x", Int),
             Operand::new("y", Int),
         ])
-        .operands_out(vec![Operand::new("a", &Int.as_truthy())])
+        .operands_out(&[Operand::new("a", &Int.as_truthy())])
         .inst_builder_imm_method(true),
     );
 
@@ -1689,8 +1665,8 @@ pub(crate) fn define(
         "#,
             &formats.binary,
         )
-        .operands_in(vec![Operand::new("x", Int), Operand::new("y", Int)])
-        .operands_out(vec![Operand::new("a", Int)])
+        .operands_in(&[Operand::new("x", Int), Operand::new("y", Int)])
+        .operands_out(&[Operand::new("a", Int)])
         .inst_builder_imm_method(true),
     );
 
@@ -1705,8 +1681,8 @@ pub(crate) fn define(
         "#,
             &formats.binary,
         )
-        .operands_in(vec![Operand::new("x", Int), Operand::new("y", Int)])
-        .operands_out(vec![Operand::new("a", Int)]),
+        .operands_in(&[Operand::new("x", Int), Operand::new("y", Int)])
+        .operands_out(&[Operand::new("a", Int)]),
     );
 
     ig.push(
@@ -1717,8 +1693,8 @@ pub(crate) fn define(
         "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("x", Int)])
-        .operands_out(vec![Operand::new("a", Int)]),
+        .operands_in(&[Operand::new("x", Int)])
+        .operands_out(&[Operand::new("a", Int)]),
     );
 
     ig.push(
@@ -1729,8 +1705,8 @@ pub(crate) fn define(
         "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("x", Int)])
-        .operands_out(vec![Operand::new("a", Int)]),
+        .operands_in(&[Operand::new("x", Int)])
+        .operands_out(&[Operand::new("a", Int)]),
     );
 
     ig.push(
@@ -1746,8 +1722,8 @@ pub(crate) fn define(
         "#,
             &formats.binary,
         )
-        .operands_in(vec![Operand::new("x", Int), Operand::new("y", Int)])
-        .operands_out(vec![Operand::new("a", Int)])
+        .operands_in(&[Operand::new("x", Int), Operand::new("y", Int)])
+        .operands_out(&[Operand::new("a", Int)])
         .inst_builder_imm_method(true),
     );
 
@@ -1762,8 +1738,8 @@ pub(crate) fn define(
         "#,
             &formats.binary,
         )
-        .operands_in(vec![Operand::new("x", Int), Operand::new("y", Int)])
-        .operands_out(vec![Operand::new("a", Int)]),
+        .operands_in(&[Operand::new("x", Int), Operand::new("y", Int)])
+        .operands_out(&[Operand::new("a", Int)]),
     );
 
     ig.push(
@@ -1777,8 +1753,8 @@ pub(crate) fn define(
         "#,
             &formats.binary,
         )
-        .operands_in(vec![Operand::new("x", Int), Operand::new("y", Int)])
-        .operands_out(vec![Operand::new("a", Int)]),
+        .operands_in(&[Operand::new("x", Int), Operand::new("y", Int)])
+        .operands_out(&[Operand::new("a", Int)]),
     );
 
     let I16or32 = &TypeVar::new(
@@ -1799,8 +1775,8 @@ pub(crate) fn define(
         "#,
             &formats.binary,
         )
-        .operands_in(vec![Operand::new("x", I16or32), Operand::new("y", I16or32)])
-        .operands_out(vec![Operand::new("a", I16or32)]),
+        .operands_in(&[Operand::new("x", I16or32), Operand::new("y", I16or32)])
+        .operands_out(&[Operand::new("a", I16or32)]),
     );
 
     ig.push(
@@ -1815,8 +1791,8 @@ pub(crate) fn define(
         "#,
             &formats.binary,
         )
-        .operands_in(vec![Operand::new("x", I16or32), Operand::new("y", I16or32)])
-        .operands_out(vec![Operand::new("a", I16or32)]),
+        .operands_in(&[Operand::new("x", I16or32), Operand::new("y", I16or32)])
+        .operands_out(&[Operand::new("a", I16or32)]),
     );
 
     // Integer division and remainder are scalar-only; most
@@ -1832,8 +1808,8 @@ pub(crate) fn define(
         "#,
             &formats.binary,
         )
-        .operands_in(vec![Operand::new("x", iB), Operand::new("y", iB)])
-        .operands_out(vec![Operand::new("a", iB)])
+        .operands_in(&[Operand::new("x", iB), Operand::new("y", iB)])
+        .operands_out(&[Operand::new("a", iB)])
         .can_trap()
         .side_effects_idempotent()
         .inst_builder_imm_method(true),
@@ -1852,8 +1828,8 @@ pub(crate) fn define(
         "#,
             &formats.binary,
         )
-        .operands_in(vec![Operand::new("x", iB), Operand::new("y", iB)])
-        .operands_out(vec![Operand::new("a", iB)])
+        .operands_in(&[Operand::new("x", iB), Operand::new("y", iB)])
+        .operands_out(&[Operand::new("a", iB)])
         .can_trap()
         .side_effects_idempotent()
         .inst_builder_imm_method(true),
@@ -1869,8 +1845,8 @@ pub(crate) fn define(
         "#,
             &formats.binary,
         )
-        .operands_in(vec![Operand::new("x", iB), Operand::new("y", iB)])
-        .operands_out(vec![Operand::new("a", iB)])
+        .operands_in(&[Operand::new("x", iB), Operand::new("y", iB)])
+        .operands_out(&[Operand::new("a", iB)])
         .can_trap()
         .side_effects_idempotent()
         .inst_builder_imm_method(true),
@@ -1886,8 +1862,8 @@ pub(crate) fn define(
         "#,
             &formats.binary,
         )
-        .operands_in(vec![Operand::new("x", iB), Operand::new("y", iB)])
-        .operands_out(vec![Operand::new("a", iB)])
+        .operands_in(&[Operand::new("x", iB), Operand::new("y", iB)])
+        .operands_out(&[Operand::new("a", iB)])
         .can_trap()
         .side_effects_idempotent()
         .inst_builder_imm_method(true),
@@ -1904,12 +1880,12 @@ pub(crate) fn define(
         "#,
             &formats.ternary,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("x", iB),
             Operand::new("y", iB),
             Operand::new("c_in", i8).with_doc("Input carry flag"),
         ])
-        .operands_out(vec![
+        .operands_out(&[
             Operand::new("a", iB),
             Operand::new("c_out", i8).with_doc("Output carry flag"),
         ]),
@@ -1926,12 +1902,12 @@ pub(crate) fn define(
         "#,
             &formats.ternary,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("x", iB),
             Operand::new("y", iB),
             Operand::new("c_in", i8).with_doc("Input carry flag"),
         ])
-        .operands_out(vec![
+        .operands_out(&[
             Operand::new("a", iB),
             Operand::new("c_out", i8).with_doc("Output carry flag"),
         ]),
@@ -1954,8 +1930,8 @@ pub(crate) fn define(
             "#,
                 &formats.binary,
             )
-            .operands_in(vec![Operand::new("x", iB), Operand::new("y", iB)])
-            .operands_out(vec![Operand::new("a", iB), of_out.clone()]),
+            .operands_in(&[Operand::new("x", iB), Operand::new("y", iB)])
+            .operands_out(&[Operand::new("a", iB), of_out.clone()]),
         );
 
         ig.push(
@@ -1969,8 +1945,8 @@ pub(crate) fn define(
             "#,
                 &formats.binary,
             )
-            .operands_in(vec![Operand::new("x", iB), Operand::new("y", iB)])
-            .operands_out(vec![Operand::new("a", iB), of_out.clone()]),
+            .operands_in(&[Operand::new("x", iB), Operand::new("y", iB)])
+            .operands_out(&[Operand::new("a", iB), of_out.clone()]),
         );
 
         ig.push(
@@ -1988,8 +1964,8 @@ pub(crate) fn define(
             "#,
                 &formats.binary,
             )
-            .operands_in(vec![Operand::new("x", iB), Operand::new("y", iB)])
-            .operands_out(vec![Operand::new("a", iB), of_out.clone()]),
+            .operands_in(&[Operand::new("x", iB), Operand::new("y", iB)])
+            .operands_out(&[Operand::new("a", iB), of_out.clone()]),
         );
 
         ig.push(
@@ -2003,8 +1979,8 @@ pub(crate) fn define(
             "#,
                 &formats.binary,
             )
-            .operands_in(vec![Operand::new("x", iB), Operand::new("y", iB)])
-            .operands_out(vec![Operand::new("a", iB), of_out.clone()]),
+            .operands_in(&[Operand::new("x", iB), Operand::new("y", iB)])
+            .operands_out(&[Operand::new("a", iB), of_out.clone()]),
         );
 
         {
@@ -2029,11 +2005,11 @@ pub(crate) fn define(
                 "#,
                     &formats.binary,
                 )
-                .operands_in(vec![
+                .operands_in(&[
                     Operand::new("x", NarrowScalar),
                     Operand::new("y", NarrowScalar),
                 ])
-                .operands_out(vec![Operand::new("a", NarrowScalar), of_out.clone()]),
+                .operands_out(&[Operand::new("a", NarrowScalar), of_out.clone()]),
             );
 
             ig.push(
@@ -2047,11 +2023,11 @@ pub(crate) fn define(
                 "#,
                     &formats.binary,
                 )
-                .operands_in(vec![
+                .operands_in(&[
                     Operand::new("x", NarrowScalar),
                     Operand::new("y", NarrowScalar),
                 ])
-                .operands_out(vec![Operand::new("a", NarrowScalar), of_out.clone()]),
+                .operands_out(&[Operand::new("a", NarrowScalar), of_out.clone()]),
             );
         }
     }
@@ -2072,12 +2048,12 @@ pub(crate) fn define(
         "#,
             &formats.int_add_trap,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("x", i32_64),
             Operand::new("y", i32_64),
             Operand::new("code", &imm.trapcode),
         ])
-        .operands_out(vec![Operand::new("a", i32_64)])
+        .operands_out(&[Operand::new("a", i32_64)])
         .can_trap()
         .side_effects_idempotent(),
     );
@@ -2094,12 +2070,12 @@ pub(crate) fn define(
         "#,
             &formats.ternary,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("x", iB),
             Operand::new("y", iB),
             Operand::new("b_in", i8).with_doc("Input borrow flag"),
         ])
-        .operands_out(vec![
+        .operands_out(&[
             Operand::new("a", iB),
             Operand::new("b_out", i8).with_doc("Output borrow flag"),
         ]),
@@ -2117,12 +2093,12 @@ pub(crate) fn define(
         "#,
             &formats.ternary,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("x", iB),
             Operand::new("y", iB),
             Operand::new("b_in", i8).with_doc("Input borrow flag"),
         ])
-        .operands_out(vec![
+        .operands_out(&[
             Operand::new("a", iB),
             Operand::new("b_out", i8).with_doc("Output borrow flag"),
         ]),
@@ -2147,8 +2123,8 @@ pub(crate) fn define(
         "#,
             &formats.binary,
         )
-        .operands_in(vec![Operand::new("x", bits), Operand::new("y", bits)])
-        .operands_out(vec![Operand::new("a", bits)])
+        .operands_in(&[Operand::new("x", bits), Operand::new("y", bits)])
+        .operands_out(&[Operand::new("a", bits)])
         .inst_builder_imm_method(true),
     );
 
@@ -2160,8 +2136,8 @@ pub(crate) fn define(
         "#,
             &formats.binary,
         )
-        .operands_in(vec![Operand::new("x", bits), Operand::new("y", bits)])
-        .operands_out(vec![Operand::new("a", bits)])
+        .operands_in(&[Operand::new("x", bits), Operand::new("y", bits)])
+        .operands_out(&[Operand::new("a", bits)])
         .inst_builder_imm_method(true),
     );
 
@@ -2173,8 +2149,8 @@ pub(crate) fn define(
         "#,
             &formats.binary,
         )
-        .operands_in(vec![Operand::new("x", bits), Operand::new("y", bits)])
-        .operands_out(vec![Operand::new("a", bits)])
+        .operands_in(&[Operand::new("x", bits), Operand::new("y", bits)])
+        .operands_out(&[Operand::new("a", bits)])
         .inst_builder_imm_method(true),
     );
 
@@ -2186,8 +2162,8 @@ pub(crate) fn define(
         "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("x", bits)])
-        .operands_out(vec![Operand::new("a", bits)]),
+        .operands_in(&[Operand::new("x", bits)])
+        .operands_out(&[Operand::new("a", bits)]),
     );
 
     ig.push(
@@ -2200,11 +2176,11 @@ pub(crate) fn define(
         "#,
             &formats.binary,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("x", Int).with_doc("Scalar or vector value to shift"),
             Operand::new("y", iB).with_doc("Number of bits to shift"),
         ])
-        .operands_out(vec![Operand::new("a", Int)])
+        .operands_out(&[Operand::new("a", Int)])
         .inst_builder_imm_method(true),
     );
 
@@ -2218,11 +2194,11 @@ pub(crate) fn define(
         "#,
             &formats.binary,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("x", Int).with_doc("Scalar or vector value to shift"),
             Operand::new("y", iB).with_doc("Number of bits to shift"),
         ])
-        .operands_out(vec![Operand::new("a", Int)])
+        .operands_out(&[Operand::new("a", Int)])
         .inst_builder_imm_method(true),
     );
 
@@ -2244,11 +2220,11 @@ pub(crate) fn define(
         "#,
             &formats.binary,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("x", Int).with_doc("Scalar or vector value to shift"),
             Operand::new("y", iB).with_doc("Number of bits to shift"),
         ])
-        .operands_out(vec![Operand::new("a", Int)])
+        .operands_out(&[Operand::new("a", Int)])
         .inst_builder_imm_method(true),
     );
 
@@ -2271,11 +2247,11 @@ pub(crate) fn define(
         "#,
             &formats.binary,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("x", Int).with_doc("Scalar or vector value to shift"),
             Operand::new("y", iB).with_doc("Number of bits to shift"),
         ])
-        .operands_out(vec![Operand::new("a", Int)])
+        .operands_out(&[Operand::new("a", Int)])
         .inst_builder_imm_method(true),
     );
 
@@ -2291,11 +2267,11 @@ pub(crate) fn define(
         "#,
             &formats.binary,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("x", Int).with_doc("Scalar or vector value to shift"),
             Operand::new("y", iB).with_doc("Number of bits to shift"),
         ])
-        .operands_out(vec![Operand::new("a", Int)])
+        .operands_out(&[Operand::new("a", Int)])
         .inst_builder_imm_method(true),
     );
 
@@ -2309,8 +2285,8 @@ pub(crate) fn define(
         "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("x", iB)])
-        .operands_out(vec![Operand::new("a", iB)]),
+        .operands_in(&[Operand::new("x", iB)])
+        .operands_out(&[Operand::new("a", iB)]),
     );
 
     ig.push(
@@ -2325,8 +2301,8 @@ pub(crate) fn define(
         "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("x", iB)])
-        .operands_out(vec![Operand::new("a", iB)]),
+        .operands_in(&[Operand::new("x", iB)])
+        .operands_out(&[Operand::new("a", iB)]),
     );
 
     ig.push(
@@ -2341,8 +2317,8 @@ pub(crate) fn define(
         "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("x", iB)])
-        .operands_out(vec![Operand::new("a", iB)]),
+        .operands_in(&[Operand::new("x", iB)])
+        .operands_out(&[Operand::new("a", iB)]),
     );
 
     ig.push(
@@ -2357,8 +2333,8 @@ pub(crate) fn define(
         "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("x", iB)])
-        .operands_out(vec![Operand::new("a", iB)]),
+        .operands_in(&[Operand::new("x", iB)])
+        .operands_out(&[Operand::new("a", iB)]),
     );
 
     ig.push(
@@ -2371,8 +2347,8 @@ pub(crate) fn define(
         "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("x", iSwappable)])
-        .operands_out(vec![Operand::new("a", iSwappable)]),
+        .operands_in(&[Operand::new("x", iSwappable)])
+        .operands_out(&[Operand::new("a", iSwappable)]),
     );
 
     ig.push(
@@ -2385,8 +2361,8 @@ pub(crate) fn define(
         "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("x", Int)])
-        .operands_out(vec![Operand::new("a", Int)]),
+        .operands_in(&[Operand::new("x", Int)])
+        .operands_out(&[Operand::new("a", Int)]),
     );
 
     let Float = &TypeVar::new(
@@ -2479,12 +2455,12 @@ pub(crate) fn define(
         "#,
             &formats.float_compare,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("Cond", &imm.floatcc),
             Operand::new("x", Float),
             Operand::new("y", Float),
         ])
-        .operands_out(vec![Operand::new("a", &Float.as_truthy())]),
+        .operands_out(&[Operand::new("a", &Float.as_truthy())]),
     );
 
     ig.push(
@@ -2495,9 +2471,9 @@ pub(crate) fn define(
         "#,
             &formats.binary,
         )
-        .operands_in(vec![Operand::new("x", Float), Operand::new("y", Float)])
-        .operands_out(vec![
-            Operand::new("a", Float).with_doc("Result of applying operator to each lane"),
+        .operands_in(&[Operand::new("x", Float), Operand::new("y", Float)])
+        .operands_out(&[
+            Operand::new("a", Float).with_doc("Result of applying operator to each lane")
         ]),
     );
 
@@ -2509,9 +2485,9 @@ pub(crate) fn define(
         "#,
             &formats.binary,
         )
-        .operands_in(vec![Operand::new("x", Float), Operand::new("y", Float)])
-        .operands_out(vec![
-            Operand::new("a", Float).with_doc("Result of applying operator to each lane"),
+        .operands_in(&[Operand::new("x", Float), Operand::new("y", Float)])
+        .operands_out(&[
+            Operand::new("a", Float).with_doc("Result of applying operator to each lane")
         ]),
     );
 
@@ -2523,9 +2499,9 @@ pub(crate) fn define(
         "#,
             &formats.binary,
         )
-        .operands_in(vec![Operand::new("x", Float), Operand::new("y", Float)])
-        .operands_out(vec![
-            Operand::new("a", Float).with_doc("Result of applying operator to each lane"),
+        .operands_in(&[Operand::new("x", Float), Operand::new("y", Float)])
+        .operands_out(&[
+            Operand::new("a", Float).with_doc("Result of applying operator to each lane")
         ]),
     );
 
@@ -2541,9 +2517,9 @@ pub(crate) fn define(
         "#,
             &formats.binary,
         )
-        .operands_in(vec![Operand::new("x", Float), Operand::new("y", Float)])
-        .operands_out(vec![
-            Operand::new("a", Float).with_doc("Result of applying operator to each lane"),
+        .operands_in(&[Operand::new("x", Float), Operand::new("y", Float)])
+        .operands_out(&[
+            Operand::new("a", Float).with_doc("Result of applying operator to each lane")
         ]),
     );
 
@@ -2555,9 +2531,9 @@ pub(crate) fn define(
         "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("x", Float)])
-        .operands_out(vec![
-            Operand::new("a", Float).with_doc("Result of applying operator to each lane"),
+        .operands_in(&[Operand::new("x", Float)])
+        .operands_out(&[
+            Operand::new("a", Float).with_doc("Result of applying operator to each lane")
         ]),
     );
 
@@ -2572,13 +2548,13 @@ pub(crate) fn define(
         "#,
             &formats.ternary,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("x", Float),
             Operand::new("y", Float),
             Operand::new("z", Float),
         ])
-        .operands_out(vec![
-            Operand::new("a", Float).with_doc("Result of applying operator to each lane"),
+        .operands_out(&[
+            Operand::new("a", Float).with_doc("Result of applying operator to each lane")
         ]),
     );
 
@@ -2592,10 +2568,8 @@ pub(crate) fn define(
         "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("x", Float)])
-        .operands_out(vec![
-            Operand::new("a", Float).with_doc("``x`` with its sign bit inverted"),
-        ]),
+        .operands_in(&[Operand::new("x", Float)])
+        .operands_out(&[Operand::new("a", Float).with_doc("``x`` with its sign bit inverted")]),
     );
 
     ig.push(
@@ -2608,10 +2582,8 @@ pub(crate) fn define(
         "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("x", Float)])
-        .operands_out(vec![
-            Operand::new("a", Float).with_doc("``x`` with its sign bit cleared"),
-        ]),
+        .operands_in(&[Operand::new("x", Float)])
+        .operands_out(&[Operand::new("a", Float).with_doc("``x`` with its sign bit cleared")]),
     );
 
     ig.push(
@@ -2625,9 +2597,9 @@ pub(crate) fn define(
         "#,
             &formats.binary,
         )
-        .operands_in(vec![Operand::new("x", Float), Operand::new("y", Float)])
-        .operands_out(vec![
-            Operand::new("a", Float).with_doc("``x`` with its sign bit changed to that of ``y``"),
+        .operands_in(&[Operand::new("x", Float), Operand::new("y", Float)])
+        .operands_out(&[
+            Operand::new("a", Float).with_doc("``x`` with its sign bit changed to that of ``y``")
         ]),
     );
 
@@ -2644,10 +2616,8 @@ pub(crate) fn define(
         "#,
             &formats.binary,
         )
-        .operands_in(vec![Operand::new("x", Float), Operand::new("y", Float)])
-        .operands_out(vec![
-            Operand::new("a", Float).with_doc("The smaller of ``x`` and ``y``"),
-        ]),
+        .operands_in(&[Operand::new("x", Float), Operand::new("y", Float)])
+        .operands_out(&[Operand::new("a", Float).with_doc("The smaller of ``x`` and ``y``")]),
     );
 
     ig.push(
@@ -2663,10 +2633,8 @@ pub(crate) fn define(
         "#,
             &formats.binary,
         )
-        .operands_in(vec![Operand::new("x", Float), Operand::new("y", Float)])
-        .operands_out(vec![
-            Operand::new("a", Float).with_doc("The larger of ``x`` and ``y``"),
-        ]),
+        .operands_in(&[Operand::new("x", Float), Operand::new("y", Float)])
+        .operands_out(&[Operand::new("a", Float).with_doc("The larger of ``x`` and ``y``")]),
     );
 
     ig.push(
@@ -2677,10 +2645,8 @@ pub(crate) fn define(
         "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("x", Float)])
-        .operands_out(vec![
-            Operand::new("a", Float).with_doc("``x`` rounded to integral value"),
-        ]),
+        .operands_in(&[Operand::new("x", Float)])
+        .operands_out(&[Operand::new("a", Float).with_doc("``x`` rounded to integral value")]),
     );
 
     ig.push(
@@ -2691,10 +2657,8 @@ pub(crate) fn define(
         "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("x", Float)])
-        .operands_out(vec![
-            Operand::new("a", Float).with_doc("``x`` rounded to integral value"),
-        ]),
+        .operands_in(&[Operand::new("x", Float)])
+        .operands_out(&[Operand::new("a", Float).with_doc("``x`` rounded to integral value")]),
     );
 
     ig.push(
@@ -2705,10 +2669,8 @@ pub(crate) fn define(
         "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("x", Float)])
-        .operands_out(vec![
-            Operand::new("a", Float).with_doc("``x`` rounded to integral value"),
-        ]),
+        .operands_in(&[Operand::new("x", Float)])
+        .operands_out(&[Operand::new("a", Float).with_doc("``x`` rounded to integral value")]),
     );
 
     ig.push(
@@ -2720,10 +2682,8 @@ pub(crate) fn define(
         "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("x", Float)])
-        .operands_out(vec![
-            Operand::new("a", Float).with_doc("``x`` rounded to integral value"),
-        ]),
+        .operands_in(&[Operand::new("x", Float)])
+        .operands_out(&[Operand::new("a", Float).with_doc("``x`` rounded to integral value")]),
     );
 
     ig.push(
@@ -2743,13 +2703,11 @@ pub(crate) fn define(
         "#,
             &formats.load_no_offset,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("MemFlags", &imm.memflags),
             Operand::new("x", Mem),
         ])
-        .operands_out(vec![
-            Operand::new("a", MemTo).with_doc("Bits of `x` reinterpreted"),
-        ]),
+        .operands_out(&[Operand::new("a", MemTo).with_doc("Bits of `x` reinterpreted")]),
     );
 
     ig.push(
@@ -2761,10 +2719,8 @@ pub(crate) fn define(
             "#,
             &formats.unary,
         )
-        .operands_in(vec![
-            Operand::new("s", &TxN.lane_of()).with_doc("A scalar value"),
-        ])
-        .operands_out(vec![Operand::new("a", TxN).with_doc("A vector value")]),
+        .operands_in(&[Operand::new("s", &TxN.lane_of()).with_doc("A scalar value")])
+        .operands_out(&[Operand::new("a", TxN).with_doc("A vector value")]),
     );
 
     let Truthy = &TypeVar::new(
@@ -2788,8 +2744,8 @@ pub(crate) fn define(
         "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("x", Truthy)])
-        .operands_out(vec![Operand::new("a", IntTo)]),
+        .operands_in(&[Operand::new("x", Truthy)])
+        .operands_out(&[Operand::new("a", IntTo)]),
     );
 
     let Int = &TypeVar::new(
@@ -2809,11 +2765,9 @@ pub(crate) fn define(
         "#,
             &formats.unary,
         )
-        .operands_in(vec![
-            Operand::new("x", &Int.wider())
-                .with_doc("A scalar integer type, wider than the controlling type"),
-        ])
-        .operands_out(vec![Operand::new("a", Int)]),
+        .operands_in(&[Operand::new("x", &Int.wider())
+            .with_doc("A scalar integer type, wider than the controlling type")])
+        .operands_out(&[Operand::new("a", Int)]),
     );
 
     let I16or32or64xN = &TypeVar::new(
@@ -2840,11 +2794,11 @@ pub(crate) fn define(
             "#,
             &formats.binary,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("x", I16or32or64xN),
             Operand::new("y", I16or32or64xN),
         ])
-        .operands_out(vec![Operand::new("a", &I16or32or64xN.split_lanes())]),
+        .operands_out(&[Operand::new("a", &I16or32or64xN.split_lanes())]),
     );
 
     ig.push(
@@ -2863,11 +2817,11 @@ pub(crate) fn define(
             "#,
             &formats.binary,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("x", I16or32or64xN),
             Operand::new("y", I16or32or64xN),
         ])
-        .operands_out(vec![Operand::new("a", &I16or32or64xN.split_lanes())]),
+        .operands_out(&[Operand::new("a", &I16or32or64xN.split_lanes())]),
     );
 
     ig.push(
@@ -2885,8 +2839,8 @@ pub(crate) fn define(
             "#,
             &formats.binary,
         )
-        .operands_in(vec![Operand::new("x", I16or32or64xN), Operand::new("y", I16or32or64xN)])
-        .operands_out(vec![Operand::new("a", &I16or32or64xN.split_lanes())]),
+        .operands_in(&[Operand::new("x", I16or32or64xN), Operand::new("y", I16or32or64xN)])
+        .operands_out(&[Operand::new("a", &I16or32or64xN.split_lanes())]),
     );
 
     let I8or16or32xN = &TypeVar::new(
@@ -2910,8 +2864,8 @@ pub(crate) fn define(
             "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("x", I8or16or32xN)])
-        .operands_out(vec![Operand::new("a", &I8or16or32xN.merge_lanes())]),
+        .operands_in(&[Operand::new("x", I8or16or32xN)])
+        .operands_out(&[Operand::new("a", &I8or16or32xN.merge_lanes())]),
     );
 
     ig.push(
@@ -2924,8 +2878,8 @@ pub(crate) fn define(
             "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("x", I8or16or32xN)])
-        .operands_out(vec![Operand::new("a", &I8or16or32xN.merge_lanes())]),
+        .operands_in(&[Operand::new("x", I8or16or32xN)])
+        .operands_out(&[Operand::new("a", &I8or16or32xN.merge_lanes())]),
     );
 
     ig.push(
@@ -2938,8 +2892,8 @@ pub(crate) fn define(
             "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("x", I8or16or32xN)])
-        .operands_out(vec![Operand::new("a", &I8or16or32xN.merge_lanes())]),
+        .operands_in(&[Operand::new("x", I8or16or32xN)])
+        .operands_out(&[Operand::new("a", &I8or16or32xN.merge_lanes())]),
     );
 
     ig.push(
@@ -2952,8 +2906,8 @@ pub(crate) fn define(
             "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("x", I8or16or32xN)])
-        .operands_out(vec![Operand::new("a", &I8or16or32xN.merge_lanes())]),
+        .operands_in(&[Operand::new("x", I8or16or32xN)])
+        .operands_out(&[Operand::new("a", &I8or16or32xN.merge_lanes())]),
     );
 
     ig.push(
@@ -2969,11 +2923,11 @@ pub(crate) fn define(
             "#,
             &formats.binary,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("x", I8or16or32xN),
             Operand::new("y", I8or16or32xN),
         ])
-        .operands_out(vec![Operand::new("a", I8or16or32xN)]),
+        .operands_out(&[Operand::new("a", I8or16or32xN)]),
     );
 
     let I8x16 = &TypeVar::new(
@@ -2999,8 +2953,8 @@ pub(crate) fn define(
             "#,
             &formats.binary,
         )
-        .operands_in(vec![Operand::new("x", I8x16), Operand::new("y", I8x16)])
-        .operands_out(vec![Operand::new("a", I16x8)]),
+        .operands_in(&[Operand::new("x", I8x16), Operand::new("y", I8x16)])
+        .operands_out(&[Operand::new("a", I16x8)]),
     );
 
     ig.push(
@@ -3019,10 +2973,9 @@ pub(crate) fn define(
         "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("x", &Int.narrower()).with_doc(
-            "A scalar integer type, narrower than the controlling type",
-        )])
-        .operands_out(vec![Operand::new("a", Int)]),
+        .operands_in(&[Operand::new("x", &Int.narrower())
+            .with_doc("A scalar integer type, narrower than the controlling type")])
+        .operands_out(&[Operand::new("a", Int)]),
     );
 
     ig.push(
@@ -3041,10 +2994,9 @@ pub(crate) fn define(
         "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("x", &Int.narrower()).with_doc(
-            "A scalar integer type, narrower than the controlling type",
-        )])
-        .operands_out(vec![Operand::new("a", Int)]),
+        .operands_in(&[Operand::new("x", &Int.narrower())
+            .with_doc("A scalar integer type, narrower than the controlling type")])
+        .operands_out(&[Operand::new("a", Int)]),
     );
 
     let FloatScalar = &TypeVar::new(
@@ -3070,10 +3022,9 @@ pub(crate) fn define(
         "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("x", &FloatScalar.narrower()).with_doc(
-            "A scalar only floating point number, narrower than the controlling type",
-        )])
-        .operands_out(vec![Operand::new("a", FloatScalar)]),
+        .operands_in(&[Operand::new("x", &FloatScalar.narrower())
+            .with_doc("A scalar only floating point number, narrower than the controlling type")])
+        .operands_out(&[Operand::new("a", FloatScalar)]),
     );
 
     ig.push(
@@ -3093,10 +3044,9 @@ pub(crate) fn define(
         "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("x", &FloatScalar.wider()).with_doc(
-            "A scalar only floating point number, wider than the controlling type",
-        )])
-        .operands_out(vec![Operand::new("a", FloatScalar)]),
+        .operands_in(&[Operand::new("x", &FloatScalar.wider())
+            .with_doc("A scalar only floating point number, wider than the controlling type")])
+        .operands_out(&[Operand::new("a", FloatScalar)]),
     );
 
     let F64x2 = &TypeVar::new(
@@ -3137,8 +3087,8 @@ pub(crate) fn define(
                 "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("x", F64x2)])
-        .operands_out(vec![Operand::new("a", F32x4)]),
+        .operands_in(&[Operand::new("x", F64x2)])
+        .operands_out(&[Operand::new("a", F32x4)]),
     );
 
     ig.push(
@@ -3155,8 +3105,8 @@ pub(crate) fn define(
         "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("a", F32x4)])
-        .operands_out(vec![Operand::new("x", F64x2)]),
+        .operands_in(&[Operand::new("a", F32x4)])
+        .operands_out(&[Operand::new("x", F64x2)]),
     );
 
     let IntTo = &TypeVar::new(
@@ -3178,8 +3128,8 @@ pub(crate) fn define(
         "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("x", FloatScalar)])
-        .operands_out(vec![Operand::new("a", IntTo)])
+        .operands_in(&[Operand::new("x", FloatScalar)])
+        .operands_out(&[Operand::new("a", IntTo)])
         .can_trap()
         .side_effects_idempotent(),
     );
@@ -3197,8 +3147,8 @@ pub(crate) fn define(
         "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("x", FloatScalar)])
-        .operands_out(vec![Operand::new("a", IntTo)])
+        .operands_in(&[Operand::new("x", FloatScalar)])
+        .operands_out(&[Operand::new("a", IntTo)])
         .can_trap()
         .side_effects_idempotent(),
     );
@@ -3222,8 +3172,8 @@ pub(crate) fn define(
         "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("x", Float)])
-        .operands_out(vec![Operand::new("a", IntTo)]),
+        .operands_in(&[Operand::new("x", Float)])
+        .operands_out(&[Operand::new("a", IntTo)]),
     );
 
     ig.push(
@@ -3235,8 +3185,8 @@ pub(crate) fn define(
         "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("x", Float)])
-        .operands_out(vec![Operand::new("a", IntTo)]),
+        .operands_in(&[Operand::new("x", Float)])
+        .operands_out(&[Operand::new("a", IntTo)]),
     );
 
     ig.push(
@@ -3249,8 +3199,8 @@ pub(crate) fn define(
         "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("x", Float)])
-        .operands_out(vec![Operand::new("a", IntTo)]),
+        .operands_in(&[Operand::new("x", Float)])
+        .operands_out(&[Operand::new("a", IntTo)]),
     );
 
     let Int = &TypeVar::new(
@@ -3284,8 +3234,8 @@ pub(crate) fn define(
         "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("x", Int)])
-        .operands_out(vec![Operand::new("a", FloatTo)]),
+        .operands_in(&[Operand::new("x", Int)])
+        .operands_out(&[Operand::new("a", FloatTo)]),
     );
 
     ig.push(
@@ -3301,8 +3251,8 @@ pub(crate) fn define(
         "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("x", Int)])
-        .operands_out(vec![Operand::new("a", FloatTo)]),
+        .operands_in(&[Operand::new("x", Int)])
+        .operands_out(&[Operand::new("a", FloatTo)]),
     );
 
     let WideInt = &TypeVar::new(
@@ -3325,8 +3275,8 @@ pub(crate) fn define(
         "#,
             &formats.unary,
         )
-        .operands_in(vec![Operand::new("x", WideInt)])
-        .operands_out(vec![
+        .operands_in(&[Operand::new("x", WideInt)])
+        .operands_out(&[
             Operand::new("lo", &WideInt.half_width()).with_doc("The low bits of `x`"),
             Operand::new("hi", &WideInt.half_width()).with_doc("The high bits of `x`"),
         ]),
@@ -3344,14 +3294,9 @@ pub(crate) fn define(
         "#,
             &formats.binary,
         )
-        .operands_in(vec![
-            Operand::new("lo", NarrowInt),
-            Operand::new("hi", NarrowInt),
-        ])
-        .operands_out(vec![
-            Operand::new("a", &NarrowInt.double_width())
-                .with_doc("The concatenation of `lo` and `hi`"),
-        ]),
+        .operands_in(&[Operand::new("lo", NarrowInt), Operand::new("hi", NarrowInt)])
+        .operands_out(&[Operand::new("a", &NarrowInt.double_width())
+            .with_doc("The concatenation of `lo` and `hi`")]),
     );
 
     // Instructions relating to atomic memory accesses and fences
@@ -3374,15 +3319,13 @@ pub(crate) fn define(
         "#,
             &formats.atomic_rmw,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("MemFlags", &imm.memflags),
             Operand::new("AtomicRmwOp", &imm.atomic_rmw_op),
             Operand::new("p", iAddr),
             Operand::new("x", AtomicMem).with_doc("Value to be atomically stored"),
         ])
-        .operands_out(vec![
-            Operand::new("a", AtomicMem).with_doc("Value atomically loaded"),
-        ])
+        .operands_out(&[Operand::new("a", AtomicMem).with_doc("Value atomically loaded")])
         .can_load()
         .can_store()
         .other_side_effects(),
@@ -3403,15 +3346,13 @@ pub(crate) fn define(
         "#,
             &formats.atomic_cas,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("MemFlags", &imm.memflags),
             Operand::new("p", iAddr),
             Operand::new("e", AtomicMem).with_doc("Expected value in CAS"),
             Operand::new("x", AtomicMem).with_doc("Value to be atomically stored"),
         ])
-        .operands_out(vec![
-            Operand::new("a", AtomicMem).with_doc("Value atomically loaded"),
-        ])
+        .operands_out(&[Operand::new("a", AtomicMem).with_doc("Value atomically loaded")])
         .can_load()
         .can_store()
         .other_side_effects(),
@@ -3431,13 +3372,11 @@ pub(crate) fn define(
         "#,
             &formats.load_no_offset,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("MemFlags", &imm.memflags),
             Operand::new("p", iAddr),
         ])
-        .operands_out(vec![
-            Operand::new("a", AtomicMem).with_doc("Value atomically loaded"),
-        ])
+        .operands_out(&[Operand::new("a", AtomicMem).with_doc("Value atomically loaded")])
         .can_load()
         .other_side_effects(),
     );
@@ -3456,7 +3395,7 @@ pub(crate) fn define(
         "#,
             &formats.store_no_offset,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("MemFlags", &imm.memflags),
             Operand::new("x", AtomicMem).with_doc("Value to be atomically stored"),
             Operand::new("p", iAddr),
@@ -3496,13 +3435,11 @@ pub(crate) fn define(
         "#,
             &formats.binary_imm8,
         )
-        .operands_in(vec![
+        .operands_in(&[
             Operand::new("x", TxN).with_doc("The dynamic vector to extract from"),
             Operand::new("y", &imm.uimm8).with_doc("128-bit vector index"),
         ])
-        .operands_out(vec![
-            Operand::new("a", &TxN.dynamic_to_vector()).with_doc("New fixed vector"),
-        ]),
+        .operands_out(&[Operand::new("a", &TxN.dynamic_to_vector()).with_doc("New fixed vector")]),
     );
 
     ig.push(


### PR DESCRIPTION
change: `-4.2 %` less llvm lines

```
Before:
  Lines                 Copies              Function name
  -----                 ------              -------------
  187113                4294                (TOTAL)
   16739 (8.9%,  8.9%)     1 (0.0%,  0.0%)  cranelift_codegen_meta[5b669ca35bdaf383]::shared::instructions::define
    3772 (2.0%, 11.0%)     1 (0.0%,  0.0%)  <cranelift_codegen_meta[5b669ca35bdaf383]::gen_isle::NumericOp>::ops_for_type


After:
Lines                 Copies              Function name
  -----                 ------              -------------
  179088                4286                (TOTAL)
   10042 (5.6%,  5.6%)     1 (0.0%,  0.0%)  cranelift_codegen_meta[5b669ca35bdaf383]::shared::instructions::define
    3772 (2.1%,  7.7%)     1 (0.0%,  0.0%)  <cranelift_codegen_meta[5b669ca35bdaf383]::gen_isle::NumericOp>::ops_for_type

```