### PR TITLE
Require the reference-types feature for component-model-async

### DIFF
--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -198,6 +198,7 @@ impl Config {
         config.gc_enabled = gc.unwrap_or(false);
         config.reference_types_enabled = config.gc_enabled
             || self.module_config.function_references_enabled
+            || self.module_config.component_model_async
             || reference_types.unwrap_or(false);
         config.extended_const_enabled = extended_const.unwrap_or(false);
         config.exceptions_enabled =

--- a/crates/test-util/src/wasmtime_wast.rs
+++ b/crates/test-util/src/wasmtime_wast.rs
@@ -96,7 +96,8 @@ pub fn apply_test_config(config: &mut Config, test_config: &wast::TestConfig) {
     // downstream proposals once the end proposal is enabled (e.g. when enabling
     // gc that also enables function-references and reference-types).
     let function_references = gc || function_references.unwrap_or(false);
-    let reference_types = function_references || reference_types.unwrap_or(false);
+    let reference_types =
+        function_references || component_model_async || reference_types.unwrap_or(false);
     let simd = relaxed_simd || simd.unwrap_or(false);
 
     let exceptions = stack_switching || exceptions.unwrap_or(false);

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -2786,6 +2786,15 @@ impl Config {
             )
         }
 
+        // Generated adapters between components will use `ref.func` in some
+        // async-related situations so `component-model-async` requires
+        // `reference-types`.
+        if features.contains(WasmFeatures::CM_ASYNC)
+            && !features.contains(WasmFeatures::REFERENCE_TYPES)
+        {
+            bail!("the component-model-async feature requires the wasm reference-types proposal");
+        }
+
         // If the pooling allocator is used and GC is enabled, check that
         // memories and the GC heap are configured identically, since the
         // pooling allocator can't support differently-configured heaps.

--- a/tests/all/func.rs
+++ b/tests/all/func.rs
@@ -1140,6 +1140,7 @@ fn pass_cross_store_arg(config: &mut Config) -> wasmtime::Result<()> {
 fn externref_signature_no_reference_types() -> wasmtime::Result<()> {
     let mut config = Config::new();
     config.wasm_reference_types(false);
+    config.wasm_component_model_async(false);
     let mut store = Store::new(&Engine::new(&config)?, ());
     Func::wrap(&mut store, |_: Option<Func>| {});
     let func_ty = FuncType::new(

--- a/tests/rlimited-memory.rs
+++ b/tests/rlimited-memory.rs
@@ -58,6 +58,7 @@ fn custom_limiter_detect_os_oom_failure() -> Result<()> {
     // memory grow will hit Linux for a larger mmap.
     let mut config = Config::new();
     config.wasm_reference_types(false);
+    config.wasm_component_model_async(false);
     let engine = Engine::new(&config)?;
     let linker = Linker::new(&engine);
     let module = Module::new(&engine, r#"(module (memory (export "m") 0))"#).unwrap();


### PR DESCRIPTION
Adapters between components internally use the `ref.func` instruction which requires the reference-types proposal. Without this compilation may panic due to the adapter module not validating correctly. To handle this a new validation predicate is added to `Config` to double-check that if component-model-async is enabled that reference-types is also enabled. To avoid updating dozens of tests this updates logic to enable the reference-types proposal to implicitly do that when the component-model-async proposal is enabled for a test.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
