### PR TITLE
Enable the wide-arithmetic proposal by default

### DIFF
--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -1065,7 +1065,7 @@ impl Config {
     /// Configures whether the [WebAssembly wide-arithmetic][proposal] will be
     /// enabled for compilation.
     ///
-    /// This feature is `false` by default.
+    /// This feature is `true` by default.
     ///
     /// [proposal]: https://github.com/WebAssembly/wide-arithmetic
     pub fn wasm_wide_arithmetic(&mut self, enable: bool) -> &mut Self {
@@ -2538,6 +2538,7 @@ impl Config {
         // features.
         features |= WasmFeatures::WASM3;
 
+        features |= WasmFeatures::WIDE_ARITHMETIC;
         // features |= WasmFeatures::YOUR_WASM_FEATURE;
         // ...
 

--- a/docs/stability-tiers.md
+++ b/docs/stability-tiers.md
@@ -43,6 +43,7 @@ For explanations of what each tier means see below.
 | WebAssembly Proposal | [`function-references`]                    |
 | WebAssembly Proposal | [`gc`]                                     |
 | WebAssembly Proposal | [`exception-handling`]                     |
+| WebAssembly Proposal | [`wide-arithmetic`]                        |
 | WASI Proposal        | [`wasi-io`]                                |
 | WASI Proposal        | [`wasi-clocks`]                            |
 | WASI Proposal        | [`wasi-filesystem`]                        |
@@ -89,7 +90,6 @@ For explanations of what each tier means see below.
 | Target               | Support for `#![no_std]`   | Support beyond CI checks    |
 | WebAssembly Proposal | [`custom-page-sizes`]      | Unstable wasm proposal      |
 | WebAssembly Proposal | [`threads`]                | fuzzing, API quality        |
-| WebAssembly Proposal | [`wide-arithmetic`]        | Unstable wasm proposal      |
 | Execution Backend    | Pulley                     | More time fuzzing/baking    |
 | Embedding API        | C++                        | Full-time maintainer        |
 

--- a/docs/stability-wasm-proposals.md
+++ b/docs/stability-wasm-proposals.md
@@ -35,6 +35,7 @@ The emoji legend is:
 | [`function-references`]  | ✅      | ✅    | ✅       | ✅     | ✅  | ✅    |
 | [`gc`]                   | ✅      | ✅    | ✅       | ✅     | ✅  | ✅    |
 | [`exception-handling`]   | ✅      | ✅    | ✅       | ✅     | ✅  | ✅    |
+| [`wide-arithmetic`]      | ✅      | ✅    | ✅       | ✅     | ✅  | ✅    |
 
 [^1]: The `component-model` proposal is not at phase 4 in the standardization
     process but it is still enabled-by-default in Wasmtime.
@@ -51,7 +52,6 @@ The emoji legend is:
 |--------------------------|---------|-------|----------|--------|-----|--------|
 | [`custom-page-sizes`]    | ❌      | ✅    | ✅       | ✅     | ✅  | ✅     |
 | [`threads`]              | ✅      | ✅    | 🚧[^8]   | ❌[^4] | ✅  | ✅     |
-| [`wide-arithmetic`]      | ❌      | ✅    | ✅       | ✅     | ✅  | ✅     |
 
 [^4]: Fuzzing with threads is an open implementation question that is expected
     to get fleshed out as the [`shared-everything-threads`] proposal advances.
@@ -83,6 +83,7 @@ The emoji legend is:
 | [`flexible-vectors`]          | [#9464](https://github.com/bytecodealliance/wasmtime/issues/9464) |
 | [`memory-control`]            | [#9467](https://github.com/bytecodealliance/wasmtime/issues/9467) |
 | [`shared-everything-threads`] | [#9466](https://github.com/bytecodealliance/wasmtime/issues/9466) |
+| [`compact-import-section`]    | [#14108](https://github.com/bytecodealliance/wasmtime/issues/14108) |
 
 [`mutable-globals`]: https://github.com/WebAssembly/mutable-global/blob/master/proposals/mutable-global/Overview.md
 [`sign-extension-ops`]: https://github.com/WebAssembly/spec/blob/master/proposals/sign-extension-ops/Overview.md
@@ -108,6 +109,7 @@ The emoji legend is:
 [`wide-arithmetic`]: https://github.com/WebAssembly/wide-arithmetic/blob/main/proposals/wide-arithmetic/Overview.md
 [`gc`]: https://github.com/WebAssembly/gc
 [`custom-page-sizes`]: https://github.com/WebAssembly/custom-page-sizes
+[`compact-import-section`]: https://github.com/WebAssembly/compact-import-section
 
 ## Feature requirements
 


### PR DESCRIPTION
This proposal was voted to phase 4 in last week's in-person CG meeting which was the last remaining requirement to have this on-by-default in Wasmtime. This commit updates documentation and configuration to have this proposal enabled-by-default.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
