### PR TITLE
perf: cranelift-codegen-meta: optimize llvm-lines in `fmtln!` Formatter

### DIFF
--- a/cranelift/codegen/meta/src/gen_inst.rs
+++ b/cranelift/codegen/meta/src/gen_inst.rs
@@ -951,7 +951,7 @@ fn gen_type_constraints(all_inst: &AllInstructions, fmt: &mut Formatter) {
                 .collect::<Vec<_>>()
                 .join(", ")));
             if let Some(poly) = &inst.polymorphic_info {
-                fmt.comment(format!("Polymorphic over {}", typeset_to_string(poly.ctrl_typevar.get_raw_typeset())));
+                fmt.comment(format_args!("Polymorphic over {}", typeset_to_string(poly.ctrl_typevar.get_raw_typeset())));
             }
 
             // Compute the bit field encoding, c.f. instructions.rs.

--- a/cranelift/codegen/meta/src/gen_settings.rs
+++ b/cranelift/codegen/meta/src/gen_settings.rs
@@ -317,7 +317,7 @@ fn gen_descriptors(group: &SettingGroup, fmt: &mut Formatter) {
     );
     fmt.indent(|fmt| {
         for preset in &group.presets {
-            fmt.comment(format!(
+            fmt.comment(format_args!(
                 "{}: {}",
                 preset.name,
                 preset.setting_names(group).collect::<Vec<_>>().join(", ")

--- a/cranelift/srcgen/src/lib.rs
+++ b/cranelift/srcgen/src/lib.rs
@@ -5,6 +5,7 @@
 
 use std::cmp;
 use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::Display;
 use std::fs;
 use std::io::Write;
 
@@ -43,11 +44,11 @@ impl core::fmt::Display for FileLocation {
 #[macro_export]
 macro_rules! fmtln {
     ($fmt:ident, $fmtstring:expr, $($fmtargs:expr),*) => {
-        $fmt.line_with_location(format!($fmtstring, $($fmtargs),*), $crate::loc!())
+        $fmt.line_with_location(format_args!($fmtstring, $($fmtargs),*), $crate::loc!())
     };
 
     ($fmt:ident, $arg:expr) => {
-        $fmt.line_with_location(format!($arg), $crate::loc!())
+        $fmt.line_with_location(format_args!($arg), $crate::loc!())
     };
 
     ($_:tt, $($args:expr),+) => {
@@ -131,23 +132,28 @@ impl Formatter {
     }
 
     /// Add an indented line.
-    pub fn line(&mut self, contents: impl AsRef<str>) {
-        let indented_line = format!("{}{}\n", self.get_indent(), contents.as_ref());
+    pub fn line(&mut self, contents: impl Display) {
+        let indent = self.get_indent();
+        let indented_line = format!("{indent}{contents}\n");
         self.lines.push(indented_line);
     }
 
-    /// Add an indented lin with a given a `location` appended as a comment to
+    /// Add an indented line with a given a `location` appended as a comment to
     /// the line (this is useful for identifying where a line was generated).
-    pub fn line_with_location(&mut self, contents: impl AsRef<str>, location: FileLocation) {
+    pub fn line_with_location(&mut self, contents: impl Display, location: FileLocation) {
+        use std::fmt::Write;
+
         let indent = self.get_indent();
-        let contents = contents.as_ref();
-        let indented_line = if self.lang.should_append_location(contents) {
+        let mut buf = String::new();
+
+        write!(&mut buf, "{indent}{contents}").unwrap();
+        // just after writing contents, check ends_with using should_append_location
+        if self.lang.should_append_location(&buf) {
             let comment_token = self.lang.comment_token();
-            format!("{indent}{contents} {comment_token} {location}\n")
-        } else {
-            format!("{indent}{contents}\n")
-        };
-        self.lines.push(indented_line);
+            write!(&mut buf, " {comment_token} {location}").unwrap();
+        }
+        buf.push('\n');
+        self.lines.push(buf);
     }
 
     /// Pushes an empty line.
@@ -161,10 +167,11 @@ impl Formatter {
     }
 
     /// Add a comment line.
-    pub fn comment(&mut self, s: impl AsRef<str>) {
+    pub fn comment(&mut self, comment: impl Display) {
         // Avoid `fmtln!` here: we don't want to append a location comment to a
         // comment.
-        self.line(format!("{} {}", self.lang.comment_token(), s.as_ref()));
+        let comment_token = self.lang.comment_token();
+        self.line(format!("{comment_token} {comment}"));
     }
 
     /// Add a (multi-line) documentation comment.
@@ -186,7 +193,7 @@ impl Formatter {
     /// <f()> }`. This properly indents the contents of the block.
     pub fn add_block<T, F: FnOnce(&mut Formatter) -> T>(&mut self, start: &str, f: F) -> T {
         assert!(matches!(self.lang, Language::Rust));
-        self.line(format!("{start} {{"));
+        self.line(format_args!("{start} {{"));
         let ret = self.indent(f);
         self.line("}");
         ret

--- a/cranelift/srcgen/src/lib.rs
+++ b/cranelift/srcgen/src/lib.rs
@@ -171,7 +171,7 @@ impl Formatter {
         // Avoid `fmtln!` here: we don't want to append a location comment to a
         // comment.
         let comment_token = self.lang.comment_token();
-        self.line(format!("{comment_token} {comment}"));
+        self.line(format_args!("{comment_token} {comment}"));
     }
 
     /// Add a (multi-line) documentation comment.


### PR DESCRIPTION
`-3.6%` less llvm-lines




Before:
```
Lines                 Copies              Function name
  -----                 ------              -------------
  192891                4360                (TOTAL)
   10042 (5.2%,  5.2%)     1 (0.0%,  0.0%)  cranelift_codegen_meta[b743bf4194d43139]::shared::instructions::define
    3772 (2.0%,  7.2%)     1 (0.0%,  0.0%)  <cranelift_codegen_meta[b743bf4194d43139]::gen_isle::NumericOp>::ops_for_type
    2301 (1.2%,  8.4%)     1 (0.0%,  0.1%)  cranelift_codegen_meta[b743bf4194d43139]::gen_isle::gen_numerics_isle
    2012 (1.0%,  9.4%)     1 (0.0%,  0.1%)  cranelift_codegen_meta[b743bf4194d43139]::isle::get_isle_compilations
    1510 (0.8%, 10.2%)     1 (0.0%,  0.1%)  cranelift_codegen_meta[b743bf4194d43139]::isa::x86::define
    1276 (0.7%, 10.8%)     1 (0.0%,  0.1%)  cranelift_codegen_meta[b743bf4194d43139]::gen_isle::gen_common_isle
    1150 (0.6%, 11.4%)     1 (0.0%,  0.2%)  cranelift_codegen_meta[b743bf4194d43139]::gen_asm::generate_macro_inst_fn::{closure#3}
     990 (0.5%, 12.0%)     1 (0.0%,  0.2%)  alloc[24b8200b0946867]::str::join_generic_copy::<str, u8, &str>
     958 (0.5%, 12.4%)     1 (0.0%,  0.2%)  cranelift_codegen_meta[b743bf4194d43139]::gen_asm::generate_isle
     870 (0.5%, 12.9%)     1 (0.0%,  0.2%)  cranelift_codegen_meta[b743bf4194d43139]::isa::riscv64::define
     855 (0.4%, 13.3%)     1 (0.0%,  0.3%)  cranelift_codegen_meta[b743bf4194d43139]::shared::instructions::define_control_flow
     853 (0.4%, 13.8%)     1 (0.0%,  0.3%)  cranelift_codegen_meta[b743bf4194d43139]::pulley::generate_isle
```

After:
```
 Lines                 Copies              Function name
  -----                 ------              -------------
  185944                4361                (TOTAL)
   10042 (5.4%,  5.4%)     1 (0.0%,  0.0%)  cranelift_codegen_meta[b743bf4194d43139]::shared::instructions::define
    3772 (2.0%,  7.4%)     1 (0.0%,  0.0%)  <cranelift_codegen_meta[b743bf4194d43139]::gen_isle::NumericOp>::ops_for_type
    2012 (1.1%,  8.5%)     1 (0.0%,  0.1%)  cranelift_codegen_meta[b743bf4194d43139]::isle::get_isle_compilations
    1510 (0.8%,  9.3%)     1 (0.0%,  0.1%)  cranelift_codegen_meta[b743bf4194d43139]::isa::x86::define
    1301 (0.7%, 10.0%)     1 (0.0%,  0.1%)  cranelift_codegen_meta[b743bf4194d43139]::gen_isle::gen_numerics_isle
     990 (0.5%, 10.6%)     1 (0.0%,  0.1%)  alloc[24b8200b0946867]::str::join_generic_copy::<str, u8, &str>
     916 (0.5%, 11.0%)     1 (0.0%,  0.2%)  cranelift_codegen_meta[b743bf4194d43139]::gen_isle::gen_common_isle
     870 (0.5%, 11.5%)     1 (0.0%,  0.2%)  cranelift_codegen_meta[b743bf4194d43139]::isa::riscv64::define
     855 (0.5%, 12.0%)     1 (0.0%,  0.2%)  cranelift_codegen_meta[b743bf4194d43139]::shared::instructions::define_control_flow
     853 (0.5%, 12.4%)     1 (0.0%,  0.2%)  cranelift_codegen_meta[b743bf4194d43139]::pulley::generate_isle
     825 (0.4%, 12.9%)     1 (0.0%,  0.3%)  cranelift_codegen_meta[b743bf4194d43139]::gen_inst::gen_inst_builder
     810 (0.4%, 13.3%)     1 (0.0%,  0.3%)  cranelift_codegen_meta[b743bf4194d43139]::gen_asm::generate_macro_inst_fn::{closure#3}
```