### PR TITLE
Update region to 4.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3248,14 +3248,14 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "region"
-version = "3.0.2"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b6ebd13bc009aef9cd476c1310d49ac354d36e240cf1bd753290f3dc7199a7"
+checksum = "430988f137a23121407b362bf10b09df302ed5092ffeb9af90a549edcc849115"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.11.1",
  "libc",
  "mach2 0.4.3",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -21,7 +21,7 @@ cranelift-entity = { workspace = true }
 cranelift-control = { workspace = true }
 wasmtime-unwinder = { workspace = true, optional = true, features = ["cranelift"] }
 anyhow = { workspace = true }
-region = "3.0.2"
+region = "4.0.0"
 libc = { workspace = true }
 target-lexicon = { workspace = true }
 memmap2 = "0.9.11"


### PR DESCRIPTION
This bump windows-sys to 0.62, which uses raw-dylib rather than shipping large import libraries.

Fixes https://github.com/bytecodealliance/wasmtime/issues/13181