### PR TITLE
Return is-directory when a directory fd is used as a file

### DIFF
--- a/crates/test-programs/src/bin/p2_file_read_write.rs
+++ b/crates/test-programs/src/bin/p2_file_read_write.rs
@@ -5,6 +5,11 @@ fn main() {
     let preopens = wasi::filesystem::preopens::get_directories();
     let (dir, _) = &preopens[0];
 
+    assert_eq!(
+        dir.read_via_stream(0).err(),
+        Some(wasi::filesystem::types::ErrorCode::IsDirectory)
+    );
+
     let filename = "test.txt";
     let file = dir
         .open_at(

--- a/crates/test-programs/src/bin/p3_filesystem_file_read_write.rs
+++ b/crates/test-programs/src/bin/p3_filesystem_file_read_write.rs
@@ -1,5 +1,7 @@
 use futures::join;
-use test_programs::p3::wasi::filesystem::types::{DescriptorFlags, OpenFlags, PathFlags};
+use test_programs::p3::wasi::filesystem::types::{
+    DescriptorFlags, ErrorCode, OpenFlags, PathFlags,
+};
 use test_programs::p3::{wasi, wit_stream};
 
 struct Component;
@@ -10,6 +12,13 @@ impl test_programs::p3::exports::wasi::cli::run::Guest for Component {
     async fn run() -> Result<(), ()> {
         let preopens = wasi::filesystem::preopens::get_directories();
         let (dir, _) = &preopens[0];
+
+        let (_data_rx, data_fut) = dir.read_via_stream(0);
+        let err = data_fut.await.expect_err("directory read should fail");
+        assert!(
+            matches!(err, ErrorCode::IsDirectory),
+            "unexpected error: {err:?}"
+        );
 
         let filename = "test.txt";
         {

--- a/crates/wasi/src/filesystem.rs
+++ b/crates/wasi/src/filesystem.rs
@@ -490,7 +490,10 @@ impl Descriptor {
     pub(crate) fn file(&self) -> Result<&File, ErrorCode> {
         match self {
             Descriptor::File(f) => Ok(f),
-            Descriptor::Dir(_) => Err(ErrorCode::IsDirectory),
+            // File-only ops such as advise stay bad-descriptor on a dir
+            // (wasi-testsuite filesystem-advise). read-via-stream maps Dir
+            // to is-directory on its own.
+            Descriptor::Dir(_) => Err(ErrorCode::BadDescriptor),
         }
     }
 

--- a/crates/wasi/src/filesystem.rs
+++ b/crates/wasi/src/filesystem.rs
@@ -490,7 +490,7 @@ impl Descriptor {
     pub(crate) fn file(&self) -> Result<&File, ErrorCode> {
         match self {
             Descriptor::File(f) => Ok(f),
-            Descriptor::Dir(_) => Err(ErrorCode::BadDescriptor),
+            Descriptor::Dir(_) => Err(ErrorCode::IsDirectory),
         }
     }
 

--- a/crates/wasi/src/p2/host/filesystem.rs
+++ b/crates/wasi/src/p2/host/filesystem.rs
@@ -367,8 +367,12 @@ impl HostDescriptor for WasiFilesystemCtxView<'_> {
         fd: Resource<types::Descriptor>,
         offset: types::Filesize,
     ) -> FsResult<Resource<DynInputStream>> {
-        // Trap if fd lookup fails:
-        let f = self.table.get(&fd)?.file()?;
+        // Trap if fd lookup fails. A directory is is-directory, not
+        // bad-descriptor (POSIX EISDIR on read).
+        let f = match self.table.get(&fd)? {
+            Descriptor::File(f) => f,
+            Descriptor::Dir(_) => return Err(ErrorCode::IsDirectory.into()),
+        };
 
         // Create a stream view for it.
         let reader: DynInputStream = Box::new(FileInputStream::new(f, offset));

--- a/crates/wasi/src/p3/filesystem/host.rs
+++ b/crates/wasi/src/p3/filesystem/host.rs
@@ -521,15 +521,14 @@ impl<U> types::HostDescriptorWithStore<U> for WasiFilesystem {
         fd: Resource<Descriptor>,
         offset: Filesize,
     ) -> wasmtime::Result<(StreamReader<u8>, FutureReader<Result<(), ErrorCode>>)> {
-        let file = match get_descriptor(store.get().table, &fd)?.file() {
-            Ok(file) => file.clone(),
-            Err(err) => {
+        let file = match get_descriptor(store.get().table, &fd)? {
+            Descriptor::File(file) => file.clone(),
+            Descriptor::Dir(_) => {
                 return Ok((
                     StreamReader::new(&mut store, iter::empty())?,
-                    FutureReader::new(
-                        &mut store,
-                        async move { wasmtime::error::Ok(Err(err.into())) },
-                    )?,
+                    FutureReader::new(&mut store, async move {
+                        wasmtime::error::Ok(Err(ErrorCode::IsDirectory))
+                    })?,
                 ));
             }
         };

--- a/crates/wasi/src/p3/filesystem/host.rs
+++ b/crates/wasi/src/p3/filesystem/host.rs
@@ -521,8 +521,18 @@ impl<U> types::HostDescriptorWithStore<U> for WasiFilesystem {
         fd: Resource<Descriptor>,
         offset: Filesize,
     ) -> wasmtime::Result<(StreamReader<u8>, FutureReader<Result<(), ErrorCode>>)> {
-        let file = get_file(store.get().table, &fd)?;
-        let file = file.clone();
+        let file = match get_descriptor(store.get().table, &fd)?.file() {
+            Ok(file) => file.clone(),
+            Err(err) => {
+                return Ok((
+                    StreamReader::new(&mut store, iter::empty())?,
+                    FutureReader::new(
+                        &mut store,
+                        async move { wasmtime::error::Ok(Err(err.into())) },
+                    )?,
+                ));
+            }
+        };
         let (result_tx, result_rx) = oneshot::channel();
         Ok((
             StreamReader::new(


### PR DESCRIPTION
Prior discussion: [WebAssembly/wasi-libc#869](https://github.com/WebAssembly/wasi-libc/pull/869#pullrequestreview-4931921277) ([@alexcrichton](https://github.com/alexcrichton): fix this in Wasmtime instead of extra libc syscalls).

## Why

`read()` on a directory must return `EISDIR` (POSIX). Wasmtime's `Descriptor::file()` mapped a directory to `error-code::bad-descriptor`. wasi-libc then had to `stat`/`get_type` just to remap `EBADF`. On wasip3, `read-via-stream` is a tuple import, so that host `?` trapped instead of returning a guest error.

`wasi:filesystem` already documents `is-directory` as the `EISDIR` analog. `Descriptor::dir()` already returns `not-directory` for a file. This makes `file()` the dual.

## Change

- `Descriptor::file()` returns `IsDirectory` for `Dir`.
- wasip3 `read-via-stream`: if the descriptor is not a file, return an empty stream and resolve the result future with that error (same shape as p3 TCP receive). Do not trap.
- wasip1 guests are unchanged (`fd_read` still `EBADF`; preview1 adapter still `ERRNO_BADF`).

## Tests

- `p2_file_read_write`: `read_via_stream` on the preopen directory is `is-directory`.
- `p3_filesystem_file_read_write`: the result future is `IsDirectory` (blocking and non-blocking).

Red (unpatched host): p2 guest saw `bad-descriptor` (code 3). Green: `is-directory` (code 14).

## References

- [WebAssembly/wasi-libc#869](https://github.com/WebAssembly/wasi-libc/pull/869)
- [WebAssembly/wasi-libc#865](https://github.com/WebAssembly/wasi-libc/issues/865)
- rust-lang/rust#160359
- uutils/coreutils#13625
- `Descriptor::file` as used today was introduced in [#11406](https://github.com/bytecodealliance/wasmtime/pull/11406) (`cf88a7c601`, 2025-08-12)
