### PR TITLE
debugger: expose shared memories to gdbstub

### DIFF
--- a/crates/debugger/Cargo.toml
+++ b/crates/debugger/Cargo.toml
@@ -12,7 +12,7 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
-wasmtime = { workspace = true, features = ["debug", "std", "async", "component-model", "gc", "gc-drc"] }
+wasmtime = { workspace = true, features = ["debug", "std", "async", "component-model", "gc", "gc-drc", "threads"] }
 wasmtime-wasi = { workspace = true }
 wasmtime-wasi-io = { workspace = true }
 tokio = { workspace = true, features = ["rt", "sync", "macros"] }

--- a/crates/debugger/src/host/api.rs
+++ b/crates/debugger/src/host/api.rs
@@ -7,10 +7,31 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use wasmtime::{
-    Engine, ExnRef, FrameHandle, Func, Global, Instance, Memory, Module, OwnedRooted, Result,
-    Table, Tag, Val, component::Resource, component::ResourceTable,
+    Engine, ExnRef, FrameHandle, Func, Global, Instance, Module, OwnedRooted, Result, Table, Tag,
+    Val, component::Resource, component::ResourceTable,
 };
 use wasmtime_wasi::p2::{DynPollable, Pollable, subscribe};
+
+/// A memory exposed through the debugger API.
+///
+/// The component-level resource is deliberately shared by both kinds of
+/// Wasmtime linear memory. Shared memories use their own host API and do not
+/// belong to a `Store`, unlike ordinary memories.
+#[derive(Clone)]
+pub enum Memory {
+    Unshared(wasmtime::Memory),
+    Shared(wasmtime::SharedMemory),
+}
+
+impl Memory {
+    fn unique_id(&self) -> u64 {
+        match self {
+            Memory::Unshared(memory) => memory.debug_index_in_store(),
+            // A shared memory's base address is stable for its lifetime.
+            Memory::Shared(memory) => memory.data().as_ptr() as usize as u64,
+        }
+    }
+}
 
 /// Representation of one debuggee: a store with debugged code inside,
 /// under the control of the debugger.
