### PR TITLE
Fix panic compiling an empty component with debug info

### DIFF
--- a/crates/cranelift/src/debug/transform/simulate.rs
+++ b/crates/cranelift/src/debug/transform/simulate.rs
@@ -296,8 +296,15 @@ pub fn generate_simulated_dwarf(
     out_strings: &mut write::StringTable,
     isa: &dyn TargetIsa,
 ) -> Result<(), Error> {
+    // A component without any core modules has no functions to describe, and
+    // the compilation unit below names itself after the first translation's
+    // wasm file. There is nothing to simulate, so leave the DWARF empty.
+    let Some((_, first_translation)) = compilation.translations.iter().next() else {
+        return Ok(());
+    };
+
     let (wasm_file, path) = {
-        let di = &compilation.translations.iter().next().unwrap().1.debuginfo;
+        let di = &first_translation.debuginfo;
         let path = di
             .wasm_file
             .path

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -3716,3 +3716,21 @@ fn non_utf8_raises_error() -> Result<()> {
     }
     Ok(())
 }
+
+#[test]
+fn compile_empty_component_with_debug_info() -> Result<()> {
+    // A component with no core modules reached simulated-DWARF generation with
+    // nothing to describe, which used to panic instead of compiling.
+    let td = TempDir::new()?;
+    let cwasm = td.path().join("empty-component.cwasm");
+    let stdout = run_wasmtime(&[
+        "compile",
+        "-D",
+        "debug-info=y",
+        "tests/all/cli_tests/empty_component.wat",
+        "-o",
+        cwasm.to_str().unwrap(),
+    ])?;
+    assert_eq!(stdout, "");
+    Ok(())
+}

--- a/tests/all/cli_tests/empty_component.wat
+++ b/tests/all/cli_tests/empty_component.wat
@@ -1,0 +1,1 @@
+(component)


### PR DESCRIPTION
Fixes #14100.

generate_simulated_dwarf unwrapped the first core-module translation to name its compilation unit, but a component with no core modules has no translations, so `wasmtime compile -D debug-info=y` panicked on a valid `(component)` input. Return early instead: with no translations there are no functions to describe.