### PR TITLE
winch: compile exceptions as uncatchable traps

### DIFF
--- a/crates/test-util/src/wast.rs
+++ b/crates/test-util/src/wast.rs
@@ -458,7 +458,6 @@ impl Compiler {
                     || config.tail_call()
                     || config.function_references()
                     || config.relaxed_simd()
-                    || config.exceptions()
                     || config.legacy_exceptions()
                     || config.stack_switching()
                 {
@@ -564,11 +563,15 @@ impl WastTest {
             let unsupported = [
                 "extended-const/elem.wast",
                 "extended-const/global.wast",
-                "misc_testsuite/component-model/modules.wast",
                 "misc_testsuite/externref-segments.wast",
                 "misc_testsuite/externref-table-dropped-segment-issue-8281.wast",
                 "misc_testsuite/many_table_gets_lead_to_gc.wast",
                 "misc_testsuite/no-panic.wast",
+                // Currently exceptions trap on throw, re-enable after catch
+                // is implemented.
+                "misc_testsuite/traps-skip-catch-all.wast",
+                "misc_testsuite/component-model/async/exceptions.wast",
+                "spec_testsuite/throw.wast",
             ];
 
             if unsupported.iter().any(|part| self.path.ends_with(part)) {

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -3045,20 +3045,6 @@ impl Config {
             bail!("cannot disable the simd proposal but enable the relaxed simd proposal");
         }
 
-        // The GC, function-references, and exception-handling proposals require
-        // Wasmtime's GC runtime support.
-        if !features.contains(WasmFeatures::GC_TYPES) {
-            if features.contains(WasmFeatures::EXCEPTIONS) {
-                bail!("cannot disable gc support but enable the exceptions proposal");
-            }
-            if features.contains(WasmFeatures::GC) {
-                bail!("cannot disable gc support but enable the gc proposal");
-            }
-            if features.contains(WasmFeatures::FUNCTION_REFERENCES) {
-                bail!("cannot disable gc support but enable the function-references proposal");
-            }
-        }
-
         if features.contains(WasmFeatures::STACK_SWITCHING) {
             use target_lexicon::OperatingSystem;
             let model = match target.operating_system {

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -2467,11 +2467,12 @@ impl Config {
                 }
             }
             Some(Strategy::Winch) => {
+                // Exception handling in Winch is a work in progress. Throws currently
+                // compile as uncatchable traps.
                 unsupported |= WasmFeatures::GC
                     | WasmFeatures::FUNCTION_REFERENCES
                     | WasmFeatures::RELAXED_SIMD
                     | WasmFeatures::TAIL_CALL
-                    | WasmFeatures::EXCEPTIONS
                     | WasmFeatures::LEGACY_EXCEPTIONS
                     | WasmFeatures::STACK_SWITCHING;
 
@@ -3042,6 +3043,20 @@ impl Config {
 
         if features.contains(WasmFeatures::RELAXED_SIMD) && !features.contains(WasmFeatures::SIMD) {
             bail!("cannot disable the simd proposal but enable the relaxed simd proposal");
+        }
+
+        // The GC, function-references, and exception-handling proposals require
+        // Wasmtime's GC runtime support.
+        if !features.contains(WasmFeatures::GC_TYPES) {
+            if features.contains(WasmFeatures::EXCEPTIONS) {
+                bail!("cannot disable gc support but enable the exceptions proposal");
+            }
+            if features.contains(WasmFeatures::GC) {
+                bail!("cannot disable gc support but enable the gc proposal");
+            }
+            if features.contains(WasmFeatures::FUNCTION_REFERENCES) {
+                bail!("cannot disable gc support but enable the function-references proposal");
+            }
         }
 
         if features.contains(WasmFeatures::STACK_SWITCHING) {

--- a/tests/all/exceptions.rs
+++ b/tests/all/exceptions.rs
@@ -3,7 +3,8 @@ use std::sync::atomic::{AtomicBool, Ordering::Relaxed};
 use wasmtime::*;
 use wasmtime_test_macros::wasmtime_test;
 
-#[wasmtime_test(wasm_features(exceptions))]
+// Currently exceptions trap on throw, re-enable after catch is implemented.
+#[wasmtime_test(strategies(not(Winch)), wasm_features(exceptions))]
 #[cfg_attr(miri, ignore)]
 fn basic_throw(config: &mut Config) -> Result<()> {
     let engine = Engine::new(config)?;
@@ -39,7 +40,8 @@ fn basic_throw(config: &mut Config) -> Result<()> {
     Ok(())
 }
 
-#[wasmtime_test(wasm_features(exceptions))]
+// Currently exceptions trap on throw, re-enable after catch is implemented.
+#[wasmtime_test(strategies(not(Winch)), wasm_features(exceptions))]
 #[cfg_attr(miri, ignore)]
 fn dynamic_tags(config: &mut Config) -> Result<()> {
     let engine = Engine::new(config)?;
@@ -99,7 +101,8 @@ fn dynamic_tags(config: &mut Config) -> Result<()> {
     Ok(())
 }
 
-#[wasmtime_test(wasm_features(exceptions))]
+// Currently exceptions trap on throw, re-enable after catch is implemented.
+#[wasmtime_test(strategies(not(Winch)), wasm_features(exceptions))]
 #[cfg_attr(miri, ignore)]
 fn exception_escape_to_host(config: &mut Config) -> Result<()> {
     let engine = Engine::new(config)?;
@@ -132,7 +135,8 @@ fn exception_escape_to_host(config: &mut Config) -> Result<()> {
     Ok(())
 }
 
-#[wasmtime_test(wasm_features(exceptions))]
+// Currently exceptions trap on throw, re-enable after catch is implemented.
+#[wasmtime_test(strategies(not(Winch)), wasm_features(exceptions))]
 #[cfg_attr(miri, ignore)]
 fn exception_from_host(config: &mut Config) -> Result<()> {
     let engine = Engine::new(config)?;
@@ -272,7 +276,8 @@ fn thrown_exception_without_throwing(config: &mut Config) -> Result<()> {
     Ok(())
 }
 
-#[wasmtime_test(wasm_features(exceptions))]
+// Currently exceptions trap on throw, re-enable after catch is implemented.
+#[wasmtime_test(strategies(not(Winch)), wasm_features(exceptions))]
 #[cfg_attr(miri, ignore)]
 fn wasm_exceptions_have_backtraces(config: &mut Config) -> Result<()> {
     let engine = Engine::new(config)?;
@@ -298,7 +303,8 @@ fn wasm_exceptions_have_backtraces(config: &mut Config) -> Result<()> {
     Ok(())
 }
 
-#[wasmtime_test(wasm_features(exceptions))]
+// Currently exceptions trap on throw, re-enable after catch is implemented.
+#[wasmtime_test(strategies(not(Winch)), wasm_features(exceptions))]
 #[cfg_attr(miri, ignore)]
 fn store_pending_exnref_is_cloned(config: &mut Config) -> wasmtime::Result<()> {
     config.collector(Collector::DeferredReferenceCounting);
@@ -353,7 +359,8 @@ fn store_pending_exnref_is_cloned(config: &mut Config) -> wasmtime::Result<()> {
     Ok(())
 }
 
-#[wasmtime_test(wasm_features(exceptions, reference_types))]
+// Currently exceptions trap on throw, re-enable after catch is implemented.
+#[wasmtime_test(strategies(not(Winch)), wasm_features(exceptions, reference_types))]
 #[cfg_attr(miri, ignore)]
 fn store_pending_exnref_is_exposed(config: &mut Config) -> wasmtime::Result<()> {
     config.collector(Collector::DeferredReferenceCounting);
@@ -470,5 +477,26 @@ fn store_pending_exnref_has_write_barrier(config: &mut Config) -> wasmtime::Resu
     eprintln!("a4");
     assert!(dropped.load(Relaxed));
 
+    Ok(())
+}
+
+// Winch does not support exnref values yet. Modules that place an exnref
+// in a value position should fail with a compile error instead of
+// panicking.
+#[wasmtime_test(strategies(only(Winch)), wasm_features(exceptions, reference_types))]
+#[cfg_attr(miri, ignore)]
+fn exnref_local_is_unsupported(config: &mut Config) -> Result<()> {
+    let engine = Engine::new(config)?;
+    let wat = r#"
+        (module
+          (func (result i32)
+            (local exnref)
+            (i32.const 0)))
+    "#;
+    let err = Module::new(&engine, wat).unwrap_err();
+    assert!(
+        format!("{err:?}").contains("Unsupported Wasm type"),
+        "unexpected error: {err:?}"
+    );
     Ok(())
 }

--- a/tests/disas/winch/aarch64/exceptions/throw.wat
+++ b/tests/disas/winch/aarch64/exceptions/throw.wat
@@ -1,0 +1,37 @@
+;;! target = "aarch64"
+;;! test = "winch"
+;;! flags = ["-W", "exceptions"]
+
+;; Currently exceptions trap on throw: `throw` becomes a trap and
+;; `try_table` compiles as a plain block.
+(module
+  (tag $e (param i32))
+  (func (result i32)
+    (block $h (result i32)
+      (try_table (result i32) (catch $e $h)
+        (throw $e (i32.const 42))))))
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
+;;       mov     x28, sp
+;;       ldur    x16, [x0, #8]
+;;       ldur    x16, [x16, #0x18]
+;;       mov     x17, #0
+;;       movk    x17, #0x10
+;;       add     x16, x16, x17
+;;       cmp     sp, x16
+;;       b.lo    #0x5c
+;;   2c: mov     x9, x0
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       udf     #0xc11f
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
+;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret
+;;   5c: udf     #0xc11f

--- a/tests/disas/winch/x64/exceptions/throw.wat
+++ b/tests/disas/winch/x64/exceptions/throw.wat
@@ -1,0 +1,29 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = ["-W", "exceptions"]
+
+;; Currently exceptions trap on throw: `throw` becomes a trap and
+;; `try_table` compiles as a plain block.
+(module
+  (tag $e (param i32))
+  (func (result i32)
+    (block $h (result i32)
+      (try_table (result i32) (catch $e $h)
+        (throw $e (i32.const 42))))))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x18(%r11), %r11
+;;       addq    $0x10, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x3a
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x10, %rsp
+;;       movq    %rdi, 8(%rsp)
+;;       movq    %rsi, (%rsp)
+;;       ud2
+;;       addq    $0x10, %rsp
+;;       popq    %rbp
+;;       retq
+;;   3a: ud2

--- a/winch/codegen/src/abi/mod.rs
+++ b/winch/codegen/src/abi/mod.rs
@@ -141,7 +141,7 @@ pub(crate) trait ABI {
     fn stack_slot_size() -> u8;
 
     /// Returns the size in bytes of the given [`WasmType`].
-    fn sizeof(ty: &WasmValType) -> u8;
+    fn sizeof(ty: &WasmValType) -> Result<u8>;
 
     /// The target pointer size represented as [WasmValType].
     fn ptr_type() -> WasmValType {

--- a/winch/codegen/src/frame/mod.rs
+++ b/winch/codegen/src/frame/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     Result,
     abi::{ABI, ABIOperand, ABISig, LocalSlot, align_to},
-    codegen::{CodeGenPhase, Emission, Prologue},
+    codegen::{CodeGenError, CodeGenPhase, Emission, Prologue},
     masm::{MacroAssembler, SPOffset},
     stack::needs_stack_map,
 };
@@ -9,7 +9,8 @@ use smallvec::SmallVec;
 use std::marker::PhantomData;
 use std::ops::Range;
 use wasmparser::{BinaryReader, FuncValidator, ValidatorResources};
-use wasmtime_environ::{TypeConvert, WasmValType};
+use wasmtime_core::bail;
+use wasmtime_environ::{TypeConvert, WasmHeapType, WasmValType};
 
 /// WebAssembly locals.
 // TODO:
@@ -62,6 +63,12 @@ impl DefinedLocals {
             validator.define_locals(position, count, ty)?;
 
             let ty = types.convert_valtype(ty)?;
+            if let WasmValType::Ref(r) = &ty {
+                match r.heap_type {
+                    WasmHeapType::Func | WasmHeapType::Extern => {}
+                    _ => bail!(CodeGenError::unsupported_wasm_type()),
+                }
+            }
             for _ in 0..count {
                 let ty_size = <A as ABI>::sizeof(&ty);
                 next_stack = align_to(next_stack, ty_size as u32) + (ty_size as u32);

--- a/winch/codegen/src/frame/mod.rs
+++ b/winch/codegen/src/frame/mod.rs
@@ -1,7 +1,7 @@
 use crate::{
     Result,
     abi::{ABI, ABIOperand, ABISig, LocalSlot, align_to},
-    codegen::{CodeGenError, CodeGenPhase, Emission, Prologue},
+    codegen::{CodeGenPhase, Emission, Prologue},
     masm::{MacroAssembler, SPOffset},
     stack::needs_stack_map,
 };
@@ -9,8 +9,7 @@ use smallvec::SmallVec;
 use std::marker::PhantomData;
 use std::ops::Range;
 use wasmparser::{BinaryReader, FuncValidator, ValidatorResources};
-use wasmtime_core::bail;
-use wasmtime_environ::{TypeConvert, WasmHeapType, WasmValType};
+use wasmtime_environ::{TypeConvert, WasmValType};
 
 /// WebAssembly locals.
 // TODO:
@@ -63,14 +62,8 @@ impl DefinedLocals {
             validator.define_locals(position, count, ty)?;
 
             let ty = types.convert_valtype(ty)?;
-            if let WasmValType::Ref(r) = &ty {
-                match r.heap_type {
-                    WasmHeapType::Func | WasmHeapType::Extern => {}
-                    _ => bail!(CodeGenError::unsupported_wasm_type()),
-                }
-            }
             for _ in 0..count {
-                let ty_size = <A as ABI>::sizeof(&ty);
+                let ty_size = <A as ABI>::sizeof(&ty)?;
                 next_stack = align_to(next_stack, ty_size as u32) + (ty_size as u32);
                 slots.push(LocalSlot::new(ty, next_stack));
             }

--- a/winch/codegen/src/isa/aarch64/abi.rs
+++ b/winch/codegen/src/isa/aarch64/abi.rs
@@ -127,17 +127,17 @@ impl ABI for Aarch64ABI {
         Self::word_bytes()
     }
 
-    fn sizeof(ty: &WasmValType) -> u8 {
-        match ty {
+    fn sizeof(ty: &WasmValType) -> Result<u8> {
+        Ok(match ty {
             WasmValType::Ref(rt) => match rt.heap_type {
                 WasmHeapType::Func => Self::word_bytes(),
                 WasmHeapType::Extern => Self::word_bytes() / 2,
-                ht => unimplemented!("Support for WasmHeapType: {ht}"),
+                ht => bail!("{}: {ht}", CodeGenError::unsupported_wasm_type()),
             },
             WasmValType::F64 | WasmValType::I64 => Self::word_bytes(),
             WasmValType::F32 | WasmValType::I32 => Self::word_bytes() / 2,
             WasmValType::V128 => Self::word_bytes() * 2,
-        }
+        })
     }
 }
 
@@ -159,15 +159,10 @@ impl Aarch64ABI {
                 (index_env.next_fpr().map(regs::vreg), ty)
             }
 
-            ty @ WasmValType::Ref(rt) => match rt.heap_type {
-                WasmHeapType::Func | WasmHeapType::Extern => {
-                    (index_env.next_gpr().map(regs::xreg), ty)
-                }
-                _ => bail!(CodeGenError::unsupported_wasm_type()),
-            },
+            ty @ WasmValType::Ref(_) => (index_env.next_gpr().map(regs::xreg), ty),
         };
 
-        let ty_size = <Self as ABI>::sizeof(wasm_arg);
+        let ty_size = <Self as ABI>::sizeof(wasm_arg)?;
         let default = || {
             // Stack slots for parameters are aligned to a fixed slot size,
             // 8 bytes if the type size is 8 or less and type-sized aligned
@@ -214,7 +209,7 @@ mod tests {
     };
 
     #[test]
-    fn ref_sizes_match_cranelift_representation() {
+    fn ref_sizes_match_cranelift_representation() -> Result<()> {
         use wasmtime_environ::{WasmHeapType, WasmRefType};
         let ty = |heap_type| {
             WasmValType::Ref(WasmRefType {
@@ -223,10 +218,11 @@ mod tests {
             })
         };
         assert_eq!(
-            Aarch64ABI::sizeof(&ty(WasmHeapType::Func)),
+            Aarch64ABI::sizeof(&ty(WasmHeapType::Func))?,
             Aarch64ABI::word_bytes()
         );
-        assert_eq!(Aarch64ABI::sizeof(&ty(WasmHeapType::Extern)), 4);
+        assert_eq!(Aarch64ABI::sizeof(&ty(WasmHeapType::Extern))?, 4);
+        Ok(())
     }
 
     #[test]

--- a/winch/codegen/src/isa/x64/abi.rs
+++ b/winch/codegen/src/isa/x64/abi.rs
@@ -112,17 +112,17 @@ impl ABI for X64ABI {
         Self::word_bytes()
     }
 
-    fn sizeof(ty: &WasmValType) -> u8 {
-        match ty {
+    fn sizeof(ty: &WasmValType) -> Result<u8> {
+        Ok(match ty {
             WasmValType::Ref(rt) => match rt.heap_type {
                 WasmHeapType::Func => Self::word_bytes(),
                 WasmHeapType::Extern => Self::word_bytes() / 2,
-                ht => unimplemented!("Support for WasmHeapType: {ht}"),
+                ht => bail!("{}: {ht}", CodeGenError::unsupported_wasm_type()),
             },
             WasmValType::F64 | WasmValType::I64 => Self::word_bytes(),
             WasmValType::F32 | WasmValType::I32 => Self::word_bytes() / 2,
             WasmValType::V128 => Self::word_bytes() * 2,
-        }
+        })
     }
 }
 
@@ -135,13 +135,10 @@ impl X64ABI {
         params_or_returns: ParamsOrReturns,
     ) -> Result<(ABIOperand, u32)> {
         let (reg, ty) = match wasm_arg {
-            ty @ WasmValType::Ref(rt) => match rt.heap_type {
-                WasmHeapType::Func | WasmHeapType::Extern => (
-                    Self::int_reg_for(index_env.next_gpr(), call_conv, params_or_returns),
-                    ty,
-                ),
-                _ => bail!(CodeGenError::unsupported_wasm_type()),
-            },
+            ty @ WasmValType::Ref(_) => (
+                Self::int_reg_for(index_env.next_gpr(), call_conv, params_or_returns),
+                ty,
+            ),
 
             ty @ (WasmValType::I32 | WasmValType::I64) => (
                 Self::int_reg_for(index_env.next_gpr(), call_conv, params_or_returns),
@@ -155,7 +152,7 @@ impl X64ABI {
             ),
         };
 
-        let ty_size = <Self as ABI>::sizeof(wasm_arg);
+        let ty_size = <Self as ABI>::sizeof(wasm_arg)?;
         let default = || {
             let slot_size = Self::stack_slot_size();
             if params_or_returns == ParamsOrReturns::Params {

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -23,10 +23,10 @@ use crate::{Result, bail, format_err};
 use regalloc2::RegClass;
 use smallvec::{SmallVec, smallvec};
 use wasmparser::{
-    BlockType, BrTable, HeapType, Ieee32, Ieee64, MemArg, V128, ValType, VisitOperator,
+    BlockType, BrTable, HeapType, Ieee32, Ieee64, MemArg, TryTable, V128, ValType, VisitOperator,
     VisitSimdOperator,
 };
-use wasmtime_cranelift::TRAP_INDIRECT_CALL_TO_NULL;
+use wasmtime_cranelift::{TRAP_INDIRECT_CALL_TO_NULL, TRAP_UNHANDLED_TAG};
 use wasmtime_environ::{
     DataIndex, ElemIndex, FuncIndex, GlobalIndex, MemoryIndex, TableIndex, TypeIndex, WasmHeapType,
     WasmValType,
@@ -196,6 +196,9 @@ macro_rules! def_unsupported {
     (emit Else $($rest:tt)*) => {};
     (emit Block $($rest:tt)*) => {};
     (emit Loop $($rest:tt)*) => {};
+    (emit TryTable $($rest:tt)*) => {};
+    (emit Throw $($rest:tt)*) => {};
+    (emit ThrowRef $($rest:tt)*) => {};
     (emit Br $($rest:tt)*) => {};
     (emit BrIf $($rest:tt)*) => {};
     (emit Return $($rest:tt)*) => {};
@@ -1841,6 +1844,41 @@ where
             self.masm,
             &mut self.context,
         )?);
+
+        Ok(())
+    }
+
+    // Exceptions currently trap on throw, so a `try_table` compiles like
+    // a `block`. The catch clauses are unreachable and no handler metadata
+    // is emitted.
+    fn visit_try_table(&mut self, try_table: TryTable) -> Self::Output {
+        self.control_frames.push(ControlStackFrame::block(
+            self.env.resolve_block_sig(try_table.ty)?,
+            self.masm,
+            &mut self.context,
+        )?);
+
+        Ok(())
+    }
+
+    // A thrown exception is compiled as an unhandled-tag trap; see
+    // `visit_try_table`.
+    fn visit_throw(&mut self, _tag_index: u32) -> Self::Output {
+        self.masm.trap(TRAP_UNHANDLED_TAG)?;
+        self.context.reachable = false;
+        let outermost = &mut self.control_frames[0];
+        outermost.set_as_target();
+
+        Ok(())
+    }
+
+    // A rethrown exception is compiled as an unhandled-tag trap; see
+    // `visit_try_table`.
+    fn visit_throw_ref(&mut self) -> Self::Output {
+        self.masm.trap(TRAP_UNHANDLED_TAG)?;
+        self.context.reachable = false;
+        let outermost = &mut self.control_frames[0];
+        outermost.set_as_target();
 
         Ok(())
     }


### PR DESCRIPTION
This PR begins the process of adding EH support for Winch.  Following the approach outlined in the [rfc](https://github.com/bytecodealliance/rfcs/blob/main/accepted/exception-handling.md#incremental-milestone-exceptions-as-uncatchable-traps), this first step compiles `try_table` as a plain block and compiles `throw` and `throw_ref` as uncatchable traps.  Follow on PRs will implement full `catch`/`throw` behavior.