### PR TITLE
Cranelift: don't lower dead `notrap` loads

### DIFF
--- a/cranelift/codegen/src/inst_predicates.rs
+++ b/cranelift/codegen/src/inst_predicates.rs
@@ -94,9 +94,25 @@ pub fn is_mergeable_for_egraph(func: &Function, inst: Inst) -> bool {
 
 /// Does the given instruction have any side-effect as per [has_side_effect], or else is a load,
 /// but not the get_pinned_reg opcode?
+///
+/// Loads are included so that lowering colors them as side-effecting, which is
+/// what keeps a load from being merged into a consumer across an intervening
+/// store. Deciding whether a load has to be *emitted* is a different question;
+/// see [`must_lower_even_if_unused`].
 pub fn has_lowering_side_effect(func: &Function, inst: Inst) -> bool {
     let op = func.dfg.insts[inst].opcode();
     op != Opcode::GetPinnedReg && (has_side_effect(func, inst) || op.can_load())
+}
+
+/// Must lowering emit the given instruction even when none of its results are
+/// used?
+///
+/// This is [has_lowering_side_effect] without its "or is a load" clause: a load
+/// that is defined not to trap has no effect of its own, so if nothing wants the
+/// value it read there is no reason to emit it.
+pub fn must_lower_even_if_unused(func: &Function, inst: Inst) -> bool {
+    let op = func.dfg.insts[inst].opcode();
+    op != Opcode::GetPinnedReg && has_side_effect(func, inst)
 }
 
 /// Is the given instruction a constant value (`iconst`, `fconst`) that can be

--- a/cranelift/codegen/src/machinst/lower.rs
+++ b/cranelift/codegen/src/machinst/lower.rs
@@ -6,7 +6,9 @@
 // top of it, e.g. the side-effect/coloring analysis and the scan support.
 
 use crate::entity::SecondaryMap;
-use crate::inst_predicates::{has_lowering_side_effect, is_constant_64bit};
+use crate::inst_predicates::{
+    has_lowering_side_effect, is_constant_64bit, must_lower_even_if_unused,
+};
 use crate::ir::{
     ArgumentPurpose, Block, BlockArg, Constant, ConstantData, DataFlowGraph, ExternalName,
     Function, GlobalValue, GlobalValueData, Immediate, Inst, InstructionData, RelSourceLoc, SigRef,
@@ -750,14 +752,19 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
 
             // Are any outputs used at least once?
             let value_needed = self.is_any_inst_result_needed(inst);
+
+            // Do we have to emit this instruction even though nothing uses its
+            // results? Note that this is not the same question as
+            // `has_side_effect` above: loads are colored as side-effecting so
+            // that load merging cannot move one across a store, but a load that
+            // is defined not to trap can simply be dropped when it is dead.
+            let must_lower = must_lower_even_if_unused(self.f, inst);
+
             trace!(
-                "lower_clif_block: block {} inst {} ({:?}) is_branch {} side_effect {} value_needed {}",
-                block,
-                inst,
-                data,
+                "lower_clif_block: {block}, {inst}, ({data:?}), is_branch {}, \
+                 has_side_effect {has_side_effect}, must_lower {must_lower}, \
+                 value_needed {value_needed}",
                 data.opcode().is_branch(),
-                has_side_effect,
-                value_needed,
             );
 
             // Update scan state to color prior to this inst (as we are scanning
@@ -777,11 +784,11 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
             // order, and therefore **before** in reversed order.
             // Only emit value label aliases if the instruction will be lowered
             // (otherwise we want to keep using the earlier label instead).
-            self.emit_value_label_live_range_start_for_inst(inst, has_side_effect || value_needed);
+            self.emit_value_label_live_range_start_for_inst(inst, must_lower || value_needed);
 
             // Normal instruction: codegen if the instruction is side-effecting
             // or any of its outputs is used.
-            if has_side_effect || value_needed {
+            if must_lower || value_needed {
                 trace!("lowering: inst {}: {}", inst, self.f.dfg.display_inst(inst));
                 let temp_regs = match backend.lower(self, inst) {
                     Some(regs) => regs,

--- a/cranelift/filetests/filetests/isa/aarch64/dead-notrap-load.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/dead-notrap-load.clif
@@ -1,0 +1,111 @@
+test compile precise-output
+target aarch64
+
+;; A `notrap` load has no side effect of its own, so when nothing uses the value
+;; it read, lowering drops it.
+
+function %dead_notrap_load(i64) {
+block0(v0: i64):
+    v1 = load.i64 notrap aligned v0
+    return
+}
+
+; VCode:
+; block0:
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   ret
+
+;; Extending loads too.
+
+function %dead_notrap_uload8(i64) {
+block0(v0: i64):
+    v1 = uload8.i32 notrap aligned v0
+    return
+}
+
+; VCode:
+; block0:
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   ret
+
+;; Chains collapse within the single backward pass over the block: dropping the
+;; second load is what makes the first one dead.
+
+function %dead_notrap_load_chain(i64) {
+block0(v0: i64):
+    v1 = load.i64 notrap aligned readonly v0+176
+    v2 = load.i32 notrap aligned v1
+    return
+}
+
+; VCode:
+; block0:
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   ret
+
+;; The address computation survives if it is live for some other reason.
+
+function %dead_notrap_load_live_address(i64) -> i64 {
+block0(v0: i64):
+    v1 = iconst.i64 8
+    v2 = iadd v0, v1
+    v3 = load.i64 notrap aligned v2
+    return v2
+}
+
+; VCode:
+; block0:
+;   add x0, x0, #8
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   add x0, x0, #8
+;   ret
+
+;; A load without `notrap` is defined to trap on inaccessible memory, so it is
+;; still emitted even though its result is unused.
+
+function %dead_trapping_load(i64) {
+block0(v0: i64):
+    v1 = load.i64 aligned v0
+    return
+}
+
+; VCode:
+; block0:
+;   ldr x2, [x0]
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   ldr x2, [x0] ; trap: heap_oob
+;   ret
+
+;; Atomic loads are always side-effecting, `notrap` or not.
+
+function %dead_atomic_load(i64) {
+block0(v0: i64):
+    v1 = atomic_load.i64 notrap aligned v0
+    return
+}
+
+; VCode:
+; block0:
+;   ldar x2, [x0]
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   ldar x2, [x0]
+;   ret
+

--- a/cranelift/filetests/filetests/isa/riscv64/dead-notrap-load.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/dead-notrap-load.clif
@@ -1,0 +1,113 @@
+test compile precise-output
+target riscv64
+
+;; A `notrap` load has no side effect of its own, so when nothing uses the value
+;; it read, lowering drops it.
+
+function %dead_notrap_load(i64) {
+block0(v0: i64):
+    v1 = load.i64 notrap aligned v0
+    return
+}
+
+; VCode:
+; block0:
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   ret
+
+;; Extending loads too.
+
+function %dead_notrap_uload8(i64) {
+block0(v0: i64):
+    v1 = uload8.i32 notrap aligned v0
+    return
+}
+
+; VCode:
+; block0:
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   ret
+
+;; Chains collapse within the single backward pass over the block: dropping the
+;; second load is what makes the first one dead.
+
+function %dead_notrap_load_chain(i64) {
+block0(v0: i64):
+    v1 = load.i64 notrap aligned readonly v0+176
+    v2 = load.i32 notrap aligned v1
+    return
+}
+
+; VCode:
+; block0:
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   ret
+
+;; The address computation survives if it is live for some other reason.
+
+function %dead_notrap_load_live_address(i64) -> i64 {
+block0(v0: i64):
+    v1 = iconst.i64 8
+    v2 = iadd v0, v1
+    v3 = load.i64 notrap aligned v2
+    return v2
+}
+
+; VCode:
+; block0:
+;   addi a0,a0,8
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a0, a0, 8
+;   ret
+
+;; A load without `notrap` is defined to trap on inaccessible memory, so it is
+;; still emitted even though its result is unused.
+
+function %dead_trapping_load(i64) {
+block0(v0: i64):
+    v1 = load.i64 aligned v0
+    return
+}
+
+; VCode:
+; block0:
+;   ld a0,0(a0)
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   ld a0, 0(a0) ; trap: heap_oob
+;   ret
+
+;; Atomic loads are always side-effecting, `notrap` or not.
+
+function %dead_atomic_load(i64) {
+block0(v0: i64):
+    v1 = atomic_load.i64 notrap aligned v0
+    return
+}
+
+; VCode:
+; block0:
+;   atomic_load.i64 a0,(a0)
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   fence rw, rw
+;   ld a0, 0(a0) ; trap: heap_oob
+;   fence r, rw
+;   ret
+

--- a/cranelift/filetests/filetests/isa/s390x/dead-notrap-load.clif
+++ b/cranelift/filetests/filetests/isa/s390x/dead-notrap-load.clif
@@ -1,0 +1,111 @@
+test compile precise-output
+target s390x
+
+;; A `notrap` load has no side effect of its own, so when nothing uses the value
+;; it read, lowering drops it.
+
+function %dead_notrap_load(i64) {
+block0(v0: i64):
+    v1 = load.i64 notrap aligned v0
+    return
+}
+
+; VCode:
+; block0:
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   br %r14
+
+;; Extending loads too.
+
+function %dead_notrap_uload8(i64) {
+block0(v0: i64):
+    v1 = uload8.i32 notrap aligned v0
+    return
+}
+
+; VCode:
+; block0:
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   br %r14
+
+;; Chains collapse within the single backward pass over the block: dropping the
+;; second load is what makes the first one dead.
+
+function %dead_notrap_load_chain(i64) {
+block0(v0: i64):
+    v1 = load.i64 notrap aligned readonly v0+176
+    v2 = load.i32 notrap aligned v1
+    return
+}
+
+; VCode:
+; block0:
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   br %r14
+
+;; The address computation survives if it is live for some other reason.
+
+function %dead_notrap_load_live_address(i64) -> i64 {
+block0(v0: i64):
+    v1 = iconst.i64 8
+    v2 = iadd v0, v1
+    v3 = load.i64 notrap aligned v2
+    return v2
+}
+
+; VCode:
+; block0:
+;   aghi %r2, 8
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   aghi %r2, 8
+;   br %r14
+
+;; A load without `notrap` is defined to trap on inaccessible memory, so it is
+;; still emitted even though its result is unused.
+
+function %dead_trapping_load(i64) {
+block0(v0: i64):
+    v1 = load.i64 aligned v0
+    return
+}
+
+; VCode:
+; block0:
+;   lg %r2, 0(%r2)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   lg %r2, 0(%r2) ; trap: heap_oob
+;   br %r14
+
+;; Atomic loads are always side-effecting, `notrap` or not.
+
+function %dead_atomic_load(i64) {
+block0(v0: i64):
+    v1 = atomic_load.i64 notrap aligned v0
+    return
+}
+
+; VCode:
+; block0:
+;   lg %r2, 0(%r2)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   lg %r2, 0(%r2)
+;   br %r14
+

--- a/cranelift/filetests/filetests/isa/x64/dead-notrap-load.clif
+++ b/cranelift/filetests/filetests/isa/x64/dead-notrap-load.clif
@@ -1,0 +1,164 @@
+test compile precise-output
+target x86_64
+
+;; A `notrap` load has no side effect of its own, so when nothing uses the value
+;; it read, lowering drops it.
+
+function %dead_notrap_load(i64) {
+block0(v0: i64):
+    v1 = load.i64 notrap aligned v0
+    return
+}
+
+; VCode:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0:
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+;; Extending loads too.
+
+function %dead_notrap_uload8(i64) {
+block0(v0: i64):
+    v1 = uload8.i32 notrap aligned v0
+    return
+}
+
+; VCode:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0:
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+;; Chains collapse within the single backward pass over the block: dropping the
+;; second load is what makes the first one dead.
+
+function %dead_notrap_load_chain(i64) {
+block0(v0: i64):
+    v1 = load.i64 notrap aligned readonly v0+176
+    v2 = load.i32 notrap aligned v1
+    return
+}
+
+; VCode:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0:
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+;; The address computation survives if it is live for some other reason.
+
+function %dead_notrap_load_live_address(i64) -> i64 {
+block0(v0: i64):
+    v1 = iconst.i64 8
+    v2 = iadd v0, v1
+    v3 = load.i64 notrap aligned v2
+    return v2
+}
+
+; VCode:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0:
+;   leaq 8(%rdi), %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   leaq 8(%rdi), %rax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+;; A load without `notrap` is defined to trap on inaccessible memory, so it is
+;; still emitted even though its result is unused.
+
+function %dead_trapping_load(i64) {
+block0(v0: i64):
+    v1 = load.i64 aligned v0
+    return
+}
+
+; VCode:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0:
+;   movq (%rdi), %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movq (%rdi), %rdx ; trap: heap_oob
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+;; Atomic loads are always side-effecting, `notrap` or not.
+
+function %dead_atomic_load(i64) {
+block0(v0: i64):
+    v1 = atomic_load.i64 notrap aligned v0
+    return
+}
+
+; VCode:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0:
+;   movq (%rdi), %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movq (%rdi), %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq

--- a/tests/disas/component-model/direct-adapter-calls-x64.wat
+++ b/tests/disas/component-model/direct-adapter-calls-x64.wat
@@ -87,7 +87,7 @@
 ;;       movq    0x18(%r10), %r10
 ;;       addq    $0x60, %r10
 ;;       cmpq    %rsp, %r10
-;;       ja      0x103
+;;       ja      0xfd
 ;;   79: subq    $0x50, %rsp
 ;;       movq    %rbx, 0x20(%rsp)
 ;;       movq    %r12, 0x28(%rsp)
@@ -96,23 +96,21 @@
 ;;       movq    %r15, 0x40(%rsp)
 ;;       movq    %rdi, (%rsp)
 ;;       movq    (%rsp), %rdi
-;;       movq    0xa8(%rdi), %rcx
-;;       movl    (%rcx), %esi
-;;       movq    %rcx, 0x10(%rsp)
-;;       testl   %esi, %esi
-;;       movq    %rsi, 8(%rsp)
-;;       je      0x105
-;;   b9: movq    (%rsp), %rdi
-;;       movq    0x90(%rdi), %rax
-;;       movl    (%rax), %eax
+;;       movq    0xa8(%rdi), %r10
+;;       movl    (%r10), %r11d
+;;       movq    %r10, 0x10(%rsp)
+;;       testl   %r11d, %r11d
+;;       movq    %r11, 8(%rsp)
+;;       je      0xff
+;;   bb: movq    (%rsp), %rdi
 ;;       movq    0x48(%rdi), %rdi
 ;;       movq    (%rsp), %rsi
 ;;       callq   0
 ;;       ├─╼ exception frame offset: SP = FP - 0x50
-;;       ╰─╼ exception handler: default handler, context at [SP+0x0], handler=0x101
-;;       movq    0x10(%rsp), %rcx
-;;       movq    8(%rsp), %rsi
-;;       movl    %esi, (%rcx)
+;;       ╰─╼ exception handler: default handler, context at [SP+0x0], handler=0xfb
+;;       movq    0x10(%rsp), %r10
+;;       movq    8(%rsp), %r11
+;;       movl    %r11d, (%r10)
 ;;       movq    0x20(%rsp), %rbx
 ;;       movq    0x28(%rsp), %r12
 ;;       movq    0x30(%rsp), %r13
@@ -122,6 +120,6 @@
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;  101: ud2
-;;  103: ud2
-;;  105: ud2
+;;   fb: ud2
+;;   fd: ud2
+;;   ff: ud2

--- a/tests/disas/component-model/sync-adapter-calls-x64.wat
+++ b/tests/disas/component-model/sync-adapter-calls-x64.wat
@@ -56,45 +56,41 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r10
 ;;       movq    0x18(%r10), %r10
-;;       addq    $0x30, %r10
+;;       addq    $0x20, %r10
 ;;       cmpq    %rsp, %r10
-;;       ja      0xfb
-;;   39: subq    $0x30, %rsp
-;;       movq    %rbx, 0x20(%rsp)
+;;       ja      0xe6
+;;   39: subq    $0x20, %rsp
 ;;       movq    0x48(%rdi), %rdi
 ;;       movq    0xe8(%rdi), %rax
 ;;       movl    (%rax), %ecx
 ;;       testl   %ecx, %ecx
-;;       je      0xfd
-;;   57: movq    0x100(%rdi), %rdx
+;;       je      0xe8
+;;   52: movq    0x100(%rdi), %rdx
 ;;       movl    (%rdx), %esi
 ;;       movl    $0, (%rdx)
-;;       movq    8(%rdi), %r8
-;;       movq    0x88(%r8), %r9
-;;       leaq    (%rsp), %rbx
-;;       movq    %r9, (%rsp)
+;;       movq    8(%rdi), %rdi
+;;       movq    0x88(%rdi), %r8
+;;       leaq    (%rsp), %r10
+;;       movq    %r8, (%rsp)
 ;;       movl    $2, 8(%rsp)
 ;;       movl    $0, 0xc(%rsp)
 ;;       movl    $1, 0x10(%rsp)
-;;       movl    0x80(%r8), %r10d
-;;       movl    %r10d, 0x14(%rsp)
-;;       movl    $0, 0x80(%r8)
-;;       movl    0x84(%r8), %r11d
+;;       movl    0x80(%rdi), %r9d
+;;       movl    %r9d, 0x14(%rsp)
+;;       movl    $0, 0x80(%rdi)
+;;       movl    0x84(%rdi), %r11d
 ;;       movl    %r11d, 0x18(%rsp)
-;;       movl    $0, 0x84(%r8)
-;;       movq    %rbx, 0x88(%r8)
-;;       movq    0xd0(%rdi), %rdi
-;;       movl    (%rdi), %edi
-;;       movq    %r9, 0x88(%r8)
-;;       movl    %r10d, 0x80(%r8)
-;;       movl    %r11d, 0x84(%r8)
+;;       movl    $0, 0x84(%rdi)
+;;       movq    %r10, 0x88(%rdi)
+;;       movq    %r8, 0x88(%rdi)
+;;       movl    %r9d, 0x80(%rdi)
+;;       movl    %r11d, 0x84(%rdi)
 ;;       movl    %ecx, (%rax)
 ;;       movl    %esi, (%rdx)
 ;;       movl    $0x4fc, %eax
-;;       movq    0x20(%rsp), %rbx
-;;       addq    $0x30, %rsp
+;;       addq    $0x20, %rsp
 ;;       movq    %rbp, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   fb: ud2
-;;   fd: ud2
+;;   e6: ud2
+;;   e8: ud2


### PR DESCRIPTION
If a load is marked `notrap` then it is not side-effecting and we need not emit
it when its loaded value is unused.

Note that we *do* still have to increment the side effect color for these
instructions to prevent merging/sinking loads across stores that could change
the value they observe.

This drops two dead vmctx flag loads from our component-model fused adapter's
fast path.

Depends on https://github.com/bytecodealliance/wasmtime/pull/14113