### PR TITLE
Fix `named_imports` with a hyphen in interface names

### DIFF
--- a/crates/component-macro/tests/codegen.rs
+++ b/crates/component-macro/tests/codegen.rs
@@ -861,6 +861,31 @@ mod named_imports {
         }
     }
 
+    mod hyphenated_interface_name {
+        wasmtime::component::bindgen!({
+            inline: "
+                package foo:foo;
+
+                interface my-itf {
+                    ping: func();
+                }
+
+                world the-world {
+                    import my-itf;
+                }
+            ",
+            named_imports: {
+                "foo:foo/my-itf": String,
+            },
+        });
+
+        struct MyHost;
+
+        impl named_imports::foo::foo::my_itf::Host for MyHost {
+            fn ping(&mut self, _id: String) {}
+        }
+    }
+
     mod async_store {
         #[derive(Clone)]
         pub struct MyId(u32);

--- a/crates/wit-bindgen/src/lib.rs
+++ b/crates/wit-bindgen/src/lib.rs
@@ -502,7 +502,7 @@ impl Wasmtime {
         let key_name = resolve.name_world_key(&key);
         generator.generate_add_to_linker(id, &key_name);
         let body = String::from(mem::take(&mut generator.src));
-        let interface_name = resolve.interfaces[id].name.as_ref().unwrap();
+        let interface_name = to_rust_ident(resolve.interfaces[id].name.as_ref().unwrap());
         let body = format!("pub mod {interface_name} {{\n{body}\n}}");
         let path = self.generate_interface_name(resolve, id, &key, InterfaceKind::Named);
         self.named_import_modules


### PR DESCRIPTION
Closes #14090

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
