### PR TITLE
Fix new warnings on Rust nightly

### DIFF
--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -32,7 +32,7 @@ runs:
         elif [ "${{ inputs.toolchain }}" = "msrv" ]; then
           echo "version=1.$msrv.0" >> "$GITHUB_OUTPUT"
         elif [ "${{ inputs.toolchain }}" = "wasmtime-ci-pinned-nightly" ]; then
-          echo "version=nightly-2026-07-09" >> "$GITHUB_OUTPUT"
+          echo "version=nightly-2026-08-12" >> "$GITHUB_OUTPUT"
         elif [ "${{ inputs.toolchain }}" = "wasmtime-ci-oss-fuzz-pin" ]; then
           # Do not change this number unless OSS-Fuzz has updated. If you update
           # this version and do not update OSS-Fuzz then you will break our

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -233,8 +233,8 @@ unused_extern_crates = 'warn'
 trivial_numeric_casts = 'warn'
 unstable_features = 'warn'
 unused_import_braces = 'warn'
-unused-lifetimes = 'warn'
-unused-macro-rules = 'warn'
+unused_lifetimes = 'warn'
+unused_macro_rules = 'warn'
 
 # Don't warn about unknown cfgs for our custom cfgs.
 [workspace.lints.rust.unexpected_cfgs]

