### PR TITLE
Run linker callback finalizers on invalid names

### DIFF
--- a/crates/c-api/src/async.rs
+++ b/crates/c-api/src/async.rs
@@ -288,9 +288,9 @@ pub unsafe extern "C" fn wasmtime_linker_define_async_func(
     finalizer: Option<extern "C" fn(*mut std::ffi::c_void)>,
 ) -> Option<Box<wasmtime_error_t>> {
     let ty = ty.ty().ty(linker.linker.engine());
+    let cb = c_async_callback_to_rust_fn(callback, data, finalizer);
     let module = to_str!(module, module_len);
     let name = to_str!(name, name_len);
-    let cb = c_async_callback_to_rust_fn(callback, data, finalizer);
 
     handle_result(
         linker.linker.func_new_async(module, name, ty, cb),

--- a/crates/c-api/src/linker.rs
+++ b/crates/c-api/src/linker.rs
@@ -79,9 +79,9 @@ pub unsafe extern "C" fn wasmtime_linker_define_func(
     finalizer: Option<extern "C" fn(*mut std::ffi::c_void)>,
 ) -> Option<Box<wasmtime_error_t>> {
     let ty = ty.ty().ty(linker.linker.engine());
+    let cb = crate::func::c_callback_to_rust_fn(callback, data, finalizer);
     let module = to_str!(module, module_len);
     let name = to_str!(name, name_len);
-    let cb = crate::func::c_callback_to_rust_fn(callback, data, finalizer);
     handle_result(linker.linker.func_new(module, name, ty, cb), |_linker| ())
 }
 
@@ -98,9 +98,9 @@ pub unsafe extern "C" fn wasmtime_linker_define_func_unchecked(
     finalizer: Option<extern "C" fn(*mut std::ffi::c_void)>,
 ) -> Option<Box<wasmtime_error_t>> {
     let ty = ty.ty().ty(linker.linker.engine());
+    let cb = crate::func::c_unchecked_callback_to_rust_fn(callback, data, finalizer);
     let module = to_str!(module, module_len);
     let name = to_str!(name, name_len);
-    let cb = crate::func::c_unchecked_callback_to_rust_fn(callback, data, finalizer);
     handle_result(
         linker.linker.func_new_unchecked(module, name, ty, cb),
         |_linker| (),

--- a/crates/c-api/tests/async.cc
+++ b/crates/c-api/tests/async.cc
@@ -6,6 +6,33 @@
 
 using namespace wasmtime;
 
+namespace {
+
+void async_callback(void *, wasmtime_caller_t *, const wasmtime_val_t *, size_t,
+                    wasmtime_val_t *, size_t, wasm_trap_t **,
+                    wasmtime_async_continuation_t *) {}
+
+void finalize(void *data) { *static_cast<bool *>(data) = true; }
+
+} // namespace
+
+TEST(async, finalizes_callback_when_name_parsing_fails) {
+  Engine engine;
+  Linker linker(engine);
+  auto *ty = wasm_functype_new_0_0();
+  const char invalid_utf8[] = {static_cast<char>(0xff)};
+  bool finalized = false;
+
+  auto *error = wasmtime_linker_define_async_func(
+      linker.capi(), invalid_utf8, sizeof(invalid_utf8), "name", 4, ty,
+      async_callback, &finalized, finalize);
+
+  ASSERT_NE(error, nullptr);
+  wasmtime_error_delete(error);
+  EXPECT_TRUE(finalized);
+  wasm_functype_delete(ty);
+}
+
 TEST(async, call_func_async) {
   Engine engine;
   Store store(engine);

--- a/crates/c-api/tests/linker.cc
+++ b/crates/c-api/tests/linker.cc
@@ -1,8 +1,25 @@
 #include <gtest/gtest.h>
+#include <wasmtime.h>
 #include <wasmtime/func.hh>
 #include <wasmtime/linker.hh>
 
 using namespace wasmtime;
+
+namespace {
+
+wasm_trap_t *callback(void *, wasmtime_caller_t *, const wasmtime_val_t *,
+                      size_t, wasmtime_val_t *, size_t) {
+  return nullptr;
+}
+
+wasm_trap_t *unchecked_callback(void *, wasmtime_caller_t *,
+                                wasmtime_val_raw_t *, size_t) {
+  return nullptr;
+}
+
+void finalize(void *data) { *static_cast<bool *>(data) = true; }
+
+} // namespace
 
 TEST(Linker, Smoke) {
   Engine engine;
@@ -73,6 +90,31 @@ TEST(Linker, CallableCopy) {
 
   CallableFunc cf;
   linker.func_new("a", "f", FuncType({}, {}), cf).unwrap();
+}
+
+TEST(Linker, FinalizesCallbacksWhenNameParsingFails) {
+  Engine engine;
+  Linker linker(engine);
+  auto *ty = wasm_functype_new_0_0();
+  const char invalid_utf8[] = {static_cast<char>(0xff)};
+
+  bool finalized = false;
+  auto *error = wasmtime_linker_define_func(linker.capi(), invalid_utf8,
+                                            sizeof(invalid_utf8), "name", 4, ty,
+                                            callback, &finalized, finalize);
+  ASSERT_NE(error, nullptr);
+  wasmtime_error_delete(error);
+  EXPECT_TRUE(finalized);
+
+  finalized = false;
+  error = wasmtime_linker_define_func_unchecked(
+      linker.capi(), "module", 6, invalid_utf8, sizeof(invalid_utf8), ty,
+      unchecked_callback, &finalized, finalize);
+  ASSERT_NE(error, nullptr);
+  wasmtime_error_delete(error);
+  EXPECT_TRUE(finalized);
+
+  wasm_functype_delete(ty);
 }
 
 TEST(Linker, DefineUnknownImportsAsTraps) {


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->


Follow-up to bytecodealliance/wasmtime-go#293.

When one of the linker function APIs receives an invalid UTF-8 module or function name, `to_str!` returns an error before the Rust callback closure is constructed.

The closure owns the C-provided `data` and `finalizer` through `ForeignData`.

Constructing it after parsing the names therefore means that the finalizer is not called when name parsing fails.

Move callback construction before UTF-8 validation in:

- `wasmtime_linker_define_func`
- `wasmtime_linker_define_func_unchecked`
- `wasmtime_linker_define_async_func`

This transfers ownership of `data` to `ForeignData` before any fallible name parsing. If parsing fails, normal Rust drop behavior invokes the finalizer.

Regression tests verify this behavior for the checked, unchecked, and async linker function APIs.

## Testing

- C API test suite: 137/137 passed
- `cargo fmt --all -- --check`
- clang-format dry run on the modified C++ test files
