### PR TITLE
Wasmtime debug instrumentation: remove stale comment about moving GCs.

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -1204,18 +1204,10 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
             // values were pushed; hence, these operand-stack values
             // are "dirty" and need to be flushed to the stackslot.
             //
-            // N.B.: note that we don't re-sync GC-rooted values, and
-            // we don't root the instrumentation slots
-            // explicitly. This is safe as long as we don't have a
-            // moving GC, because the value that we're observing in
-            // the main program dataflow is already rooted in the main
-            // program (we are only storing an extra copy of it). But
-            // if/when we do build a moving GC, we will need to handle
-            // this, probably by invalidating the "freshness" of all
-            // ref-typed values after a safepoint and re-writing them
-            // to the instrumentation slot; or alternately, extending
-            // the debug instrumentation mechanism to be able to
-            // directly refer to the user stack-slot.
+            // N.B.: note that we explicitly GC-root instrumentation
+            // slots, so we do not need to synchronize the canonical GC
+            // refs across may-GC points; the values will be separately
+            // updated by a GC pass in these slots.
             for i in self.stacks.stack_shape.len()..self.stacks.stack.len() {
                 let parent_shape = i
                     .checked_sub(1)


### PR DESCRIPTION
We previously noted that instrumentation slots were not seen by a GC, and only implicitly rooted (by live program values) for a non-moving GC. However as part of landing debug support, we eventually had to add proper rooting; the GC now explicitly scans instrumentation slots on the stack as well as the user stackslots. So this comment is out-of-date, and moving GCs work fine with debug (which is great, because we have one now!).

Fixes #13798.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