--- a/cranelift/codegen/meta/src/cdsl/typevar.rs
+++ b/cranelift/codegen/meta/src/cdsl/typevar.rs
@@ -662,7 +662,7 @@ fn range_to_set(range: Option<Range>) -> NumSet {
     assert!(low <= high);
 
     for i in low.trailing_zeros()..=high.trailing_zeros() {
-        assert!(1 << i <= RangeBound::max_value());
+        assert!(1 << i <= RangeBound::MAX);
         set.insert(1 << i);
     }
     set

--- a/cranelift/codegen/src/ir/dfg.rs
+++ b/cranelift/codegen/src/ir/dfg.rs
@@ -16,7 +16,6 @@ use core::fmt;
 use core::iter;
 use core::mem;
 use core::ops::{Index, IndexMut};
-use core::u16;
 
 use alloc::collections::BTreeMap;
 #[cfg(feature = "enable-serde")]

--- a/cranelift/codegen/src/ir/entities.rs
+++ b/cranelift/codegen/src/ir/entities.rs
@@ -22,7 +22,6 @@
 use crate::entity::entity_impl;
 use crate::ir::AliasRegion;
 use core::fmt;
-use core::u32;
 #[cfg(feature = "enable-serde")]
 use serde_derive::{Deserialize, Serialize};
 

--- a/cranelift/codegen/src/ir/extname.rs
+++ b/cranelift/codegen/src/ir/extname.rs
@@ -241,7 +241,6 @@ mod tests {
         LibCall, UserExternalName, entities::UserExternalNameRef, function::FunctionParameters,
     };
     use alloc::string::ToString;
-    use core::u32;
     use cranelift_entity::EntityRef as _;
 
     #[cfg(target_pointer_width = "64")]

--- a/cranelift/codegen/src/ir/immediates.rs
+++ b/cranelift/codegen/src/ir/immediates.rs
@@ -9,7 +9,6 @@ use core::cmp::Ordering;
 use core::fmt::{self, Display, Formatter};
 use core::ops::{Add, BitAnd, BitOr, BitXor, Div, Mul, Neg, Not, Sub};
 use core::str::FromStr;
-use core::{i32, u32};
 use libm::Libm;
 #[cfg(feature = "enable-serde")]
 use serde_derive::{Deserialize, Serialize};
@@ -1124,7 +1123,6 @@ fn parse_float(s: &str, w: u8, t: u8) -> Result<u128, &'static str> {
 mod tests {
     use super::*;
     use alloc::string::ToString;
-    use core::{f32, f64};
 
     #[test]
     fn format_imm64() {

--- a/cranelift/codegen/src/isa/aarch64/inst/imms.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/imms.rs
@@ -431,7 +431,7 @@ impl ImmLogic {
             let mask = (1 << d) - 1;
             (d, clz_a, 0, mask)
         } else {
-            (64, a.leading_zeros(), 1, u64::max_value())
+            (64, a.leading_zeros(), 1, u64::MAX)
         };
 
         // If the repeat period d is not a power of two, it can't be encoded.
@@ -476,7 +476,7 @@ impl ImmLogic {
         // makes the answer come out right for stretches that reach the very top of
         // the word (e.g. numbers like 0xffffc00000000000).
         let clz_b = if b == 0 {
-            u32::max_value() // -1
+            u32::MAX // -1
         } else {
             b.leading_zeros()
         };
@@ -489,7 +489,7 @@ impl ImmLogic {
             // where we compensate: the number of set bits becomes the number of clear
             // bits, and the rotation count is based on position b rather than position
             // a (since b is the location of the 'lowest' 1 bit after inversion).
-            // Need wrapping for when clz_b is max_value() (for when b == 0).
+            // Need wrapping for when clz_b is u32::MAX (for when b == 0).
             (d - s, clz_b.wrapping_add(1) & (d - 1))
         } else {
             (s, (clz_a + 1) & (d - 1))
@@ -977,7 +977,7 @@ mod test {
     #[test]
     fn imm_logical_test() {
         assert_eq!(None, ImmLogic::maybe_from_u64(0, I64));
-        assert_eq!(None, ImmLogic::maybe_from_u64(u64::max_value(), I64));
+        assert_eq!(None, ImmLogic::maybe_from_u64(u64::MAX, I64));
 
         assert_eq!(
             Some(ImmLogic {
@@ -1064,13 +1064,13 @@ mod test {
 
         assert_eq!(
             Some(ImmLogic {
-                value: u64::max_value() - 1,
+                value: u64::MAX - 1,
                 n: true,
                 r: 63,
                 s: 62,
                 size: OperandSize::Size64,
             }),
-            ImmLogic::maybe_from_u64(u64::max_value() - 1, I64)
+            ImmLogic::maybe_from_u64(u64::MAX - 1, I64)
         );
 
         assert_eq!(

--- a/cranelift/codegen/src/isa/aarch64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower/isle.rs
@@ -33,7 +33,6 @@ use crate::{
 };
 use alloc::boxed::Box;
 use alloc::vec::Vec;
-use core::u32;
 use regalloc2::PReg;
 
 type BoxCallInfo = Box<CallInfo<ExternalName>>;
@@ -259,7 +258,7 @@ impl Context for IsleContext<'_, '_, MInst, AArch64Backend> {
     fn lshl_from_u64(&mut self, ty: Type, n: u64) -> Option<ShiftOpAndAmt> {
         let shiftimm = ShiftOpShiftImm::maybe_from_shift(n)?;
         let shiftee_bits = ty_bits(ty);
-        if shiftee_bits <= core::u8::MAX as usize {
+        if shiftee_bits <= u8::MAX as usize {
             let shiftimm = shiftimm.mask(shiftee_bits as u8);
             Some(ShiftOpAndAmt::new(ShiftOp::LSL, shiftimm))
         } else {
@@ -270,7 +269,7 @@ impl Context for IsleContext<'_, '_, MInst, AArch64Backend> {
     fn ashr_from_u64(&mut self, ty: Type, n: u64) -> Option<ShiftOpAndAmt> {
         let shiftimm = ShiftOpShiftImm::maybe_from_shift(n)?;
         let shiftee_bits = ty_bits(ty);
-        if shiftee_bits <= core::u8::MAX as usize {
+        if shiftee_bits <= u8::MAX as usize {
             let shiftimm = shiftimm.mask(shiftee_bits as u8);
             Some(ShiftOpAndAmt::new(ShiftOp::ASR, shiftimm))
         } else {

--- a/cranelift/codegen/src/isa/unwind/winx64.rs
+++ b/cranelift/codegen/src/isa/unwind/winx64.rs
@@ -92,7 +92,7 @@ impl UnwindCode {
                 };
                 writer.write_u8(*instruction_offset);
                 let scaled_stack_offset = stack_offset / 16;
-                if scaled_stack_offset <= core::u16::MAX as u32 {
+                if scaled_stack_offset <= u16::MAX as u32 {
                     writer.write_u8((*reg << 4) | (op_small as u8));
                     writer.write_u16_le(scaled_stack_offset as u16);
                 } else {
@@ -141,7 +141,7 @@ impl UnwindCode {
                 }
             }
             Self::SaveXmm { stack_offset, .. } | Self::SaveReg { stack_offset, .. } => {
-                if *stack_offset <= core::u16::MAX as u32 {
+                if *stack_offset <= u16::MAX as u32 {
                     2
                 } else {
                     3

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -1131,7 +1131,7 @@ pub(crate) fn emit(
                         inst.emit(sink, info, state);
                     }
                     OperandSize::Size64 => {
-                        // An f64 can represent `i32::min_value() - 1` exactly with precision to spare,
+                        // An f64 can represent `i32::MIN - 1` exactly with precision to spare,
                         // so there are values less than -2^(N-1) that convert correctly to INT_MIN.
                         let cst = if output_bits < 64 {
                             no_overflow_cc = CC::NBE; // >
@@ -1363,9 +1363,9 @@ pub(crate) fn emit(
                 let inst = Inst::imm(
                     OperandSize::Size64,
                     if *dst_size == OperandSize::Size64 {
-                        u64::max_value()
+                        u64::MAX
                     } else {
-                        u32::max_value() as u64
+                        u64::from(u32::MAX)
                     },
                     dst,
                 );

--- a/cranelift/entity/src/lib.rs
+++ b/cranelift/entity/src/lib.rs
@@ -121,7 +121,7 @@ macro_rules! entity_impl {
         impl $crate::EntityRef for $entity {
             #[inline]
             fn new(index: usize) -> Self {
-                debug_assert!(index < ($crate::__core::u32::MAX as usize));
+                debug_assert!(index < (u32::MAX as usize));
                 $entity(index as u32)
             }
 
@@ -134,12 +134,12 @@ macro_rules! entity_impl {
         impl $crate::packed_option::ReservedValue for $entity {
             #[inline]
             fn reserved_value() -> $entity {
-                $entity($crate::__core::u32::MAX)
+                $entity(u32::MAX)
             }
 
             #[inline]
             fn is_reserved_value(&self) -> bool {
-                self.0 == $crate::__core::u32::MAX
+                self.0 == u32::MAX
             }
         }
 
@@ -148,7 +148,7 @@ macro_rules! entity_impl {
             #[allow(dead_code, reason = "macro-generated code")]
             #[inline]
             pub fn from_u32(x: u32) -> Self {
-                debug_assert!(x < $crate::__core::u32::MAX);
+                debug_assert!(x < u32::MAX);
                 $entity(x)
             }
 
@@ -211,7 +211,7 @@ macro_rules! entity_impl {
         impl $crate::EntityRef for $entity {
             #[inline]
             fn new(index: usize) -> Self {
-                debug_assert!(index < ($crate::__core::u32::MAX as usize));
+                debug_assert!(index < (u32::MAX as usize));
                 let $arg = index as u32;
                 $to_expr
             }
@@ -226,12 +226,12 @@ macro_rules! entity_impl {
         impl $crate::packed_option::ReservedValue for $entity {
             #[inline]
             fn reserved_value() -> $entity {
-                $entity::from_u32($crate::__core::u32::MAX)
+                $entity::from_u32(u32::MAX)
             }
 
             #[inline]
             fn is_reserved_value(&self) -> bool {
-                self.as_u32() == $crate::__core::u32::MAX
+                self.as_u32() == u32::MAX
             }
         }
 
@@ -240,7 +240,7 @@ macro_rules! entity_impl {
             #[allow(dead_code, reason = "macro-generated code")]
             #[inline]
             pub fn from_u32(x: u32) -> Self {
-                debug_assert!(x < $crate::__core::u32::MAX);
+                debug_assert!(x < u32::MAX);
                 let $arg = x;
                 $to_expr
             }

--- a/cranelift/entity/src/set.rs
+++ b/cranelift/entity/src/set.rs
@@ -200,7 +200,6 @@ where
 mod tests {
     use super::*;
     use alloc::{format, vec::Vec};
-    use core::u32;
 
     // `EntityRef` impl for testing.
     #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]

--- a/cranelift/entity/src/sparse.rs
+++ b/cranelift/entity/src/sparse.rs
@@ -13,7 +13,6 @@ use alloc::vec::Vec;
 use core::fmt;
 use core::mem;
 use core::slice;
-use core::u32;
 
 #[cfg(feature = "enable-serde")]
 use serde_derive::{Deserialize, Serialize};

--- a/cranelift/frontend/src/variable.rs
+++ b/cranelift/frontend/src/variable.rs
@@ -8,7 +8,6 @@
 //! Thus, make sure that Variable's indexes are allocated contiguously and
 //! starting at `0`.
 
-use core::u32;
 use cranelift_codegen::entity::entity_impl;
 
 /// An opaque reference to a variable.

--- a/cranelift/reader/src/lexer.rs
+++ b/cranelift/reader/src/lexer.rs
@@ -4,7 +4,6 @@ use crate::error::Location;
 use cranelift_codegen::ir::types;
 use cranelift_codegen::ir::{Block, Value};
 use std::str::CharIndices;
-use std::u16;
 
 /// A Token returned from the `Lexer`.
 ///

--- a/cranelift/reader/src/parser.rs
+++ b/cranelift/reader/src/parser.rs
@@ -29,7 +29,6 @@ use cranelift_codegen::{settings, settings::Configurable, timing};
 use smallvec::SmallVec;
 use std::mem;
 use std::str::FromStr;
-use std::{u16, u32};
 use target_lexicon::Triple;
 
 macro_rules! match_imm {

--- a/crates/c-api/src/types.rs
+++ b/crates/c-api/src/types.rs
@@ -7,7 +7,7 @@ pub struct wasm_limits_t {
 
 impl wasm_limits_t {
     pub(crate) fn max(&self) -> Option<u32> {
-        if self.max == u32::max_value() {
+        if self.max == u32::MAX {
             None
         } else {
             Some(self.max)

--- a/crates/c-api/src/types/memory.rs
+++ b/crates/c-api/src/types/memory.rs
@@ -61,7 +61,7 @@ pub extern "C" fn wasm_memorytype_limits(mt: &wasm_memorytype_t) -> &wasm_limits
     let mt = mt.ty();
     mt.limits_cache.get_or_init(|| wasm_limits_t {
         min: u32::try_from(mt.ty.minimum()).unwrap(),
-        max: u32::try_from(mt.ty.maximum().unwrap_or(u64::from(u32::max_value()))).unwrap(),
+        max: u32::try_from(mt.ty.maximum().unwrap_or(u64::from(u32::MAX))).unwrap(),
     })
 }
 

--- a/crates/cache/src/worker.rs
+++ b/crates/cache/src/worker.rs
@@ -66,8 +66,8 @@ enum CacheEvent {
 impl Worker {
     pub(super) fn start_new(cache_config: &CacheConfig) -> Self {
         let queue_size = match cache_config.worker_event_queue_size() {
-            num if num <= usize::max_value() as u64 => num as usize,
-            _ => usize::max_value(),
+            num if num <= usize::MAX as u64 => num as usize,
+            _ => usize::MAX,
         };
         let (tx, rx) = sync_channel(queue_size);
 

--- a/crates/core/src/error/context.rs
+++ b/crates/core/src/error/context.rs
@@ -46,6 +46,7 @@ mod sealed {
 /// assert_eq!(x, 42);
 ///
 /// let error = u32_to_u8(999).unwrap_err();
+/// let std_error = u8::try_from(999_u32).unwrap_err();
 ///
 /// // The error is a `String` because of our added context.
 /// assert!(error.is::<String>());
@@ -58,18 +59,18 @@ mod sealed {
 /// assert!(error.is::<std::num::TryFromIntError>());
 /// assert_eq!(
 ///     error.root_cause().to_string(),
-///     "out of range integral type conversion attempted",
+///     std_error.to_string(),
 /// );
 ///
 /// // The debug output of the error contains the full error chain.
 /// assert_eq!(
 ///     format!("{error:?}").trim(),
-///     r#"
+///     format!(r#"
 /// failed to convert `999` into a `u8` (max = `255`)
 ///
 /// Caused by:
-///     out of range integral type conversion attempted
-///     "#.trim(),
+///     {std_error}
+///     "#).trim(),
 /// );
 /// ```
 ///

--- a/crates/core/src/math.rs
+++ b/crates/core/src/math.rs
@@ -39,12 +39,12 @@
 /// converted to.
 pub const fn f32_cvt_to_int_bounds(signed: bool, out_bits: u32) -> (f32, f32) {
     match (signed, out_bits) {
-        (true, 8) => (i8::min_value() as f32 - 1., i8::max_value() as f32 + 1.),
-        (true, 16) => (i16::min_value() as f32 - 1., i16::max_value() as f32 + 1.),
+        (true, 8) => (i8::MIN as f32 - 1., i8::MAX as f32 + 1.),
+        (true, 16) => (i16::MIN as f32 - 1., i16::MAX as f32 + 1.),
         (true, 32) => (-2147483904.0, 2147483648.0),
         (true, 64) => (-9223373136366403584.0, 9223372036854775808.0),
-        (false, 8) => (-1., u8::max_value() as f32 + 1.),
-        (false, 16) => (-1., u16::max_value() as f32 + 1.),
+        (false, 8) => (-1., u8::MAX as f32 + 1.),
+        (false, 16) => (-1., u16::MAX as f32 + 1.),
         (false, 32) => (-1., 4294967296.0),
         (false, 64) => (-1., 18446744073709551616.0),
         _ => unreachable!(),
@@ -54,12 +54,12 @@ pub const fn f32_cvt_to_int_bounds(signed: bool, out_bits: u32) -> (f32, f32) {
 /// Same as [`f32_cvt_to_int_bounds`] but used for f64-to-int conversions.
 pub const fn f64_cvt_to_int_bounds(signed: bool, out_bits: u32) -> (f64, f64) {
     match (signed, out_bits) {
-        (true, 8) => (i8::min_value() as f64 - 1., i8::max_value() as f64 + 1.),
-        (true, 16) => (i16::min_value() as f64 - 1., i16::max_value() as f64 + 1.),
+        (true, 8) => (i8::MIN as f64 - 1., i8::MAX as f64 + 1.),
+        (true, 16) => (i16::MIN as f64 - 1., i16::MAX as f64 + 1.),
         (true, 32) => (-2147483649.0, 2147483648.0),
         (true, 64) => (-9223372036854777856.0, 9223372036854775808.0),
-        (false, 8) => (-1., u8::max_value() as f64 + 1.),
-        (false, 16) => (-1., u16::max_value() as f64 + 1.),
+        (false, 8) => (-1., u8::MAX as f64 + 1.),
+        (false, 16) => (-1., u16::MAX as f64 + 1.),
         (false, 32) => (-1., 4294967296.0),
         (false, 64) => (-1., 18446744073709551616.0),
         _ => unreachable!(),

--- a/crates/cranelift/src/compiled_function.rs
+++ b/crates/cranelift/src/compiled_function.rs
@@ -163,7 +163,7 @@ impl CompiledFunction {
     /// Create and return the compiled function address map from the original source offset
     /// and length.
     pub fn set_address_map(&mut self, offset: u32, length: u32, with_instruction_addresses: bool) {
-        assert!((offset + length) <= u32::max_value());
+        assert!((offset + length) <= u32::MAX);
         let len = self.buffer.data().len();
         let srclocs = self
             .buffer

--- a/crates/cranelift/src/translate/translation_utils.rs
+++ b/crates/cranelift/src/translate/translation_utils.rs
@@ -1,7 +1,6 @@
 //! Helper functions and structures for the translation.
 use crate::func_environ::FuncEnvironment;
 use crate::translate::environ::TargetEnvironment;
-use core::u32;
 use cranelift_codegen::ir;
 use cranelift_frontend::FunctionBuilder;
 use smallvec::SmallVec;

--- a/crates/environ/src/module_artifacts.rs
+++ b/crates/environ/src/module_artifacts.rs
@@ -7,7 +7,7 @@ use crate::{
     PanicOnOom as _,
 };
 use core::ops::Range;
-use core::{fmt, u32};
+use core::fmt;
 use core::{iter, str};
 use serde_derive::{Deserialize, Serialize};
 #[cfg(feature = "rr")]

--- a/crates/environ/src/module_artifacts.rs
+++ b/crates/environ/src/module_artifacts.rs
@@ -6,8 +6,8 @@ use crate::{
     EntityRef, FilePos, FuncIndex, FuncKey, FuncKeyIndex, FuncKeyKind, FuncKeyNamespace, Module,
     PanicOnOom as _,
 };
-use core::ops::Range;
 use core::fmt;
+use core::ops::Range;
 use core::{iter, str};
 use serde_derive::{Deserialize, Serialize};
 #[cfg(feature = "rr")]

--- a/crates/jit-icache-coherence/src/lib.rs
+++ b/crates/jit-icache-coherence/src/lib.rs
@@ -66,10 +66,8 @@
 //! ```
 //!
 //! <div class="example-wrap" style="display:inline-block"><pre class="compile_fail" style="white-space:normal;font:inherit;">
-//!
-//!  **Warning**: In order to correctly use this interface you should always call [clear_cache].
-//!  A followup call to [pipeline_flush_mt] is required if you are running in a multi-threaded environment.
-//!
+//! **Warning**: In order to correctly use this interface you should always call [clear_cache].
+//! A followup call to [pipeline_flush_mt] is required if you are running in a multi-threaded environment.
 //! </pre></div>
 //!
 //! [ARM Community - Caches and Self-Modifying Code]: https://community.arm.com/arm-community-blogs/b/architectures-and-processors-blog/posts/caches-and-self-modifying-code

--- a/crates/test-programs/src/bin/p1_poll_oneoff_files.rs
+++ b/crates/test-programs/src/bin/p1_poll_oneoff_files.rs
@@ -247,7 +247,7 @@ unsafe fn test_fd_readwrite_valid_fd(dir_fd: wasip1::Fd, blocking_mode: Blocking
 
 unsafe fn test_fd_readwrite_invalid_fd() {
     let fd_readwrite = wasip1::SubscriptionFdReadwrite {
-        file_descriptor: wasip1::Fd::max_value(),
+        file_descriptor: wasip1::Fd::MAX,
     };
     let r#in = [
         wasip1::Subscription {

--- a/crates/wasmtime/src/runtime/component/bindgen_examples/mod.rs
+++ b/crates/wasmtime/src/runtime/component/bindgen_examples/mod.rs
@@ -592,10 +592,10 @@ pub mod _7_async;
 ///     type Data<'a> = &'a mut MyState;
 /// }
 ///
-/// impl MyWorldImportsWithStore for MyState {
+/// impl<T> MyWorldImportsWithStore<T> for MyState {
 ///     /// Synchronous functions that have access to the store are defined in
 ///     /// Rust as a normal `fn` with an `Access` as the first parameter.
-///     fn sync_with_store<T>(mut host: Access<'_, T, Self>) {
+///     fn sync_with_store(mut host: Access<'_, T, Self>) {
 ///         // The `Access` type implements `AsContextMut` to manipulate and
 ///         // operate on the store.
 ///         let mut store: StoreContextMut<'_, T> = host.as_context_mut();
@@ -608,7 +608,7 @@ pub mod _7_async;
 ///
 ///     /// Asynchronous functions that have access to the store are defined in
 ///     /// Rust as an `async fn` with an `Accessor` as the first parameter.
-///     async fn async_with_store<T>(accessor: &Accessor<T, Self>) {
+///     async fn async_with_store(accessor: &Accessor<T, Self>) {
 ///         // The `Accessor` type does not implement `AsContextMut` directly
 ///         // and instead represents the ability to, synchronously, work with
 ///         // the store. Notably borrows into the store or `Self` cannot be

--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -717,7 +717,7 @@ impl Func {
     /// let instance = Instance::new(&mut store, &module, &[add.into()])?;
     /// let foo = instance.get_typed_func::<(i32, i32), i32>(&mut store, "foo")?;
     /// assert_eq!(foo.call(&mut store, (1, 2))?, 3);
-    /// assert!(foo.call(&mut store, (i32::max_value(), 1)).is_err());
+    /// assert!(foo.call(&mut store, (i32::MAX, 1)).is_err());
     /// # Ok(())
     /// # }
     /// ```
@@ -1405,7 +1405,7 @@ impl Func {
     /// # use wasmtime::*;
     /// # fn foo(add_with_overflow: &Func, mut store: Store<()>) -> Result<()> {
     /// let typed = add_with_overflow.typed::<(u32, u32), (u32, i32)>(&store)?;
-    /// let (result, overflow) = typed.call(&mut store, (u32::max_value(), 2))?;
+    /// let (result, overflow) = typed.call(&mut store, (u32::MAX, 2))?;
     /// assert_eq!(result, 1);
     /// assert_eq!(overflow, 1);
     /// # Ok(())

--- a/crates/wasmtime/src/runtime/vm/table.rs
+++ b/crates/wasmtime/src/runtime/vm/table.rs
@@ -12,7 +12,7 @@ use core::mem;
 use core::ops::Range;
 use core::ptr::NonNull;
 use core::slice;
-use core::{cmp, usize};
+use core::cmp;
 use wasmtime_environ::{
     FUNCREF_INIT_BIT, FUNCREF_MASK, IndexType, Trap, Tunables, WasmHeapTopType, WasmRefType,
 };

--- a/crates/wasmtime/src/runtime/vm/table.rs
+++ b/crates/wasmtime/src/runtime/vm/table.rs
@@ -8,11 +8,11 @@ use crate::runtime::vm::stack_switching::VMContObj;
 use crate::runtime::vm::vmcontext::{VMFuncRef, VMTableDefinition};
 use crate::runtime::vm::{GcStore, SendSyncPtr, VMGcRef, VmPtr};
 use core::alloc::Layout;
+use core::cmp;
 use core::mem;
 use core::ops::Range;
 use core::ptr::NonNull;
 use core::slice;
-use core::cmp;
 use wasmtime_environ::{
     FUNCREF_INIT_BIT, FUNCREF_MASK, IndexType, Trap, Tunables, WasmHeapTopType, WasmRefType,
 };

--- a/crates/wasmtime/src/runtime/vm/vmcontext.rs
+++ b/crates/wasmtime/src/runtime/vm/vmcontext.rs
@@ -799,7 +799,7 @@ impl Default for VMStoreContext {
             fuel_consumed: UnsafeCell::new(0),
             epoch_deadline: UnsafeCell::new(0),
             execution_version: 0,
-            stack_limit: UnsafeCell::new(usize::max_value()),
+            stack_limit: UnsafeCell::new(usize::MAX),
             gc_heap: UnsafeCell::new(VMMemoryDefinition {
                 base: NonNull::dangling().into(),
                 current_length: AtomicUsize::new(0),

--- a/crates/wiggle/tests/ints.rs
+++ b/crates/wiggle/tests/ints.rs
@@ -24,7 +24,7 @@ impl<'a> ints::Ints for WasiCtx<'a> {
 }
 
 fn cookie_strat() -> impl Strategy<Value = types::Cookie> {
-    (0..std::u64::MAX)
+    (0..u64::MAX)
         .prop_map(|x| types::Cookie::try_from(x).expect("within range of cookie"))
         .boxed()
 }


### PR DESCRIPTION
Getting out ahead of Rust's release trains to keep us warning-free.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
