### PR TITLE
update `WasiCtxBuilder::allow_{tcp,udp}` docs

### DIFF
--- a/crates/wasi/src/ctx.rs
+++ b/crates/wasi/src/ctx.rs
@@ -414,10 +414,9 @@ impl WasiCtxBuilder {
         self
     }
 
-    /// Allow usage of UDP.
+    /// Allow usage of UDP
     ///
-    /// This is enabled by default, but can be disabled if UDP should be blanket
-    /// disabled.
+    /// By default this is disabled.
     pub fn allow_udp(&mut self, enable: bool) -> &mut Self {
         self.sockets.allowed_network_uses.udp = enable;
         self
@@ -425,8 +424,7 @@ impl WasiCtxBuilder {
 
     /// Allow usage of TCP
     ///
-    /// This is enabled by default, but can be disabled if TCP should be blanket
-    /// disabled.
+    /// By default this is disabled.
     pub fn allow_tcp(&mut self, enable: bool) -> &mut Self {
         self.sockets.allowed_network_uses.tcp = enable;
         self


### PR DESCRIPTION
PR #13936 disabled these settings by default but did not update the docs to match.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
