### PR TITLE
Shuffle more finalizers in the C API

### DIFF
--- a/crates/c-api/src/component/linker.rs
+++ b/crates/c-api/src/component/linker.rs
@@ -115,12 +115,12 @@ pub unsafe extern "C" fn wasmtime_component_linker_instance_add_func(
     data: *mut c_void,
     finalizer: Option<extern "C" fn(*mut c_void)>,
 ) -> Option<Box<wasmtime_error_t>> {
+    let foreign = crate::ForeignData { data, finalizer };
+
     let name = unsafe { std::slice::from_raw_parts(name, name_len) };
     let Ok(name) = std::str::from_utf8(name) else {
         return crate::bad_utf8();
     };
-
-    let foreign = crate::ForeignData { data, finalizer };
 
     let result = linker_instance
         .linker_instance
@@ -181,12 +181,12 @@ pub unsafe extern "C" fn wasmtime_component_linker_instance_add_func_async(
     data: *mut c_void,
     finalizer: Option<extern "C" fn(*mut c_void)>,
 ) -> Option<Box<wasmtime_error_t>> {
+    let foreign = crate::ForeignData { data, finalizer };
+
     let name = unsafe { std::slice::from_raw_parts(name, name_len) };
     let Ok(name) = std::str::from_utf8(name) else {
         return crate::bad_utf8();
     };
-
-    let foreign = crate::ForeignData { data, finalizer };
 
     let result =
         linker_instance
@@ -322,12 +322,12 @@ pub unsafe extern "C" fn wasmtime_component_linker_instance_add_resource(
     data: *mut c_void,
     finalizer: Option<extern "C" fn(*mut c_void)>,
 ) -> Option<Box<wasmtime_error_t>> {
+    let foreign = crate::ForeignData { data, finalizer };
+
     let name = unsafe { std::slice::from_raw_parts(name, name_len) };
     let Ok(name) = std::str::from_utf8(name) else {
         return crate::bad_utf8();
     };
-
-    let foreign = crate::ForeignData { data, finalizer };
 
     let result = linker_instance
         .linker_instance

--- a/crates/c-api/tests/component/linker.cc
+++ b/crates/c-api/tests/component/linker.cc
@@ -4,6 +4,62 @@
 
 using namespace wasmtime::component;
 
+static wasmtime_error_t *func_callback(void *, wasmtime_context_t *,
+                                       const wasmtime_component_func_type_t *,
+                                       wasmtime_component_val_t *, size_t,
+                                       wasmtime_component_val_t *, size_t) {
+  return nullptr;
+}
+
+static void async_func_callback(void *, wasmtime_context_t *,
+                                const wasmtime_component_func_type_t *,
+                                wasmtime_component_val_t *, size_t,
+                                wasmtime_component_val_t *, size_t,
+                                wasmtime_error_t **,
+                                wasmtime_async_continuation_t *) {}
+
+static wasmtime_error_t *resource_destructor(void *, wasmtime_context_t *, uint32_t) {
+  return nullptr;
+}
+
+static void finalize(void *data) { *static_cast<bool *>(data) = true; }
+
+TEST(Linker, finalizes_callbacks_when_name_parsing_fails) {
+  wasmtime::Engine engine;
+  auto *raw = wasmtime_component_linker_new(engine.capi());
+  auto *root = wasmtime_component_linker_root(raw);
+  const char invalid_utf8[] = {static_cast<char>(0xff)};
+
+  bool finalized = false;
+  auto *error = wasmtime_component_linker_instance_add_func(
+      root, invalid_utf8, sizeof(invalid_utf8), func_callback, &finalized,
+      finalize);
+  ASSERT_NE(error, nullptr);
+  wasmtime_error_delete(error);
+  EXPECT_TRUE(finalized);
+
+  finalized = false;
+  error = wasmtime_component_linker_instance_add_func_async(
+      root, invalid_utf8, sizeof(invalid_utf8), async_func_callback, &finalized,
+      finalize);
+  ASSERT_NE(error, nullptr);
+  wasmtime_error_delete(error);
+  EXPECT_TRUE(finalized);
+
+  finalized = false;
+  auto *ty = wasmtime_component_resource_type_new_host(0);
+  error = wasmtime_component_linker_instance_add_resource(
+      root, invalid_utf8, sizeof(invalid_utf8), ty, resource_destructor,
+      &finalized, finalize);
+  ASSERT_NE(error, nullptr);
+  wasmtime_error_delete(error);
+  EXPECT_TRUE(finalized);
+  wasmtime_component_resource_type_delete(ty);
+
+  wasmtime_component_linker_instance_delete(root);
+  wasmtime_component_linker_delete(raw);
+}
+
 TEST(Linker, allow_shadowing) {
   wasmtime::Engine engine;
   Linker linker(engine);

--- a/crates/c-api/tests/component/linker.cc
+++ b/crates/c-api/tests/component/linker.cc
@@ -18,7 +18,8 @@ static void async_func_callback(void *, wasmtime_context_t *,
                                 wasmtime_error_t **,
                                 wasmtime_async_continuation_t *) {}
 
-static wasmtime_error_t *resource_destructor(void *, wasmtime_context_t *, uint32_t) {
+static wasmtime_error_t *resource_destructor(void *, wasmtime_context_t *,
+                                             uint32_t) {
   return nullptr;
 }
 


### PR DESCRIPTION
This implements a similar refactoring to #14126 but for the component linker as well.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