@@ -446,7 +467,7 @@ impl wit::HostModule for ResourceTable {
 
 impl wit::HostMemory for ResourceTable {
     async fn size_bytes(&mut self, self_: Resource<Memory>, d: Resource<Debuggee>) -> Result<u64> {
-        let memory = *self.get(&self_)?;
+        let memory = self.get(&self_)?.clone();
         let d = debugger(self, &d)?;
         d.memory_size_bytes(memory).await
     }
@@ -456,7 +477,7 @@ impl wit::HostMemory for ResourceTable {
         self_: Resource<Memory>,
         d: Resource<Debuggee>,
     ) -> Result<u64> {
-        let memory = *self.get(&self_)?;
+        let memory = self.get(&self_)?.clone();
         let d = debugger(self, &d)?;
         d.memory_page_size(memory).await
     }
@@ -467,7 +488,7 @@ impl wit::HostMemory for ResourceTable {
         d: Resource<Debuggee>,
         delta_bytes: u64,
     ) -> Result<u64> {
-        let memory = *self.get(&self_)?;
+        let memory = self.get(&self_)?.clone();
         let d = debugger(self, &d)?;
         d.memory_grow(memory, delta_bytes).await
     }
@@ -479,7 +500,7 @@ impl wit::HostMemory for ResourceTable {
         addr: u64,
         len: u64,
     ) -> Result<Vec<u8>> {
-        let memory = *self.get(&self_)?;
+        let memory = self.get(&self_)?.clone();
         let d = debugger(self, &d)?;
         Ok(d.memory_read_bytes(memory, addr, len)
             .await?
@@ -493,7 +514,7 @@ impl wit::HostMemory for ResourceTable {
         addr: u64,
         bytes: Vec<u8>,
     ) -> Result<()> {
-        let memory = *self.get(&self_)?;
+        let memory = self.get(&self_)?.clone();
         let d = debugger(self, &d)?;
         d.memory_write_bytes(memory, addr, bytes)
             .await?
@@ -507,7 +528,7 @@ impl wit::HostMemory for ResourceTable {
         d: Resource<Debuggee>,
         addr: u64,
     ) -> Result<u8> {
-        let memory = *self.get(&self_)?;
+        let memory = self.get(&self_)?.clone();
         let d = debugger(self, &d)?;
         Ok(d.memory_read_u8(memory, addr)
             .await?
@@ -520,7 +541,7 @@ impl wit::HostMemory for ResourceTable {
         d: Resource<Debuggee>,
         addr: u64,
     ) -> Result<u16> {
-        let memory = *self.get(&self_)?;
+        let memory = self.get(&self_)?.clone();
         let d = debugger(self, &d)?;
         Ok(d.memory_read_u16(memory, addr)
             .await?
@@ -533,7 +554,7 @@ impl wit::HostMemory for ResourceTable {
         d: Resource<Debuggee>,
         addr: u64,
     ) -> Result<u32> {
-        let memory = *self.get(&self_)?;
+        let memory = self.get(&self_)?.clone();
         let d = debugger(self, &d)?;
         Ok(d.memory_read_u32(memory, addr)
             .await?
@@ -546,7 +567,7 @@ impl wit::HostMemory for ResourceTable {
         d: Resource<Debuggee>,
         addr: u64,
     ) -> Result<u64> {
-        let memory = *self.get(&self_)?;
+        let memory = self.get(&self_)?.clone();
         let d = debugger(self, &d)?;
         Ok(d.memory_read_u64(memory, addr)
             .await?
@@ -560,7 +581,7 @@ impl wit::HostMemory for ResourceTable {
         addr: u64,
         value: u8,
     ) -> Result<()> {
-        let memory = *self.get(&self_)?;
+        let memory = self.get(&self_)?.clone();
         let d = debugger(self, &d)?;
         d.memory_write_u8(memory, addr, value)
             .await?
@@ -575,7 +596,7 @@ impl wit::HostMemory for ResourceTable {
         addr: u64,
         value: u16,
     ) -> Result<()> {
-        let memory = *self.get(&self_)?;
+        let memory = self.get(&self_)?.clone();
         let d = debugger(self, &d)?;
         d.memory_write_u16(memory, addr, value)
             .await?
@@ -590,7 +611,7 @@ impl wit::HostMemory for ResourceTable {
         addr: u64,
         value: u32,
     ) -> Result<()> {
-        let memory = *self.get(&self_)?;
+        let memory = self.get(&self_)?.clone();
         let d = debugger(self, &d)?;
         d.memory_write_u32(memory, addr, value)
             .await?
@@ -605,7 +626,7 @@ impl wit::HostMemory for ResourceTable {
         addr: u64,
         value: u64,
     ) -> Result<()> {
-        let memory = *self.get(&self_)?;
+        let memory = self.get(&self_)?.clone();
         let d = debugger(self, &d)?;
         d.memory_write_u64(memory, addr, value)
             .await?
@@ -614,12 +635,12 @@ impl wit::HostMemory for ResourceTable {
     }
 
     async fn clone(&mut self, self_: Resource<Memory>) -> Result<Resource<Memory>> {
-        let memory = *self.get(&self_)?;
+        let memory = self.get(&self_)?.clone();
         Ok(self.push(memory)?)
     }
 
     async fn unique_id(&mut self, self_: Resource<Memory>) -> Result<u64> {
-        Ok(self.get(&self_)?.debug_index_in_store())
+        Ok(self.get(&self_)?.unique_id())
     }
 
     async fn drop(&mut self, rep: Resource<Memory>) -> Result<()> {
@@ -1047,5 +1068,88 @@ impl wit::HostWasmValue for ResourceTable {
 impl wit::Host for ResourceTable {
     fn convert_error(&mut self, err: wasmtime::Error) -> Result<wit::Error> {
         err.downcast()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::host::add_debuggee;
+    use wasmtime::{Config, Engine, Instance, Module, Store};
+
+    #[cfg_attr(miri, ignore)]
+    #[cfg(target_pointer_width = "64")]
+    #[tokio::test]
+    async fn shared_memory_is_exposed_to_debugger() -> wasmtime::Result<()> {
+        let mut config = Config::new();
+        config.wasm_threads(true);
+        config.shared_memory(true);
+        config.guest_debug(true);
+        let engine = Engine::new(&config)?;
+        let module = Module::new(&engine, r#"(module (memory (export "memory") 1 2 shared))"#)?;
+        let mut store = Store::new(&engine, ());
+        let instance = Instance::new_async(&mut store, &module, &[]).await?;
+
+        let debuggee = crate::Debuggee::new(store, |_store| Box::pin(async { Ok(()) }));
+        let mut table = ResourceTable::new();
+        let debuggee = add_debuggee(&mut table, debuggee)?;
+        let instance = table.push(instance)?;
+        let memory = <ResourceTable as wit::HostInstance>::get_memory(
+            &mut table,
+            instance,
+            Resource::new_borrow(debuggee.rep()),
+            0,
+        )
+        .await?;
+        let size = <ResourceTable as wit::HostMemory>::size_bytes(
+            &mut table,
+            Resource::new_borrow(memory.rep()),
+            Resource::new_borrow(debuggee.rep()),
+        )
+        .await?;
+        assert_eq!(size, 65536);
+
+        let page_size = <ResourceTable as wit::HostMemory>::page_size_bytes(
+            &mut table,
+            Resource::new_borrow(memory.rep()),
+            Resource::new_borrow(debuggee.rep()),
+        )
+        .await?;
+        assert_eq!(page_size, 65536);
+        let old_size = <ResourceTable as wit::HostMemory>::grow_to_bytes(
+            &mut table,
+            Resource::new_borrow(memory.rep()),
+            Resource::new_borrow(debuggee.rep()),
+            page_size,
+        )
+        .await?;
+        assert_eq!(old_size, size);
+        let size = <ResourceTable as wit::HostMemory>::size_bytes(
+            &mut table,
+            Resource::new_borrow(memory.rep()),
+            Resource::new_borrow(debuggee.rep()),
+        )
+        .await?;
+        assert_eq!(size, 2 * page_size);
+
+        <ResourceTable as wit::HostMemory>::set_u32(
+            &mut table,
+            Resource::new_borrow(memory.rep()),
+            Resource::new_borrow(debuggee.rep()),
+            0,
+            0x1234_5678,
+        )
+        .await?;
+        let value = <ResourceTable as wit::HostMemory>::get_u32(
+            &mut table,
+            Resource::new_borrow(memory.rep()),
+            Resource::new_borrow(debuggee.rep()),
+            0,
+        )
+        .await?;
+        assert_eq!(value, 0x1234_5678);
+
+        <ResourceTable as wit::HostDebuggee>::drop(&mut table, debuggee).await?;
+        Ok(())
     }
 }

--- a/crates/debugger/src/host/api.rs
+++ b/crates/debugger/src/host/api.rs
@@ -27,8 +27,7 @@ impl Memory {
     fn unique_id(&self) -> u64 {
         match self {
             Memory::Unshared(memory) => memory.debug_index_in_store(),
-            // A shared memory's base address is stable for its lifetime.
-            Memory::Shared(memory) => memory.data().as_ptr() as usize as u64,
+            Memory::Shared(memory) => memory.debug_index_in_store(),
         }
     }
 }
@@ -1068,88 +1067,5 @@ impl wit::HostWasmValue for ResourceTable {
 impl wit::Host for ResourceTable {
     fn convert_error(&mut self, err: wasmtime::Error) -> Result<wit::Error> {
         err.downcast()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::host::add_debuggee;
-    use wasmtime::{Config, Engine, Instance, Module, Store};
-
-    #[cfg_attr(miri, ignore)]
-    #[cfg(target_pointer_width = "64")]
-    #[tokio::test]
-    async fn shared_memory_is_exposed_to_debugger() -> wasmtime::Result<()> {
-        let mut config = Config::new();
-        config.wasm_threads(true);
-        config.shared_memory(true);
-        config.guest_debug(true);
-        let engine = Engine::new(&config)?;
-        let module = Module::new(&engine, r#"(module (memory (export "memory") 1 2 shared))"#)?;
-        let mut store = Store::new(&engine, ());
-        let instance = Instance::new_async(&mut store, &module, &[]).await?;
-
-        let debuggee = crate::Debuggee::new(store, |_store| Box::pin(async { Ok(()) }));
-        let mut table = ResourceTable::new();
-        let debuggee = add_debuggee(&mut table, debuggee)?;
-        let instance = table.push(instance)?;
-        let memory = <ResourceTable as wit::HostInstance>::get_memory(
-            &mut table,
-            instance,
-            Resource::new_borrow(debuggee.rep()),
-            0,
-        )
-        .await?;
-        let size = <ResourceTable as wit::HostMemory>::size_bytes(
-            &mut table,
-            Resource::new_borrow(memory.rep()),
-            Resource::new_borrow(debuggee.rep()),
-        )
-        .await?;
-        assert_eq!(size, 65536);
-
-        let page_size = <ResourceTable as wit::HostMemory>::page_size_bytes(
-            &mut table,
-            Resource::new_borrow(memory.rep()),
-            Resource::new_borrow(debuggee.rep()),
-        )
-        .await?;
-        assert_eq!(page_size, 65536);
-        let old_size = <ResourceTable as wit::HostMemory>::grow_to_bytes(
-            &mut table,
-            Resource::new_borrow(memory.rep()),
-            Resource::new_borrow(debuggee.rep()),
-            page_size,
-        )
-        .await?;
-        assert_eq!(old_size, size);
-        let size = <ResourceTable as wit::HostMemory>::size_bytes(
-            &mut table,
-            Resource::new_borrow(memory.rep()),
-            Resource::new_borrow(debuggee.rep()),
-        )
-        .await?;
-        assert_eq!(size, 2 * page_size);
-
-        <ResourceTable as wit::HostMemory>::set_u32(
-            &mut table,
-            Resource::new_borrow(memory.rep()),
-            Resource::new_borrow(debuggee.rep()),
-            0,
-            0x1234_5678,
-        )
-        .await?;
-        let value = <ResourceTable as wit::HostMemory>::get_u32(
-            &mut table,
-            Resource::new_borrow(memory.rep()),
-            Resource::new_borrow(debuggee.rep()),
-            0,
-        )
-        .await?;
-        assert_eq!(value, 0x1234_5678);
-
-        <ResourceTable as wit::HostDebuggee>::drop(&mut table, debuggee).await?;
-        Ok(())
     }
 }

--- a/crates/debugger/src/host/bindings.rs
+++ b/crates/debugger/src/host/bindings.rs
@@ -23,7 +23,7 @@ wasmtime::component::bindgen!({
         "bytecodealliance:wasmtime/debuggee.module": wasmtime::Module,
         "bytecodealliance:wasmtime/debuggee.table": wasmtime::Table,
         "bytecodealliance:wasmtime/debuggee.global": wasmtime::Global,
-        "bytecodealliance:wasmtime/debuggee.memory": wasmtime::Memory,
+        "bytecodealliance:wasmtime/debuggee.memory": super::api::Memory,
         "bytecodealliance:wasmtime/debuggee.wasm-tag": wasmtime::Tag,
         "bytecodealliance:wasmtime/debuggee.wasm-func": wasmtime::Func,
         "bytecodealliance:wasmtime/debuggee.wasm-exception": super::api::WasmException,

--- a/crates/debugger/src/host/opaque.rs
+++ b/crates/debugger/src/host/opaque.rs
@@ -2,11 +2,51 @@
 //! within a resource.
 
 use crate::host::wit;
-use crate::host::{api::WasmValue, bindings::val_type_to_wasm_type};
-use wasmtime::{
-    Engine, ExnRef, ExnRefPre, ExnType, FrameHandle, Func, FuncType, Global, Instance, Memory,
-    Module, OwnedRooted, Result, Table, Tag, TagType, Val, ValType,
+use crate::host::{
+    api::{Memory, WasmValue},
+    bindings::val_type_to_wasm_type,
 };
+use std::sync::atomic::{AtomicU8, Ordering};
+use wasmtime::{
+    Engine, ExnRef, ExnRefPre, ExnType, FrameHandle, Func, FuncType, Global, Instance, Module,
+    OwnedRooted, Result, Table, Tag, TagType, Val, ValType,
+};
+
+fn shared_memory_read_bytes(
+    memory: &wasmtime::SharedMemory,
+    addr: u64,
+    len: u64,
+) -> Option<Vec<u8>> {
+    let addr = usize::try_from(addr).ok()?;
+    let len = usize::try_from(len).ok()?;
+    let end = addr.checked_add(len)?;
+    let data = memory.data().get(addr..end)?;
+    Some(
+        data.iter()
+            .map(|byte| {
+                // SAFETY: `byte` is a valid byte from `SharedMemory::data`,
+                // and `AtomicU8` has the same alignment requirement as `u8`.
+                unsafe { AtomicU8::from_ptr(byte.get()).load(Ordering::Relaxed) }
+            })
+            .collect(),
+    )
+}
+
+fn shared_memory_write_bytes(
+    memory: &wasmtime::SharedMemory,
+    addr: u64,
+    bytes: &[u8],
+) -> Option<()> {
+    let addr = usize::try_from(addr).ok()?;
+    let end = addr.checked_add(bytes.len())?;
+    let data = memory.data().get(addr..end)?;
+    for (byte, value) in data.iter().zip(bytes) {
+        // SAFETY: `byte` is a valid byte from `SharedMemory::data`, and
+        // `AtomicU8` has the same alignment requirement as `u8`.
+        unsafe { AtomicU8::from_ptr(byte.get()).store(*value, Ordering::Relaxed) };
+    }
+    Some(())
+}
 
 /// Type-erased interface to the `Debugger<T>` implementing all
 /// functionality necessary for the interfaces here. This needs to be
@@ -168,8 +208,17 @@ impl<T: Send + 'static> OpaqueDebugger for crate::Debuggee<T> {
         instance: Instance,
         idx: u32,
     ) -> Result<Option<Memory>> {
-        self.with_store(move |mut store| instance.debug_memory(&mut store, idx))
-            .await
+        self.with_store(move |mut store| {
+            instance
+                .debug_memory(&mut store, idx)
+                .map(Memory::Unshared)
+                .or_else(|| {
+                    instance
+                        .debug_shared_memory(&mut store, idx)
+                        .map(Memory::Shared)
+                })
+        })
+        .await
     }
 
     async fn instance_get_global(
@@ -197,24 +246,39 @@ impl<T: Send + 'static> OpaqueDebugger for crate::Debuggee<T> {
     }
 
     async fn memory_size_bytes(&mut self, memory: Memory) -> Result<u64> {
-        self.with_store(move |store| u64::try_from(memory.data_size(&store)).unwrap())
-            .await
+        self.with_store(move |store| match memory {
+            Memory::Unshared(memory) => u64::try_from(memory.data_size(&store)).unwrap(),
+            Memory::Shared(memory) => u64::try_from(memory.data_size()).unwrap(),
+        })
+        .await
     }
 
     async fn memory_page_size(&mut self, memory: Memory) -> Result<u64> {
-        self.with_store(move |store| memory.page_size(&store)).await
+        self.with_store(move |store| match memory {
+            Memory::Unshared(memory) => memory.page_size(&store),
+            Memory::Shared(memory) => memory.page_size(),
+        })
+        .await
     }
 
     async fn memory_grow(&mut self, memory: Memory, delta_bytes: u64) -> Result<u64> {
         self.with_store(move |mut store| -> Result<u64> {
-            let page_size = memory.page_size(&store);
+            let page_size = match &memory {
+                Memory::Unshared(memory) => memory.page_size(&store),
+                Memory::Shared(memory) => memory.page_size(),
+            };
             if delta_bytes & (page_size - 1) != 0 {
                 return Err(wit::Error::MemoryGrowFailure.into());
             }
             let delta_pages = delta_bytes / page_size;
-            let old_pages = memory
-                .grow(&mut store, delta_pages)
-                .map_err(|_| wit::Error::MemoryGrowFailure)?;
+            let old_pages = match memory {
+                Memory::Unshared(memory) => memory
+                    .grow(&mut store, delta_pages)
+                    .map_err(|_| wit::Error::MemoryGrowFailure)?,
+                Memory::Shared(memory) => memory
+                    .grow(delta_pages)
+                    .map_err(|_| wit::Error::MemoryGrowFailure)?,
+            };
             Ok(old_pages * page_size)
         })
         .await?
@@ -226,11 +290,15 @@ impl<T: Send + 'static> OpaqueDebugger for crate::Debuggee<T> {
         addr: u64,
         len: u64,
     ) -> Result<Option<Vec<u8>>> {
-        self.with_store(move |store| {
-            let data = memory.data(&store);
-            let addr = usize::try_from(addr).unwrap();
-            let len = usize::try_from(len).unwrap();
-            data.get(addr..addr + len).map(|s| s.to_vec())
+        self.with_store(move |store| match memory {
+            Memory::Unshared(memory) => {
+                let data = memory.data(&store);
+                let addr = usize::try_from(addr).ok()?;
+                let len = usize::try_from(len).ok()?;
+                let end = addr.checked_add(len)?;
+                data.get(addr..end).map(|s| s.to_vec())
+            }
+            Memory::Shared(memory) => shared_memory_read_bytes(&memory, addr, len),
         })
         .await
     }
@@ -241,62 +309,90 @@ impl<T: Send + 'static> OpaqueDebugger for crate::Debuggee<T> {
         addr: u64,
         bytes: Vec<u8>,
     ) -> Result<Option<()>> {
-        self.with_store(move |mut store| {
-            let data = memory.data_mut(&mut store);
-            let addr = usize::try_from(addr).unwrap();
-            let dest = data.get_mut(addr..addr + bytes.len())?;
-            dest.copy_from_slice(&bytes);
-            Some(())
+        self.with_store(move |mut store| match memory {
+            Memory::Unshared(memory) => {
+                let data = memory.data_mut(&mut store);
+                let addr = usize::try_from(addr).ok()?;
+                let end = addr.checked_add(bytes.len())?;
+                let dest = data.get_mut(addr..end)?;
+                dest.copy_from_slice(&bytes);
+                Some(())
+            }
+            Memory::Shared(memory) => shared_memory_write_bytes(&memory, addr, &bytes),
         })
         .await
     }
 
     async fn memory_read_u8(&mut self, memory: Memory, addr: u64) -> Result<Option<u8>> {
-        self.with_store(move |store| {
-            let data = memory.data(&store);
-            let addr = usize::try_from(addr).unwrap();
-            Some(*data.get(addr)?)
+        self.with_store(move |store| match memory {
+            Memory::Unshared(memory) => {
+                let data = memory.data(&store);
+                let addr = usize::try_from(addr).ok()?;
+                Some(*data.get(addr)?)
+            }
+            Memory::Shared(memory) => Some(shared_memory_read_bytes(&memory, addr, 1)?[0]),
         })
         .await
     }
 
     async fn memory_read_u16(&mut self, memory: Memory, addr: u64) -> Result<Option<u16>> {
-        self.with_store(move |store| {
-            let data = memory.data(&store);
-            let addr = usize::try_from(addr).unwrap();
-            Some(u16::from_le_bytes([*data.get(addr)?, *data.get(addr + 1)?]))
+        self.with_store(move |store| match memory {
+            Memory::Unshared(memory) => {
+                let data = memory.data(&store);
+                let addr = usize::try_from(addr).ok()?;
+                Some(u16::from_le_bytes([*data.get(addr)?, *data.get(addr + 1)?]))
+            }
+            Memory::Shared(memory) => Some(u16::from_le_bytes(
+                shared_memory_read_bytes(&memory, addr, 2)?
+                    .try_into()
+                    .unwrap(),
+            )),
         })
         .await
     }
 
     async fn memory_read_u32(&mut self, memory: Memory, addr: u64) -> Result<Option<u32>> {
-        self.with_store(move |store| {
-            let data = memory.data(&store);
-            let addr = usize::try_from(addr).unwrap();
-            Some(u32::from_le_bytes([
-                *data.get(addr)?,
-                *data.get(addr + 1)?,
-                *data.get(addr + 2)?,
-                *data.get(addr + 3)?,
-            ]))
+        self.with_store(move |store| match memory {
+            Memory::Unshared(memory) => {
+                let data = memory.data(&store);
+                let addr = usize::try_from(addr).ok()?;
+                Some(u32::from_le_bytes([
+                    *data.get(addr)?,
+                    *data.get(addr + 1)?,
+                    *data.get(addr + 2)?,
+                    *data.get(addr + 3)?,
+                ]))
+            }
+            Memory::Shared(memory) => Some(u32::from_le_bytes(
+                shared_memory_read_bytes(&memory, addr, 4)?
+                    .try_into()
+                    .unwrap(),
+            )),
         })
         .await
     }
 
     async fn memory_read_u64(&mut self, memory: Memory, addr: u64) -> Result<Option<u64>> {
-        self.with_store(move |store| {
-            let data = memory.data(&store);
-            let addr = usize::try_from(addr).unwrap();
-            Some(u64::from_le_bytes([
-                *data.get(addr)?,
-                *data.get(addr + 1)?,
-                *data.get(addr + 2)?,
-                *data.get(addr + 3)?,
-                *data.get(addr + 4)?,
-                *data.get(addr + 5)?,
-                *data.get(addr + 6)?,
-                *data.get(addr + 7)?,
-            ]))
+        self.with_store(move |store| match memory {
+            Memory::Unshared(memory) => {
+                let data = memory.data(&store);
+                let addr = usize::try_from(addr).ok()?;
+                Some(u64::from_le_bytes([
+                    *data.get(addr)?,
+                    *data.get(addr + 1)?,
+                    *data.get(addr + 2)?,
+                    *data.get(addr + 3)?,
+                    *data.get(addr + 4)?,
+                    *data.get(addr + 5)?,
+                    *data.get(addr + 6)?,
+                    *data.get(addr + 7)?,
+                ]))
+            }
+            Memory::Shared(memory) => Some(u64::from_le_bytes(
+                shared_memory_read_bytes(&memory, addr, 8)?
+                    .try_into()
+                    .unwrap(),
+            )),
         })
         .await
     }
@@ -307,11 +403,14 @@ impl<T: Send + 'static> OpaqueDebugger for crate::Debuggee<T> {
         addr: u64,
         value: u8,
     ) -> Result<Option<()>> {
-        self.with_store(move |mut store| {
-            let data = memory.data_mut(&mut store);
-            let addr = usize::try_from(addr).unwrap();
-            *data.get_mut(addr)? = value;
-            Some(())
+        self.with_store(move |mut store| match memory {
+            Memory::Unshared(memory) => {
+                let data = memory.data_mut(&mut store);
+                let addr = usize::try_from(addr).ok()?;
+                *data.get_mut(addr)? = value;
+                Some(())
+            }
+            Memory::Shared(memory) => shared_memory_write_bytes(&memory, addr, &[value]),
         })
         .await
     }
@@ -322,12 +421,18 @@ impl<T: Send + 'static> OpaqueDebugger for crate::Debuggee<T> {
         addr: u64,
         value: u16,
     ) -> Result<Option<()>> {
-        self.with_store(move |mut store| {
-            let data = memory.data_mut(&mut store);
-            let addr = usize::try_from(addr).unwrap();
-            data.get_mut(addr..(addr + 2))?
-                .copy_from_slice(&value.to_le_bytes());
-            Some(())
+        self.with_store(move |mut store| match memory {
+            Memory::Unshared(memory) => {
+                let data = memory.data_mut(&mut store);
+                let addr = usize::try_from(addr).ok()?;
+                let end = addr.checked_add(2)?;
+                data.get_mut(addr..end)?
+                    .copy_from_slice(&value.to_le_bytes());
+                Some(())
+            }
+            Memory::Shared(memory) => {
+                shared_memory_write_bytes(&memory, addr, &value.to_le_bytes())
+            }
         })
         .await
     }
@@ -338,12 +443,18 @@ impl<T: Send + 'static> OpaqueDebugger for crate::Debuggee<T> {
         addr: u64,
         value: u32,
     ) -> Result<Option<()>> {
-        self.with_store(move |mut store| {
-            let data = memory.data_mut(&mut store);
-            let addr = usize::try_from(addr).unwrap();
-            data.get_mut(addr..(addr + 4))?
-                .copy_from_slice(&value.to_le_bytes());
-            Some(())
+        self.with_store(move |mut store| match memory {
+            Memory::Unshared(memory) => {
+                let data = memory.data_mut(&mut store);
+                let addr = usize::try_from(addr).ok()?;
+                let end = addr.checked_add(4)?;
+                data.get_mut(addr..end)?
+                    .copy_from_slice(&value.to_le_bytes());
+                Some(())
+            }
+            Memory::Shared(memory) => {
+                shared_memory_write_bytes(&memory, addr, &value.to_le_bytes())
+            }
         })
         .await
     }
@@ -354,12 +465,18 @@ impl<T: Send + 'static> OpaqueDebugger for crate::Debuggee<T> {
         addr: u64,
         value: u64,
     ) -> Result<Option<()>> {
-        self.with_store(move |mut store| {
-            let data = memory.data_mut(&mut store);
-            let addr = usize::try_from(addr).unwrap();
-            data.get_mut(addr..(addr + 8))?
-                .copy_from_slice(&value.to_le_bytes());
-            Some(())
+        self.with_store(move |mut store| match memory {
+            Memory::Unshared(memory) => {
+                let data = memory.data_mut(&mut store);
+                let addr = usize::try_from(addr).ok()?;
+                let end = addr.checked_add(8)?;
+                data.get_mut(addr..end)?
+                    .copy_from_slice(&value.to_le_bytes());
+                Some(())
+            }
+            Memory::Shared(memory) => {
+                shared_memory_write_bytes(&memory, addr, &value.to_le_bytes())
+            }
         })
         .await
     }

--- a/crates/wasmtime/src/runtime/memory.rs
+++ b/crates/wasmtime/src/runtime/memory.rs
@@ -978,6 +978,13 @@ impl SharedMemory {
         }
     }
 
+    /// Returns a stable identifier for this shared memory when introspecting
+    /// it through the debug APIs.
+    #[cfg(feature = "debug")]
+    pub fn debug_index_in_store(&self) -> u64 {
+        u64::try_from(self.vm.vmmemory_ptr().as_ptr().addr()).unwrap()
+    }
+
     /// Equivalent of the WebAssembly `memory.atomic.notify` instruction for
     /// this shared memory.
     ///

--- a/tests/all/guest_debug/mod.rs
+++ b/tests/all/guest_debug/mod.rs
@@ -128,17 +128,22 @@ impl WasmtimeWithGdbstub {
 fn lldb_with_gdbstub_script(port: u16, script: &str) -> Result<String> {
     let _ = env_logger::try_init();
 
-    let mut cmd = Command::new(lldb_path());
-    cmd.arg("--batch");
-    cmd.arg("-o").arg(format!(
+    // A source file keeps LLDB processing commands after a resume command on
+    // versions that stop processing repeated `-o` options at the next stop.
+    let mut script_file = tempfile::Builder::new().suffix(".lldb").tempfile()?;
+    writeln!(
+        script_file,
         "process connect --plugin wasm connect://127.0.0.1:{port}"
-    ));
+    )?;
     for line in script.lines() {
         let line = line.trim();
         if !line.is_empty() {
-            cmd.arg("-o").arg(line);
+            writeln!(script_file, "{line}")?;
         }
     }
+
+    let mut cmd = Command::new(lldb_path());
+    cmd.args(["--batch", "-s"]).arg(script_file.path());
 
     eprintln!("Running LLDB: {cmd:?}");
     let output = cmd.output()?;
@@ -235,6 +240,56 @@ c
         r#"
 check: stop reason
 check: fib
+"#,
+    )?;
+    Ok(())
+}
+
+/// Shared linear memories should be readable through the synthetic Wasm
+/// address space after the guest stops.
+#[test]
+#[ignore]
+fn guest_debug_cli_shared_memory() -> Result<()> {
+    let mut module = tempfile::Builder::new().suffix(".wat").tempfile()?;
+    module.write_all(
+        br#"(module
+  (memory (export "memory") 1 1 shared)
+  (func (export "_start")
+    i32.const 0
+    i32.const 42
+    i32.store
+    unreachable))
+"#,
+    )?;
+    let module = module.into_temp_path();
+    let module_path = module
+        .to_str()
+        .ok_or_else(|| format_err!("temporary module path is not UTF-8"))?;
+
+    let port = free_port();
+    let mut wt = WasmtimeWithGdbstub::spawn(
+        "run",
+        port,
+        &["-Ccache=n", "-W", "threads=y,shared-memory=y", module_path],
+        Duration::from_secs(30),
+    )?;
+
+    let output = lldb_with_gdbstub_script(
+        port,
+        r#"
+continue
+process plugin packet send qXfer:memory-map:read::0,ffff
+memory read --size 4 --format decimal --count 1 0x0
+"#,
+    )?;
+    wt.child.kill().ok();
+    wt.child.wait()?;
+
+    check_output(
+        &output,
+        r#"
+check: <memory type="ram" start="0x0"
+check: 42
 "#,
     )?;
     Ok(())

--- a/tests/all/guest_debug/mod.rs
+++ b/tests/all/guest_debug/mod.rs
@@ -128,8 +128,6 @@ impl WasmtimeWithGdbstub {
 fn lldb_with_gdbstub_script(port: u16, script: &str) -> Result<String> {
     let _ = env_logger::try_init();
 
-    // A source file keeps LLDB processing commands after a resume command on
-    // versions that stop processing repeated `-o` options at the next stop.
     let mut script_file = tempfile::Builder::new().suffix(".lldb").tempfile()?;
     writeln!(
         script_file,
@@ -278,7 +276,6 @@ fn guest_debug_cli_shared_memory() -> Result<()> {
         port,
         r#"
 continue
-process plugin packet send qXfer:memory-map:read::0,ffff
 memory read --size 4 --format decimal --count 1 0x0
 "#,
     )?;
@@ -288,7 +285,6 @@ memory read --size 4 --format decimal --count 1 0x0
     check_output(
         &output,
         r#"
-check: <memory type="ram" start="0x0"
 check: 42
 "#,
     )?;


### PR DESCRIPTION
shared linear memories were omitted from the synthetic Wasm address space; this maps both memory types, implements shared-memory access, and adds an LLDB regression test proving address 0 reads correctly.