### PR TITLE
Fix handling of context slots in component compositions

### DIFF
--- a/crates/environ/src/component/translate/adapt.rs
+++ b/crates/environ/src/component/translate/adapt.rs
@@ -351,6 +351,9 @@ fn fact_import_to_core_def(
         fact::Import::Trap(trap) => simple_intrinsic(dfg::Trampoline::Trap(*trap)),
         fact::Import::EnterSyncCall => simple_intrinsic(dfg::Trampoline::EnterSyncCall),
         fact::Import::ExitSyncCall => simple_intrinsic(dfg::Trampoline::ExitSyncCall),
+        fact::Import::UnsafeIntrinsic(intrinsic) => {
+            dfg::CoreDef::UnsafeIntrinsic(ty.unwrap_func().unwrap_module_type_index(), *intrinsic)
+        }
     }
 }
 

--- a/crates/environ/src/fact.rs
+++ b/crates/environ/src/fact.rs
@@ -22,13 +22,13 @@ use crate::component::dfg::CoreDef;
 use crate::component::{
     Adapter, AdapterOptions as AdapterOptionsDfg, CanonicalAbiInfo, ComponentTypesBuilder,
     FlatType, InterfaceType, RuntimeComponentInstanceIndex, StringEncoding, Transcode,
-    TypeFuncIndex,
+    TypeFuncIndex, UnsafeIntrinsic,
 };
 use crate::fact::transcode::Transcoder;
 use crate::prelude::*;
 use crate::{
     EntityRef, FuncIndex, GlobalIndex, IndexType, Memory, MemoryIndex, ModuleInternedTypeIndex,
-    PrimaryMap, Trap, Tunables,
+    PrimaryMap, Trap, Tunables, WasmValType,
 };
 use std::collections::HashMap;
 use wasm_encoder::*;
@@ -96,6 +96,9 @@ pub struct Module<'a> {
 
     imported_enter_sync_call: Option<FuncIndex>,
     imported_exit_sync_call: Option<FuncIndex>,
+
+    /// Cached versions of unsafe intrinsics and where they were imported.
+    imported_unsafe_intrinsics: HashMap<UnsafeIntrinsic, FuncIndex>,
 
     /// Cached versions of the imported `trap` intrinsic, one per trap code.
     imported_traps: HashMap<Trap, FuncIndex>,
@@ -292,6 +295,7 @@ impl<'a> Module<'a> {
             imported_error_context_transfer: None,
             imported_enter_sync_call: None,
             imported_exit_sync_call: None,
+            imported_unsafe_intrinsics: HashMap::new(),
             imported_traps: HashMap::new(),
             exports: Vec::new(),
             task_may_block: None,
@@ -763,6 +767,51 @@ impl<'a> Module<'a> {
         )
     }
 
