### PR TITLE
wasmtime: Clarify that component::Linker doesn't support intra-component linking yet

### DIFF
--- a/crates/wasmtime/src/runtime/component/linker.rs
+++ b/crates/wasmtime/src/runtime/component/linker.rs
@@ -18,10 +18,10 @@ use wasmtime_environ::{Atom, PrimaryMap, StringPool};
 
 /// A type used to instantiate [`Component`]s.
 ///
-/// This type is used to supply host
-/// functionality to components. Values are defined in a [`Linker`] by their
-/// import name and then components are instantiated with a [`Linker`] using the
-/// names provided for name resolution of the component's imports.
+/// This type is used to supply host functionality to components. Values are
+/// defined in a [`Linker`] by their import name and then components are
+/// instantiated with a [`Linker`] using the names provided for name resolution
+/// of the component's imports.
 ///
 /// # Names and Semver
 ///

--- a/crates/wasmtime/src/runtime/component/linker.rs
+++ b/crates/wasmtime/src/runtime/component/linker.rs
@@ -18,14 +18,10 @@ use wasmtime_environ::{Atom, PrimaryMap, StringPool};
 
 /// A type used to instantiate [`Component`]s.
 ///
-/// This type is used to both link components together[^component-linking-not-implemented] as well as supply host
+/// This type is used to supply host
 /// functionality to components. Values are defined in a [`Linker`] by their
 /// import name and then components are instantiated with a [`Linker`] using the
 /// names provided for name resolution of the component's imports.
-///
-/// [^component-linking-not-implemented]: Linking between components isn't
-/// implemented yet. In the meantime, [wac](https://github.com/bytecodealliance/wac)
-/// can be used to link components before loading instead.
 ///
 /// # Names and Semver
 ///

--- a/crates/wasmtime/src/runtime/component/linker.rs
+++ b/crates/wasmtime/src/runtime/component/linker.rs
@@ -18,10 +18,14 @@ use wasmtime_environ::{Atom, PrimaryMap, StringPool};
 
 /// A type used to instantiate [`Component`]s.
 ///
-/// This type is used to both link components together as well as supply host
+/// This type is used to both link components together[^component-linking-not-implemented] as well as supply host
 /// functionality to components. Values are defined in a [`Linker`] by their
 /// import name and then components are instantiated with a [`Linker`] using the
 /// names provided for name resolution of the component's imports.
+///
+/// [^component-linking-not-implemented]: Linking between components isn't
+/// implemented yet. In the meantime, [wac](https://github.com/bytecodealliance/wac)
+/// can be used to link components before loading instead.
 ///
 /// # Names and Semver
 ///


### PR DESCRIPTION
Previously discussed at https://bytecodealliance.zulipchat.com/#narrow/channel/217126-wasmtime/topic/.E2.9C.94.20linking.20wasm.20components.20at.20runtime.3F/near/615012938

The current state tripped me up a bit, since the docs make it sound like it's already there and working, while the API itself seems nowhere to be found.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
