### PR TITLE
perf: cranelift-srcgen: optimize Formatter buffering

### DIFF
--- a/cranelift/srcgen/src/lib.rs
+++ b/cranelift/srcgen/src/lib.rs
@@ -11,8 +11,6 @@ use std::io::Write;
 
 pub mod error;
 
-static SHIFTWIDTH: usize = 4;
-
 /// A macro for constructing a [`FileLocation`] at the current location.
 #[macro_export]
 macro_rules! loc {
@@ -85,10 +83,19 @@ impl Language {
     }
 }
 
+static SHIFTWIDTH: usize = 4;
+
+/// Returns 4 times as many spaces. Max indent is 64, which consists of 256 spaces
+fn spaces_for_indent(indent: usize) -> &'static str {
+    // static str of 256 spaces
+    static INDENT_STR: &'static str = "                                                                                                                                                                                                                                                                ";
+    &INDENT_STR[..INDENT_STR.len().min(indent * SHIFTWIDTH)]
+}
+
 /// Collect source code to be written to a file and keep track of indentation.
 pub struct Formatter {
     indent: usize,
-    lines: Vec<String>,
+    lines: String,
     lang: Language,
 }
 
@@ -98,7 +105,7 @@ impl Formatter {
     pub fn new(lang: Language) -> Self {
         Self {
             indent: 0,
-            lines: Vec::new(),
+            lines: String::new(),
             lang,
         }
     }
@@ -123,19 +130,16 @@ impl Formatter {
     }
 
     /// Get the current whitespace indentation in the form of a String.
-    fn get_indent(&self) -> String {
-        if self.indent == 0 {
-            String::new()
-        } else {
-            format!("{:-1$}", " ", self.indent * SHIFTWIDTH)
-        }
+    fn get_indent(&self) -> &'static str {
+        spaces_for_indent(self.indent)
     }
 
     /// Add an indented line.
     pub fn line(&mut self, contents: impl Display) {
+        use std::fmt::Write;
+
         let indent = self.get_indent();
-        let indented_line = format!("{indent}{contents}\n");
-        self.lines.push(indented_line);
+        write!(&mut self.lines, "{indent}{contents}\n").unwrap();
     }
 
     /// Add an indented line with a given a `location` appended as a comment to
@@ -144,21 +148,19 @@ impl Formatter {
         use std::fmt::Write;
 
         let indent = self.get_indent();
-        let mut buf = String::new();
 
-        write!(&mut buf, "{indent}{contents}").unwrap();
+        write!(&mut self.lines, "{indent}{contents}").unwrap();
         // just after writing contents, check ends_with using should_append_location
-        if self.lang.should_append_location(&buf) {
+        if self.lang.should_append_location(&self.lines) {
             let comment_token = self.lang.comment_token();
-            write!(&mut buf, " {comment_token} {location}").unwrap();
+            write!(&mut self.lines, " {comment_token} {location}").unwrap();
         }
-        buf.push('\n');
-        self.lines.push(buf);
+        self.lines.push('\n');
     }
 
     /// Pushes an empty line.
     pub fn empty_line(&mut self) {
-        self.lines.push("\n".to_string());
+        self.lines.push('\n');
     }
 
     /// Add one or more lines after stripping common indentation.
@@ -248,21 +250,8 @@ impl Formatter {
         eprintln!("Writing generated file: {}", path.display());
         let mut f = fs::File::create(path)?;
 
-        for l in self.lines.iter().map(|l| l.as_bytes()) {
-            f.write_all(l)?;
-        }
-
+        f.write_all(self.lines.as_bytes())?;
         Ok(())
-    }
-}
-
-/// Compute the indentation of s, or None of an empty line.
-fn _indent(s: &str) -> Option<usize> {
-    if s.is_empty() {
-        None
-    } else {
-        let t = s.trim_start();
-        Some(s.len() - t.len())
     }
 }
 
@@ -271,7 +260,7 @@ fn _indent(s: &str) -> Option<usize> {
 /// doc strings.
 fn parse_multiline(s: &str) -> Vec<String> {
     // Convert tabs into spaces.
-    let expanded_tab = format!("{:-1$}", " ", SHIFTWIDTH);
+    let expanded_tab = spaces_for_indent(1);
     let lines: Vec<String> = s.lines().map(|l| l.replace('\t', &expanded_tab)).collect();
 
     // Determine minimum indentation, ignoring the first line and empty lines.
@@ -393,14 +382,6 @@ mod srcgen_tests {
     use super::Match;
     use super::parse_multiline;
 
-    fn from_raw_string<S: Into<String>>(s: S) -> Vec<String> {
-        s.into()
-            .trim()
-            .split("\n")
-            .map(|x| format!("{x}\n"))
-            .collect()
-    }
-
     #[test]
     fn adding_arms_works() {
         let mut m = Match::new("x");
@@ -413,9 +394,7 @@ mod srcgen_tests {
         let mut fmt = Formatter::new(Language::Rust);
         fmt.add_match(m);
 
-        let expected_lines = from_raw_string(
-            r#"
-match x {
+        let expected_lines = r#"match x {
     Green { a, b } => {
         different body
     }
@@ -427,8 +406,7 @@ match x {
         some body
     }
 }
-        "#,
-        );
+"#;
         assert_eq!(fmt.lines, expected_lines);
     }
 
@@ -444,9 +422,7 @@ match x {
         let mut fmt = Formatter::new(Language::Rust);
         fmt.add_match(m);
 
-        let expected_lines = from_raw_string(
-            r#"
-match x {
+        let expected_lines = r#"match x {
     Green { a, b } => {
         different body
     }
@@ -457,8 +433,7 @@ match x {
         unreachable!()
     }
 }
-        "#,
-        );
+"#;
         assert_eq!(fmt.lines, expected_lines);
     }
 
@@ -483,7 +458,7 @@ match x {
             "    // Nested comment\n",
             "Back home again\n",
         ];
-        assert_eq!(fmt.lines, expected_lines);
+        assert_eq!(fmt.lines, expected_lines.join(""));
     }
 
     #[test]
@@ -509,7 +484,7 @@ match x {
     fn fmt_can_add_type_to_lines() {
         let mut fmt = Formatter::new(Language::Rust);
         fmt.line(format!("pub const {}: Type = Type({:#x});", "example", 0));
-        let expected_lines = vec!["pub const example: Type = Type(0x0);\n"];
+        let expected_lines = "pub const example: Type = Type(0x0);\n";
         assert_eq!(fmt.lines, expected_lines);
     }
 
@@ -520,7 +495,7 @@ match x {
         fmt.indent_push();
         fmt.line("world");
         let expected_lines = vec!["hello\n", "    world\n"];
-        assert_eq!(fmt.lines, expected_lines);
+        assert_eq!(fmt.lines, expected_lines.join(""));
     }
 
     #[test]
@@ -528,7 +503,7 @@ match x {
         let mut fmt = Formatter::new(Language::Rust);
         fmt.doc_comment("documentation\nis\ngood");
         let expected_lines = vec!["/// documentation\n", "/// is\n", "/// good\n"];
-        assert_eq!(fmt.lines, expected_lines);
+        assert_eq!(fmt.lines, expected_lines.join(""));
     }
 
     #[test]
@@ -541,13 +516,11 @@ match x {
         If you stick to writing it.
 "#,
         );
-        let expected_lines = from_raw_string(
-            r#"
-/// documentation
+        let expected_lines = r#"/// documentation
 /// can be really good.
 ///
-/// If you stick to writing it."#,
-        );
+/// If you stick to writing it.
+"#;
         assert_eq!(fmt.lines, expected_lines);
     }
 }


### PR DESCRIPTION
This reduces run-time of `cranelift-codegen (build-script) (run)`:
- `-0.4%` on `debug`
- `-3.1%` on `release` [^1]


by changing:
- `lines: Vec<String>` to
- `lines: String`

so that
```rust
file.write_all(self.lines.as_bytes())?;
```

is called once.



Depends on #14092



[^1]: build script won't be in opt-`release` mode, because of `[profile.release.build-override]` `opt-level = 0`
https://github.com/bytecodealliance/wasmtime/blob/a48196189a5e3b5e5f288f776062fb6e7189e43f/Cargo.toml#L177-L178