+    /// Imports the `context.get` intrinsic for the `slot`th context slot.
+    fn import_context_get(&mut self, slot: usize) -> FuncIndex {
+        let intrinsic = match slot {
+            0 => UnsafeIntrinsic::ContextGetI32_0,
+            1 => UnsafeIntrinsic::ContextGetI32_1,
+            _ => unreachable!(),
+        };
+        self.import_unsafe_intrinsic(intrinsic, &format!("get{slot}"))
+    }
+
+    /// Imports the `context.set` intrinsic for the `slot`th context slot.
+    fn import_context_set(&mut self, slot: usize) -> FuncIndex {
+        let intrinsic = match slot {
+            0 => UnsafeIntrinsic::ContextSetI32_0,
+            1 => UnsafeIntrinsic::ContextSetI32_1,
+            _ => unreachable!(),
+        };
+        self.import_unsafe_intrinsic(intrinsic, &format!("set{slot}"))
+    }
+
+    fn import_unsafe_intrinsic(&mut self, intrinsic: UnsafeIntrinsic, name: &str) -> FuncIndex {
+        let map = |ty: &WasmValType| match ty {
+            crate::WasmValType::I32 => ValType::I32,
+            crate::WasmValType::I64 => ValType::I64,
+            crate::WasmValType::F32 => ValType::F32,
+            crate::WasmValType::F64 => ValType::F64,
+            crate::WasmValType::V128 => ValType::V128,
+            crate::WasmValType::Ref(_) => unreachable!(),
+        };
+        let params = intrinsic.core_params().iter().map(map).collect::<Vec<_>>();
+        let results = intrinsic.core_results().iter().map(map).collect::<Vec<_>>();
+
+        self.import_simple_get_and_set(
+            "context",
+            name,
+            &params,
+            &results,
+            Import::UnsafeIntrinsic(intrinsic),
+            |me| me.imported_unsafe_intrinsics.get(&intrinsic).copied(),
+            |me, idx| {
+                me.imported_unsafe_intrinsics.insert(intrinsic, idx);
+            },
+        )
+    }
+
     fn import_trap(&mut self, trap: Trap) -> FuncIndex {
         let name = format!("trap{}", trap as u8);
         self.import_simple_get_and_set(
@@ -925,6 +974,8 @@ pub enum Import {
     /// An intrinsic used by FACT-generated modules to pop the task previously
     /// pushed by `EnterSyncCall`.
     ExitSyncCall,
+    /// An unsafe intrinsic, such as reading/writing `context.{get,set}` slots.
+    UnsafeIntrinsic(UnsafeIntrinsic),
 }
 
 impl Options {

--- a/crates/environ/src/fact/trampoline.rs
+++ b/crates/environ/src/fact/trampoline.rs
@@ -30,7 +30,7 @@ use crate::fact::{
     LinearMemoryOptions, Module, Options,
 };
 use crate::prelude::*;
-use crate::{FuncIndex, GlobalIndex, IndexType, Trap};
+use crate::{FuncIndex, GlobalIndex, IndexType, NUM_COMPONENT_CONTEXT_SLOTS, Trap};
 use std::collections::HashMap;
 use std::mem;
 use std::ops::Range;
@@ -884,6 +884,15 @@ impl<'a, 'b> Compiler<'a, 'b> {
         }
         result_locals.reverse();
 
+        // The `exit-sync-call` intrinsic below will clobber this task's context
+        // slots, but if we've got a post-return we'll want to restore them
+        // temporarily for that. Save them if it's necessary.
+        let callee_context = if adapter.lift.post_return.is_some() {
+            self.save_context()
+        } else {
+            Vec::new()
+        };
+
         // Handle a few things related to the concurrent task infrastructure
         // after the callee has finished, such as:
         //
@@ -916,11 +925,19 @@ impl<'a, 'b> Compiler<'a, 'b> {
 
         // And finally post-return state is handled here once all results/etc
         // are all translated.
+        //
+        // Note that for this call the callee's previous context is shuffled
+        // in-and-then-back-out after the call.
         if let Some(func) = adapter.lift.post_return {
+            let caller_context = self.save_context();
+            self.restore_context(callee_context);
             for (result, _) in result_locals.iter() {
                 self.instruction(LocalGet(*result));
             }
             self.instruction(Call(func.as_u32()));
+            self.restore_context(caller_context);
+        } else {
+            assert!(callee_context.is_empty());
         }
 
         for tmp in temps {
@@ -3715,7 +3732,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
                 self.ptr_uconst(mem_opts, 0);
                 self.ptr_uconst(mem_opts, align);
                 self.alloc_size(mem_opts, &size);
-                self.instruction(Call(realloc.as_u32()));
+                self.call_realloc(realloc);
                 let addr = self.local_set_new_tmp(mem_opts.ptr());
                 self.memory_operand(opts, addr, size, align, oob_trap)
             }
@@ -3744,7 +3761,7 @@ impl<'a, 'b> Compiler<'a, 'b> {
                 self.alloc_size(mem_opts, &prev_size);
                 self.ptr_uconst(mem_opts, align);
                 self.alloc_size(mem_opts, &size);
-                self.instruction(Call(realloc.as_u32()));
+                self.call_realloc(realloc);
                 self.instruction(LocalSet(ptr.idx));
                 self.validate_guest_pointer(opts, &ptr, &size, align, oob_trap)
             }
@@ -3923,6 +3940,56 @@ impl<'a, 'b> Compiler<'a, 'b> {
             .or_insert(Vec::new())
             .push(local.idx);
         local.needs_free = false;
+    }
+
+    /// Reads all of the current task's `context.{get,set}` slots into fresh
+    /// temporary locals which can later be handed to `restore_context`.
+    fn save_context(&mut self) -> Vec<TempLocal> {
+        if !self.module.tunables.concurrency_support {
+            return Vec::new();
+        }
+        let mut saved = Vec::new();
+        for slot in 0..NUM_COMPONENT_CONTEXT_SLOTS {
+            let get = self.module.import_context_get(slot);
+            self.instruction(Call(get.as_u32()));
+            saved.push(self.local_set_new_tmp(ValType::I32));
+        }
+        saved
+    }
+
+    /// Stores zero into all of the current task's `context.{get,set}` slots.
+    fn clear_context(&mut self) {
+        if !self.module.tunables.concurrency_support {
+            return;
+        }
+        for slot in 0..NUM_COMPONENT_CONTEXT_SLOTS {
+            let set = self.module.import_context_set(slot);
+            self.instruction(I32Const(0));
+            self.instruction(Call(set.as_u32()));
+        }
+    }
+
+    /// Stores the slot values previously read by `save_context` back into the
+    /// current task's `context.{get,set}` slots.
+    fn restore_context(&mut self, saved: Vec<TempLocal>) {
+        for (slot, local) in saved.into_iter().enumerate() {
+            let set = self.module.import_context_set(slot);
+            self.instruction(LocalGet(local.idx));
+            self.instruction(Call(set.as_u32()));
+            self.free_temp_local(local);
+        }
+    }
+
+    /// Emits a call to a guest `realloc` function.
+    ///
+    /// Note that this has special handling of the current task's
+    /// `context.{get,set}` slots, namely they're saved/restored around this
+    /// call and zero'd out during the call.
+    fn call_realloc(&mut self, realloc: FuncIndex) {
+        let saved = self.save_context();
+        self.clear_context();
+        self.instruction(Call(realloc.as_u32()));
+        self.restore_context(saved);
     }
 
     fn instruction(&mut self, instr: Instruction) {

--- a/tests/misc_testsuite/component-model/async/context-in-compositions.wast
+++ b/tests/misc_testsuite/component-model/async/context-in-compositions.wast
@@ -1,0 +1,437 @@
+;;! component_model_async = true
+;;! multi_memory = true
+
+;; `post-return` observes the callee task's context slots.
+(component
+  (component $A
+    (core func $get (canon context.get i32 0))
+    (core func $set (canon context.set i32 0))
+    (core module $M
+      (import "" "get" (func $get (result i32)))
+      (import "" "set" (func $set (param i32)))
+      (func (export "f'") (param i32) (result i32)
+        (call $set (i32.const 0xcafe))
+        (i32.add (local.get 0) (i32.const 42)))
+      (func (export "post") (param i32)
+        (if (i32.ne (call $get) (i32.const 0xcafe)) (then unreachable)))
+    )
+    (core instance $m (instantiate $M (with "" (instance
+      (export "get" (func $get))
+      (export "set" (func $set))))))
+    (func (export "f") (param "x" u32) (result u32)
+      (canon lift (core func $m "f'") (post-return (core func $m "post"))))
+  )
+
+  (component $B
+    (import "f" (func $f (param "x" u32) (result u32)))
+    (core func $f' (canon lower (func $f)))
+    (core func $set (canon context.set i32 0))
+    (core module $N
+      (import "" "f'" (func $f' (param i32) (result i32)))
+      (import "" "set" (func $set (param i32)))
+      (func (export "g'") (result i32)
+        (call $set (i32.const 0x1234))
+        (call $f' (i32.const 1234)))
+    )
+    (core instance $n (instantiate $N (with "" (instance
+      (export "f'" (func $f'))
+      (export "set" (func $set))))))
+    (func (export "g") (result u32) (canon lift (core func $n "g'")))
+  )
+
+  (instance $a (instantiate $A))
+  (instance $b (instantiate $B (with "f" (func $a "f"))))
+  (export "g" (func $b "g"))
+)
+(assert_return (invoke "g") (u32.const 1276))
+
+;; A `context.set` performed by `post-return` belongs to the callee's task
+;; and must not leak back out into the caller.
+(component
+  (component $A
+    (core func $set (canon context.set i32 0))
+    (core module $M
+      (import "" "set" (func $set (param i32)))
+      (func (export "f'") (param i32) (result i32)
+        (i32.add (local.get 0) (i32.const 42)))
+      (func (export "post") (param i32)
+        (call $set (i32.const 0xbeef)))
+    )
+    (core instance $m (instantiate $M (with "" (instance
+      (export "set" (func $set))))))
+    (func (export "f") (param "x" u32) (result u32)
+      (canon lift (core func $m "f'") (post-return (core func $m "post"))))
+  )
+
+  (component $B
+    (import "f" (func $f (param "x" u32) (result u32)))
+    (core func $f' (canon lower (func $f)))
+    (core func $get (canon context.get i32 0))
+    (core func $set (canon context.set i32 0))
+    (core module $N
+      (import "" "f'" (func $f' (param i32) (result i32)))
+      (import "" "get" (func $get (result i32)))
+      (import "" "set" (func $set (param i32)))
+      (func (export "g'") (result i32) (local $r i32)
+        (call $set (i32.const 0x1234))
+        (local.set $r (call $f' (i32.const 1234)))
+        (if (i32.ne (call $get) (i32.const 0x1234)) (then unreachable))
+        (local.get $r))
+    )
+    (core instance $n (instantiate $N (with "" (instance
+      (export "f'" (func $f'))
+      (export "get" (func $get))
+      (export "set" (func $set))))))
+    (func (export "g") (result u32) (canon lift (core func $n "g'")))
+  )
+
+  (instance $a (instantiate $A))
+  (instance $b (instantiate $B (with "f" (func $a "f"))))
+  (export "g" (func $b "g"))
+)
+(assert_return (invoke "g") (u32.const 1276))
+
+;; The callee's `realloc`, invoked by the adapter to lower the string parameters
+;; into the callee's memory, runs with fresh context slots on every call: what
+;; one call stores is neither visible to the next call nor to the callee
+;; function itself.
+(component
+  (component $A
+    (core func $get (canon context.get i32 0))
+    (core func $set (canon context.set i32 0))
+    (core module $M
+      (import "" "get" (func $get (result i32)))
+      (import "" "set" (func $set (param i32)))
+      (memory (export "memory") 1)
+      (global $bump (mut i32) (i32.const 8))
+      (func (export "realloc") (param i32 i32 i32 i32) (result i32)
+        (local $ret i32)
+        (if (i32.ne (call $get) (i32.const 0)) (then unreachable))
+        (call $set (i32.const 0x9999))
+        (local.set $ret (global.get $bump))
+        (global.set $bump (i32.and
+          (i32.add (i32.add (global.get $bump) (local.get 3)) (i32.const 7))
+          (i32.const -8)))
+        (local.get $ret))
+      (func (export "f'") (param i32 i32 i32 i32)
+        (if (i32.ne (call $get) (i32.const 0)) (then unreachable)))
+    )
+    (core instance $m (instantiate $M (with "" (instance
+      (export "get" (func $get))
+      (export "set" (func $set))))))
+    (func (export "f") (param "x" string) (param "y" string)
+      (canon lift (core func $m "f'")
+        (memory (core memory $m "memory"))
+        (realloc (core func $m "realloc"))))
+  )
+
+  (component $B
+    (import "f" (func $f (param "x" string) (param "y" string)))
+    (core module $Libc
+      (memory (export "memory") 1)
+      (data (i32.const 16) "hello"))
+    (core instance $libc (instantiate $Libc))
+    (core func $f' (canon lower (func $f)
+      (memory (core memory $libc "memory"))))
+    (core func $set (canon context.set i32 0))
+    (core module $N
+      (import "" "f'" (func $f' (param i32 i32 i32 i32)))
+      (import "" "set" (func $set (param i32)))
+      (func (export "g'") (result i32)
+        (call $set (i32.const 0x1234))
+        (call $f' (i32.const 16) (i32.const 5) (i32.const 16) (i32.const 5))
+        (i32.const 100))
+    )
+    (core instance $n (instantiate $N (with "" (instance
+      (export "f'" (func $f'))
+      (export "set" (func $set))))))
+    (func (export "g") (result u32) (canon lift (core func $n "g'")))
+  )
+
+  (instance $a (instantiate $A))
+  (instance $b (instantiate $B (with "f" (func $a "f"))))
+  (export "g" (func $b "g"))
+)
+(assert_return (invoke "g") (u32.const 100))
+
+;; The caller's `realloc`, invoked by the adapter to lower the string result
+;; back into the caller's memory, also runs with fresh context slots -- it must
+;; not see the caller task's slots.
+(component
+  (component $A
+    (core module $M
+      (memory (export "memory") 1)
+      (data (i32.const 16) "hello")
+      (func (export "f'") (result i32)
+        (i32.store (i32.const 8) (i32.const 16))
+        (i32.store (i32.const 12) (i32.const 5))
+        (i32.const 8))
+    )
+    (core instance $m (instantiate $M))
+    (func (export "f") (result string)
+      (canon lift (core func $m "f'") (memory (core memory $m "memory"))))
+  )
+
+  (component $B
+    (import "f" (func $f (result string)))
+    (core func $get (canon context.get i32 0))
+    (core func $set (canon context.set i32 0))
+    (core module $Libc
+      (import "" "get" (func $get (result i32)))
+      (memory (export "memory") 1)
+      (func (export "realloc") (param i32 i32 i32 i32) (result i32)
+        (if (i32.ne (call $get) (i32.const 0)) (then unreachable))
+        (i32.const 64))
+    )
+    (core instance $libc (instantiate $Libc (with "" (instance
+      (export "get" (func $get))))))
+    (core func $f' (canon lower (func $f)
+      (memory (core memory $libc "memory"))
+      (realloc (core func $libc "realloc"))))
+    (core module $N
+      (import "" "f'" (func $f' (param i32)))
+      (import "" "set" (func $set (param i32)))
+      (func (export "g'") (result i32)
+        (call $set (i32.const 0x1234))
+        (call $f' (i32.const 8))
+        (i32.const 200))
+    )
+    (core instance $n (instantiate $N (with "" (instance
+      (export "f'" (func $f'))
+      (export "set" (func $set))))))
+    (func (export "g") (result u32) (canon lift (core func $n "g'")))
+  )
+
+  (instance $a (instantiate $A))
+  (instance $b (instantiate $B (with "f" (func $a "f"))))
+  (export "g" (func $b "g"))
+)
+(assert_return (invoke "g") (u32.const 200))
+
+;; A `context.set` performed by the caller's `realloc` is discarded when it
+;; returns rather than clobbering the caller task's slots.
+(component
+  (component $A
+    (core module $M
+      (memory (export "memory") 1)
+      (data (i32.const 16) "hello")
+      (func (export "f'") (result i32)
+        (i32.store (i32.const 8) (i32.const 16))
+        (i32.store (i32.const 12) (i32.const 5))
+        (i32.const 8))
+    )
+    (core instance $m (instantiate $M))
+    (func (export "f") (result string)
+      (canon lift (core func $m "f'") (memory (core memory $m "memory"))))
+  )
+
+  (component $B
+    (import "f" (func $f (result string)))
+    (core func $get (canon context.get i32 0))
+    (core func $set (canon context.set i32 0))
+    (core module $Libc
+      (import "" "set" (func $set (param i32)))
+      (memory (export "memory") 1)
+      (func (export "realloc") (param i32 i32 i32 i32) (result i32)
+        (call $set (i32.const 0x7777))
+        (i32.const 64))
+    )
+    (core instance $libc (instantiate $Libc (with "" (instance
+      (export "set" (func $set))))))
+    (core func $f' (canon lower (func $f)
+      (memory (core memory $libc "memory"))
+      (realloc (core func $libc "realloc"))))
+    (core module $N
+      (import "" "f'" (func $f' (param i32)))
+      (import "" "get" (func $get (result i32)))
+      (import "" "set" (func $set (param i32)))
+      (func (export "g'") (result i32)
+        (call $set (i32.const 0x1234))
+        (call $f' (i32.const 8))
+        (if (i32.ne (call $get) (i32.const 0x1234)) (then unreachable))
+        (i32.const 300))
+    )
+    (core instance $n (instantiate $N (with "" (instance
+      (export "f'" (func $f'))
+      (export "get" (func $get))
+      (export "set" (func $set))))))
+    (func (export "g") (result u32) (canon lift (core func $n "g'")))
+  )
+
+  (instance $a (instantiate $A))
+  (instance $b (instantiate $B (with "f" (func $a "f"))))
+  (export "g" (func $b "g"))
+)
+(assert_return (invoke "g") (u32.const 300))
+
+;; Similar to above, but permuting async in signatures.
+(component
+  (component $A
+    (core func $get (canon context.get i32 0))
+    (core func $set (canon context.set i32 0))
+
+    (core module $Libc
+      (import "" "get" (func $get (result i32)))
+      (import "" "set" (func $set (param i32)))
+      (memory (export "memory") 1)
+      (global $bump (mut i32) (i32.const 16))
+      (func (export "realloc") (param i32 i32 i32 i32) (result i32)
+        (local $ret i32)
+        ;; Fresh task for every `realloc`, no matter which adapter drives it.
+        (if (i32.ne (call $get) (i32.const 0)) (then unreachable))
+        (call $set (i32.const 0xa1))
+        (local.set $ret (global.get $bump))
+        (global.set $bump (i32.and
+          (i32.add (i32.add (global.get $bump) (local.get 3)) (i32.const 7))
+          (i32.const -8)))
+        (local.get $ret))
+    )
+    (core instance $libc (instantiate $Libc (with "" (instance
+      (export "get" (func $get))
+      (export "set" (func $set))))))
+
+    (core func $task.return (canon task.return (result string)
+      (memory (core memory $libc "memory"))))
+
+    (core module $M
+      (import "" "get" (func $get (result i32)))
+      (import "" "set" (func $set (param i32)))
+      (import "" "task.return" (func $task.return (param i32 i32)))
+      (import "" "memory" (memory 1))
+
+      (func (export "f-sync") (param $ptr i32) (param $len i32) (result i32)
+        (if (i32.ne (call $get) (i32.const 0)) (then unreachable))
+        (call $set (i32.const 0xc0de))
+        (i32.store (i32.const 8) (local.get $ptr))
+        (i32.store (i32.const 12) (local.get $len))
+        (i32.const 8))
+      (func (export "f-sync-post") (param i32)
+        (if (i32.ne (call $get) (i32.const 0xc0de)) (then unreachable))
+        (call $set (i32.const 0xbad)))
+
+      (func (export "f-async") (param $ptr i32) (param $len i32) (result i32)
+        (if (i32.ne (call $get) (i32.const 0)) (then unreachable))
+        (call $set (i32.const 0xc0de))
+        (call $task.return (local.get $ptr) (local.get $len))
+        (i32.const 0 (; CALLBACK_CODE_EXIT ;)))
+      (func (export "f-async-cb") (param i32 i32 i32) (result i32) unreachable)
+    )
+    (core instance $m (instantiate $M (with "" (instance
+      (export "get" (func $get))
+      (export "set" (func $set))
+      (export "task.return" (func $task.return))
+      (export "memory" (memory $libc "memory"))))))
+
+    (func (export "sync-lift") async (param "x" string) (result string)
+      (canon lift (core func $m "f-sync")
+        (memory (core memory $libc "memory"))
+        (realloc (core func $libc "realloc"))
+        (post-return (core func $m "f-sync-post"))))
+    (func (export "async-lift") async (param "x" string) (result string)
+      (canon lift (core func $m "f-async")
+        (memory (core memory $libc "memory"))
+        (realloc (core func $libc "realloc"))
+        async
+        (callback (core func $m "f-async-cb"))))
+  )
+
+  (component $B
+    (import "a" (instance $a
+      (export "sync-lift" (func async (param "x" string) (result string)))
+      (export "async-lift" (func async (param "x" string) (result string)))))
+
+    (core func $get (canon context.get i32 0))
+    (core func $set (canon context.set i32 0))
+
+    (core module $Libc
+      (import "" "get" (func $get (result i32)))
+      (import "" "set" (func $set (param i32)))
+      (memory (export "memory") 1)
+      (data (i32.const 16) "hello")
+      (global $bump (mut i32) (i32.const 64))
+      (func (export "realloc") (param i32 i32 i32 i32) (result i32)
+        (local $ret i32)
+        (if (i32.ne (call $get) (i32.const 0)) (then unreachable))
+        (call $set (i32.const 0xb1))
+        (local.set $ret (global.get $bump))
+        (global.set $bump (i32.and
+          (i32.add (i32.add (global.get $bump) (local.get 3)) (i32.const 7))
+          (i32.const -8)))
+        (local.get $ret))
+    )
+    (core instance $libc (instantiate $Libc (with "" (instance
+      (export "get" (func $get))
+      (export "set" (func $set))))))
+
+    (core func $sync-to-sync (canon lower (func $a "sync-lift")
+      (memory (core memory $libc "memory"))
+      (realloc (core func $libc "realloc"))))
+    (core func $sync-to-async (canon lower (func $a "async-lift")
+      (memory (core memory $libc "memory"))
+      (realloc (core func $libc "realloc"))))
+    (core func $async-to-sync (canon lower (func $a "sync-lift") async
+      (memory (core memory $libc "memory"))
+      (realloc (core func $libc "realloc"))))
+    (core func $async-to-async (canon lower (func $a "async-lift") async
+      (memory (core memory $libc "memory"))
+      (realloc (core func $libc "realloc"))))
+
+    (core module $M
+      (import "" "get" (func $get (result i32)))
+      (import "" "set" (func $set (param i32)))
+      (import "" "sync-to-sync" (func $sync-to-sync (param i32 i32 i32)))
+      (import "" "sync-to-async" (func $sync-to-async (param i32 i32 i32)))
+      (import "" "async-to-sync" (func $async-to-sync (param i32 i32 i32) (result i32)))
+      (import "" "async-to-async" (func $async-to-async (param i32 i32 i32) (result i32)))
+
+      (func (export "sync-to-sync")
+        (call $set (i32.const 0x1234))
+        (call $sync-to-sync (i32.const 16) (i32.const 5) (i32.const 8))
+        (if (i32.ne (call $get) (i32.const 0x1234)) (then unreachable)))
+
+      (func (export "sync-to-async")
+        (call $set (i32.const 0x1235))
+        (call $sync-to-async (i32.const 16) (i32.const 5) (i32.const 8))
+        (if (i32.ne (call $get) (i32.const 0x1235)) (then unreachable)))
+
+      (func (export "async-to-sync")
+        (call $set (i32.const 0x1236))
+        (if (i32.ne
+              (call $async-to-sync (i32.const 16) (i32.const 5) (i32.const 8))
+              (i32.const 2 (; RETURNED ;)))
+          (then unreachable))
+        (if (i32.ne (call $get) (i32.const 0x1236)) (then unreachable)))
+
+      (func (export "async-to-async")
+        (call $set (i32.const 0x1237))
+        (if (i32.ne
+              (call $async-to-async (i32.const 16) (i32.const 5) (i32.const 8))
+              (i32.const 2 (; RETURNED ;)))
+          (then unreachable))
+        (if (i32.ne (call $get) (i32.const 0x1237)) (then unreachable)))
+    )
+    (core instance $m (instantiate $M (with "" (instance
+      (export "get" (func $get))
+      (export "set" (func $set))
+      (export "sync-to-sync" (func $sync-to-sync))
+      (export "sync-to-async" (func $sync-to-async))
+      (export "async-to-sync" (func $async-to-sync))
+      (export "async-to-async" (func $async-to-async))))))
+
+    (func (export "sync-to-sync") async (canon lift (core func $m "sync-to-sync")))
+    (func (export "sync-to-async") async (canon lift (core func $m "sync-to-async")))
+    (func (export "async-to-sync") async (canon lift (core func $m "async-to-sync")))
+    (func (export "async-to-async") async (canon lift (core func $m "async-to-async")))
+  )
+
+  (instance $a (instantiate $A))
+  (instance $b (instantiate $B (with "a" (instance $a))))
+  (export "sync-to-sync" (func $b "sync-to-sync"))
+  (export "sync-to-async" (func $b "sync-to-async"))
+  (export "async-to-sync" (func $b "async-to-sync"))
+  (export "async-to-async" (func $b "async-to-async"))
+)
+(assert_return (invoke "sync-to-sync"))
+(assert_return (invoke "sync-to-async"))
+(assert_return (invoke "async-to-sync"))
+(assert_return (invoke "async-to-async"))

--- a/tests/misc_testsuite/component-model/async/task-builtins.wast
+++ b/tests/misc_testsuite/component-model/async/task-builtins.wast
@@ -272,7 +272,7 @@
         (if (i32.ne (local.get 2) (i32.const 1)) (then (unreachable)))
         (if (i32.ne (local.get 3) (i32.const 2)) (then (unreachable)))
 
-        (if (i32.ne (call $context.get) (i32.const 400)) (then (unreachable)))
+        (if (i32.ne (call $context.get) (i32.const 0)) (then (unreachable)))
         (call $context.set (i32.const 500))
 
         call $backpressure.inc
@@ -326,19 +326,19 @@
 
       ;; set this tasks's context before calling $run, in calling $run the
       ;; runtime will then call `realloc` above for the string return value
-      ;; which should see our 400 value. That will then set 500 which we should
-      ;; then see after the return.
+      ;; which should NOT see our 400 value. That will then set 500 which we
+      ;; should NOT then see after the return.
 
       (func (export "sync-to-sync")
         (call $context.set (i32.const 400))
         (call $sync-to-sync (i32.const 20))
-        (if (i32.ne (call $context.get) (i32.const 500)) (then (unreachable)))
+        (if (i32.ne (call $context.get) (i32.const 400)) (then (unreachable)))
       )
 
       (func (export "sync-to-async")
         (call $context.set (i32.const 400))
         (call $sync-to-async (i32.const 20))
-        (if (i32.ne (call $context.get) (i32.const 500)) (then (unreachable)))
+        (if (i32.ne (call $context.get) (i32.const 400)) (then (unreachable)))
       )
 
       (func (export "async-to-sync")
@@ -350,7 +350,7 @@
           )
           (then (unreachable))
         )
-        (if (i32.ne (call $context.get) (i32.const 500)) (then (unreachable)))
+        (if (i32.ne (call $context.get) (i32.const 400)) (then (unreachable)))
       )
 
       (func (export "async-to-async")
@@ -362,7 +362,7 @@
           )
           (then (unreachable))
         )
-        (if (i32.ne (call $context.get) (i32.const 500)) (then (unreachable)))
+        (if (i32.ne (call $context.get) (i32.const 400)) (then (unreachable)))
       )
     )
     (core instance $m (instantiate $M (with "" (instance


### PR DESCRIPTION
This commit fixes handling of `context.{get,set}` slots in sync-to-sync adapters generated by Wasmtime's FACT pass. Previously no care was taken here meaning that the context slots were wrong for `post-return` and `realloc` calls. All slots are now managed as they are on the host, mirroring the logic internally for management.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
