### PR TITLE
fuzz: enable SIMD for Winch on aarch64

### DIFF
--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -703,10 +703,8 @@ impl WasmtimeConfig {
                     config.config.simd_enabled = false;
                 }
 
-                // Account for the proposals that are currently only
-                // supported on x64.
+                // Account for the proposals that Winch only supports on x64.
                 if cfg!(target_arch = "aarch64") {
-                    config.config.simd_enabled = false;
                     config.config.wide_arithmetic_enabled = false;
                     config.config.threads_enabled = false;
                 }


### PR DESCRIPTION
The fuzz config disables SIMD for Winch on aarch64, but Winch has supported it since #13970, which updated the spec tests and `docs/stability-tiers.md` (`simd` → ✅ for aarch64 Winch) without touching `crates/fuzzing`. The disable dates from #12646 in February.

Checked on `aarch64-apple-darwin`: Winch and Cranelift agree on `v128.const` / `i32x4.add` / `i32x4.mul` / `i32x4.splat` / `extract_lane`, and `cargo fuzz run instantiate` with Winch forced did 61,405 runs in 300s with no crashes.

`wide_arithmetic` and `threads` stay disabled — still ❌ for Winch aarch64 in the tier table. The AVX check just above is unaffected on aarch64, since `codegen_flag("has_avx")` returns `None` there and `is_some_and` short-circuits.