### PR TITLE
Cranelift: add simplification rules

### DIFF
--- a/cranelift/codegen/src/opts/bitops.isle
+++ b/cranelift/codegen/src/opts/bitops.isle
@@ -713,3 +713,23 @@
 (rule (simplify (uge ty (bor ty y x) x)) (cmp_true ty))
 (rule (simplify (ule ty x (bor ty x y))) (cmp_true ty))
 (rule (simplify (ule ty x (bor ty y x))) (cmp_true ty))
+
+;; (~x & y) & x == (x & ~y) & y == 0.
+(rule (simplify (band ty (band ty (bnot ty x) y) x))
+      (subsume (all_zero ty)))
+(rule (simplify (band ty (band ty x (bnot ty y)) y))
+      (subsume (all_zero ty)))
+(rule (simplify (band ty x (band ty (bnot ty x) y)))
+      (subsume (all_zero ty)))
+(rule (simplify (band ty x (band ty y (bnot ty x))))
+      (subsume (all_zero ty)))
+
+;; ~(x | y) & x == ~(x | y) & y == 0.
+(rule (simplify (band ty (bnot ty (bor ty x y)) x))
+      (subsume (all_zero ty)))
+(rule (simplify (band ty (bnot ty (bor ty x y)) y))
+      (subsume (all_zero ty)))
+(rule (simplify (band ty x (bnot ty (bor ty x y))))
+      (subsume (all_zero ty)))
+(rule (simplify (band ty x (bnot ty (bor ty y x))))
+      (subsume (all_zero ty)))

--- a/cranelift/filetests/filetests/egraph/bitops.clif
+++ b/cranelift/filetests/filetests/egraph/bitops.clif
@@ -1107,3 +1107,121 @@ block0(v0: i32, v1: i32):
 ;     v5 = bor v1, v0
 ;     return v5
 ; }
+
+;; (~x & y) & x --> 0
+function %band_band_bnot_x_y_x_i32(i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32):
+    v2 = bnot v0
+    v3 = band v2, v1
+    v4 = band v3, v0
+    return v4
+}
+
+; function %band_band_bnot_x_y_x_i32(i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32):
+;     v5 = iconst.i32 0
+;     return v5
+; }
+
+function %band_band_x_bnot_y_y_f32(f32, f32) -> f32 fast {
+block0(v0: f32, v1: f32):
+    v2 = bnot v1
+    v3 = band v0, v2
+    v4 = band v3, v1
+    return v4
+}
+
+; function %band_band_x_bnot_y_y_f32(f32, f32) -> f32 fast {
+; block0(v0: f32, v1: f32):
+;     v5 = f32const 0.0
+;     return v5
+; }
+
+function %band_x_band_bnot_x_y_f32x2(f32x2, f32x2) -> f32x2 fast {
+block0(v0: f32x2, v1: f32x2):
+    v2 = bnot v0
+    v3 = band v2, v1
+    v4 = band v0, v3
+    return v4
+}
+
+; function %band_x_band_bnot_x_y_f32x2(f32x2, f32x2) -> f32x2 fast {
+; block0(v0: f32x2, v1: f32x2):
+;     const0 = 0x0000000000000000
+;     v5 = vconst.f32x2 const0
+;     return v5
+; }
+
+function %band_x_band_y_bnot_x_i32x4(i32x4, i32x4) -> i32x4 fast {
+block0(v0: i32x4, v1: i32x4):
+    v2 = bnot v0
+    v3 = band v1, v2
+    v4 = band v0, v3
+    return v4
+}
+
+; function %band_x_band_y_bnot_x_i32x4(i32x4, i32x4) -> i32x4 fast {
+; block0(v0: i32x4, v1: i32x4):
+;     const0 = 0x00000000000000000000000000000000
+;     v5 = vconst.i32x4 const0
+;     return v5
+; }
+
+;; ~(x | y) & x/y --> 0
+function %band_bnot_bor_x_y_x_i64(i64, i64) -> i64 fast {
+block0(v0: i64, v1: i64):
+    v2 = bor v0, v1
+    v3 = bnot v2
+    v4 = band v3, v0
+    return v4
+}
+
+; function %band_bnot_bor_x_y_x_i64(i64, i64) -> i64 fast {
+; block0(v0: i64, v1: i64):
+;     v5 = iconst.i64 0
+;     return v5
+; }
+
+function %band_bnot_bor_x_y_y_f64(f64, f64) -> f64 fast {
+block0(v0: f64, v1: f64):
+    v2 = bor v0, v1
+    v3 = bnot v2
+    v4 = band v3, v1
+    return v4
+}
+
+; function %band_bnot_bor_x_y_y_f64(f64, f64) -> f64 fast {
+; block0(v0: f64, v1: f64):
+;     v5 = f64const 0.0
+;     return v5
+; }
+
+function %band_x_bnot_bor_x_y_f32x2(f32x2, f32x2) -> f32x2 fast {
+block0(v0: f32x2, v1: f32x2):
+    v2 = bor v0, v1
+    v3 = bnot v2
+    v4 = band v0, v3
+    return v4
+}
+
+; function %band_x_bnot_bor_x_y_f32x2(f32x2, f32x2) -> f32x2 fast {
+; block0(v0: f32x2, v1: f32x2):
+;     const0 = 0x0000000000000000
+;     v5 = vconst.f32x2 const0
+;     return v5
+; }
+
+function %band_x_bnot_bor_y_x_i16x8(i16x8, i16x8) -> i16x8 fast {
+block0(v0: i16x8, v1: i16x8):
+    v2 = bor v1, v0
+    v3 = bnot v2
+    v4 = band v0, v3
+    return v4
+}
+
+; function %band_x_bnot_bor_y_x_i16x8(i16x8, i16x8) -> i16x8 fast {
+; block0(v0: i16x8, v1: i16x8):
+;     const0 = 0x00000000000000000000000000000000
+;     v5 = vconst.i16x8 const0
+;     return v5
+; }

--- a/cranelift/filetests/filetests/runtests/bitops.clif
+++ b/cranelift/filetests/filetests/runtests/bitops.clif
@@ -819,3 +819,29 @@ block0(v0: i32, v1: i32):
 
 ; run: %test_ule_x_bor(0, 0) == 1
 ; run: %test_ule_x_bor(1, 0) == 1
+
+;; (~x & y) & x --> 0
+function %test_band_band_bnot_x_y_x(i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32):
+    v2 = bnot v0
+    v3 = band v2, v1
+    v4 = band v3, v0
+    return v4
+}
+
+; run: %test_band_band_bnot_x_y_x(0, 0) == 0
+; run: %test_band_band_bnot_x_y_x(0x12345678, 0xffffffff) == 0
+; run: %test_band_band_bnot_x_y_x(-1, 0x55555555) == 0
+
+;; ~(x | y) & x/y --> 0
+function %test_band_bnot_bor_x_y_x(i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32):
+    v2 = bor v0, v1
+    v3 = bnot v2
+    v4 = band v3, v0
+    return v4
+}
+
+; run: %test_band_bnot_bor_x_y_x(0, 0) == 0
+; run: %test_band_bnot_bor_x_y_x(0x12345678, 0x87654321) == 0
+; run: %test_band_bnot_bor_x_y_x(-1, 0x55555555) == 0


### PR DESCRIPTION
Add simplification rules.

- `(~x & y) & x == (x & ~y) & y --> 0`
- `~(x | y) & x == ~(x | y) & y --> 0`