### PR TITLE
Enable `p3` features by default

### DIFF
--- a/crates/wasi-http/Cargo.toml
+++ b/crates/wasi-http/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 all-features = true
 
 [features]
-default = ["default-send-request", "p2"]
+default = ["default-send-request", "p2", "p3"]
 default-send-request = ["dep:tokio-rustls", "dep:rustls", "dep:webpki-roots"]
 p2 = ["wasmtime-wasi/p2"]
 p3 = ["wasmtime-wasi/p3", "dep:tokio-util"]

--- a/crates/wasi-tls/Cargo.toml
+++ b/crates/wasi-tls/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 all-features = true
 
 [features]
-default = ["p2", "rustls"]
+default = ["p2", "p3", "rustls"]
 p2 = ["wasmtime-wasi/p2"]
 p3 = ["wasmtime-wasi/p3", "wasmtime/component-model-async", "tracing"]
 rustls = ["dep:rustls", "dep:tokio-rustls", "dep:webpki-roots"]

--- a/crates/wasi/Cargo.toml
+++ b/crates/wasi/Cargo.toml
@@ -61,7 +61,7 @@ features = [
 ]
 
 [features]
-default = ["p1", "p2"]
+default = ["p1", "p2", "p3"]
 p0 = ["p1"]
 p1 = ["dep:wiggle", "p2"]
 p2 = ["wasmtime/component-model", "wasmtime/async"]


### PR DESCRIPTION
The `p3` features of `wasi-*` crates are already enabled by default in the CLI and WASIp3 is now officially released so these should also be enabled by default in the crates themselves.