### PR TITLE
winch: throw exceptions

### DIFF
--- a/crates/test-util/src/wast.rs
+++ b/crates/test-util/src/wast.rs
@@ -567,10 +567,8 @@ impl WastTest {
                 "misc_testsuite/externref-table-dropped-segment-issue-8281.wast",
                 "misc_testsuite/many_table_gets_lead_to_gc.wast",
                 "misc_testsuite/no-panic.wast",
-                // Currently exceptions trap on throw, re-enable after catch
-                // is implemented.
+                // Winch does not implement exception handlers yet.
                 "misc_testsuite/traps-skip-catch-all.wast",
-                "misc_testsuite/component-model/async/exceptions.wast",
                 "spec_testsuite/throw.wast",
             ];
 

--- a/crates/winch/src/compiler.rs
+++ b/crates/winch/src/compiler.rs
@@ -146,7 +146,7 @@ impl wasmtime_environ::Compiler for Compiler {
             )
             .map_err(|e| CompileError::Codegen(format!("{e:?}")));
         self.save_context(context, validator.into_allocations());
-        let mut func = func?;
+        let (mut func, needs_gc_heap) = func?;
 
         let reader = body.get_binary_reader();
         func.set_address_map(
@@ -161,8 +161,7 @@ impl wasmtime_environ::Compiler for Compiler {
 
         Ok(CompiledFunctionBody {
             code: box_dyn_any_compiled_function(func),
-            // TODO: Winch doesn't support GC objects and stack maps and all that yet.
-            needs_gc_heap: false,
+            needs_gc_heap,
         })
     }
 

--- a/tests/all/exceptions.rs
+++ b/tests/all/exceptions.rs
@@ -3,7 +3,7 @@ use std::sync::atomic::{AtomicBool, Ordering::Relaxed};
 use wasmtime::*;
 use wasmtime_test_macros::wasmtime_test;
 
-// Currently exceptions trap on throw, re-enable after catch is implemented.
+// Winch does not implement catches yet. Re-enable after catch is implemented.
 #[wasmtime_test(strategies(not(Winch)), wasm_features(exceptions))]
 #[cfg_attr(miri, ignore)]
 fn basic_throw(config: &mut Config) -> Result<()> {
@@ -40,7 +40,7 @@ fn basic_throw(config: &mut Config) -> Result<()> {
     Ok(())
 }
 
-// Currently exceptions trap on throw, re-enable after catch is implemented.
+// Winch does not implement catches yet. Re-enable after catch is implemented.
 #[wasmtime_test(strategies(not(Winch)), wasm_features(exceptions))]
 #[cfg_attr(miri, ignore)]
 fn dynamic_tags(config: &mut Config) -> Result<()> {
@@ -101,8 +101,7 @@ fn dynamic_tags(config: &mut Config) -> Result<()> {
     Ok(())
 }
 
-// Currently exceptions trap on throw, re-enable after catch is implemented.
-#[wasmtime_test(strategies(not(Winch)), wasm_features(exceptions))]
+#[wasmtime_test(wasm_features(exceptions))]
 #[cfg_attr(miri, ignore)]
 fn exception_escape_to_host(config: &mut Config) -> Result<()> {
     let engine = Engine::new(config)?;
@@ -135,7 +134,134 @@ fn exception_escape_to_host(config: &mut Config) -> Result<()> {
     Ok(())
 }
 
-// Currently exceptions trap on throw, re-enable after catch is implemented.
+#[wasmtime_test(wasm_features(exceptions))]
+#[cfg_attr(miri, ignore)]
+fn defined_exception_escape_to_host(config: &mut Config) -> Result<()> {
+    let engine = Engine::new(config)?;
+    let mut store = Store::new(&engine, ());
+
+    let module = Module::new(
+        &engine,
+        r#"
+        (module
+          (tag $e (export "e") (param i64))
+          (func (export "throw")
+                (throw $e (i64.const 84))))
+          "#,
+    )?;
+
+    let instance = Instance::new(&mut store, &module, &[])?;
+    let tag = instance.get_tag(&mut store, "e").unwrap();
+    let func = instance.get_func(&mut store, "throw").unwrap();
+    let result = func.call(&mut store, &[], &mut []);
+    assert!(result.unwrap_err().is::<ThrownException>());
+    let exn = store.take_pending_exception().unwrap();
+    let exntag = exn.tag(&mut store)?;
+    assert!(Tag::eq(&exntag, &tag, &store));
+    assert_eq!(exn.field(&mut store, 0)?.unwrap_i64(), 84);
+
+    Ok(())
+}
+
+#[wasmtime_test(wasm_features(exceptions, reference_types))]
+#[cfg_attr(miri, ignore)]
+fn funcref_exception_payload_escape_to_host(config: &mut Config) -> Result<()> {
+    let engine = Engine::new(config)?;
+    let mut store = Store::new(&engine, ());
+
+    let module = Module::new(
+        &engine,
+        r#"
+        (module
+          (tag $e (param funcref))
+          (func (export "throw") (param funcref)
+                (throw $e (local.get 0))))
+          "#,
+    )?;
+
+    let instance = Instance::new(&mut store, &module, &[])?;
+    let func = instance.get_func(&mut store, "throw").unwrap();
+    let expected = Func::wrap(&mut store, || 126_i32);
+    let result = func.call(&mut store, &[Val::FuncRef(Some(expected))], &mut []);
+    assert!(result.unwrap_err().is::<ThrownException>());
+    let exn = store.take_pending_exception().unwrap();
+    let payload = exn.field(&mut store, 0)?;
+    let payload = payload.unwrap_funcref().unwrap();
+    let payload = payload.typed::<(), i32>(&store)?;
+    assert_eq!(payload.call(&mut store, ())?, 126);
+
+    Ok(())
+}
+
+#[wasmtime_test(wasm_features(exceptions, reference_types))]
+#[cfg_attr(miri, ignore)]
+fn thrown_externref_payload_survives_gc(config: &mut Config) -> Result<()> {
+    config.collector(Collector::DeferredReferenceCounting);
+    let engine = Engine::new(config)?;
+    let mut store = Store::new(&engine, ());
+
+    let module = Module::new(
+        &engine,
+        r#"
+        (module
+          (tag $e (param externref))
+          (func (export "throw") (param externref)
+            (throw $e (local.get 0))))
+        "#,
+    )?;
+    let instance = Instance::new(&mut store, &module, &[])?;
+    let func = instance.get_func(&mut store, "throw").unwrap();
+    let dropped = Arc::new(AtomicBool::new(false));
+
+    {
+        let mut scope = RootScope::new(&mut store);
+        let payload = ExternRef::new(&mut scope, SetFlagOnDrop(dropped.clone()))?;
+        let result = func.call(&mut scope, &[Val::ExternRef(Some(payload))], &mut []);
+        assert!(result.unwrap_err().is::<ThrownException>());
+    }
+
+    store.gc(None)?;
+    assert!(!dropped.load(Relaxed));
+
+    let exn = store.take_pending_exception().unwrap();
+    let payload = exn
+        .field(&mut store, 0)?
+        .unwrap_externref()
+        .copied()
+        .unwrap();
+    assert!(payload.data(&store)?.is_some());
+
+    Ok(())
+}
+
+#[wasmtime_test(wasm_features(exceptions))]
+#[cfg_attr(miri, ignore)]
+fn throw_with_null_collector(config: &mut Config) -> Result<()> {
+    config.collector(Collector::Null);
+    let engine = Engine::new(config)?;
+    let mut store = Store::new(&engine, ());
+
+    let module = Module::new(
+        &engine,
+        r#"
+        (module
+          (tag $e (param i32))
+          (func (export "throw")
+            (throw $e (i32.const 42))))
+        "#,
+    )?;
+    let instance = Instance::new(&mut store, &module, &[])?;
+    let func = instance.get_func(&mut store, "throw").unwrap();
+    let result = func.call(&mut store, &[], &mut []);
+    assert!(result.unwrap_err().is::<ThrownException>());
+
+    let exn = store.take_pending_exception().unwrap();
+    assert_eq!(exn.field(&mut store, 0)?.unwrap_i32(), 42);
+
+    Ok(())
+}
+
+// Winch does not implement catches yet. Re-enable after catch is implemented.
 #[wasmtime_test(strategies(not(Winch)), wasm_features(exceptions))]
 #[cfg_attr(miri, ignore)]
 fn exception_from_host(config: &mut Config) -> Result<()> {
@@ -276,7 +402,7 @@ fn thrown_exception_without_throwing(config: &mut Config) -> Result<()> {
     Ok(())
 }
 
-// Currently exceptions trap on throw, re-enable after catch is implemented.
+// Winch does not implement catches yet. Re-enable after catch is implemented.
 #[wasmtime_test(strategies(not(Winch)), wasm_features(exceptions))]
 #[cfg_attr(miri, ignore)]
 fn wasm_exceptions_have_backtraces(config: &mut Config) -> Result<()> {
@@ -303,7 +429,7 @@ fn wasm_exceptions_have_backtraces(config: &mut Config) -> Result<()> {
     Ok(())
 }
 
-// Currently exceptions trap on throw, re-enable after catch is implemented.
+// Winch does not implement catches yet. Re-enable after catch is implemented.
 #[wasmtime_test(strategies(not(Winch)), wasm_features(exceptions))]
 #[cfg_attr(miri, ignore)]
 fn store_pending_exnref_is_cloned(config: &mut Config) -> wasmtime::Result<()> {
@@ -359,7 +485,7 @@ fn store_pending_exnref_is_cloned(config: &mut Config) -> wasmtime::Result<()> {
     Ok(())
 }
 
-// Currently exceptions trap on throw, re-enable after catch is implemented.
+// Winch does not implement catches yet. Re-enable after catch is implemented.
 #[wasmtime_test(strategies(not(Winch)), wasm_features(exceptions, reference_types))]
 #[cfg_attr(miri, ignore)]
 fn store_pending_exnref_is_exposed(config: &mut Config) -> wasmtime::Result<()> {

--- a/tests/disas/winch/aarch64/exceptions/throw-drc.wat
+++ b/tests/disas/winch/aarch64/exceptions/throw-drc.wat
@@ -1,6 +1,6 @@
 ;;! target = "aarch64"
 ;;! test = "winch"
-;;! flags = "-W exceptions -C collector=null"
+;;! flags = "-W exceptions -C collector=drc"
 
 ;; `throw` builds an exception that escapes to the host, while `try_table`
 ;; still compiles as a plain block.
@@ -21,77 +21,49 @@
 ;;       movk    x17, #0x20
 ;;       add     x16, x16, x17
 ;;       cmp     sp, x16
-;;       b.lo    #0x190
+;;       b.lo    #0x120
 ;;   2c: mov     x9, x0
 ;;       sub     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x0, x9
-;;       bl      #0x2d8
+;;       bl      #0x25c
 ;;   48: ldur    x9, [x28, #8]
-;;       ldur    x16, [x9, #0x20]
-;;       ldur    w1, [x16]
-;;       adds    w1, w1, #7
-;;       b.hs    #0x194
-;;   5c: and     w1, w1, #0xfffffff8
-;;       mov     w2, w1
-;;       adds    w2, w2, #0x18
-;;       b.hs    #0x198
-;;   6c: sub     x28, x28, #4
+;;       ldur    x1, [x9, #0x28]
+;;       ldur    w1, [x1, #8]
+;;       sub     x28, x28, #4
 ;;       mov     sp, x28
 ;;       stur    w0, [x28]
 ;;       sub     x28, x28, #4
 ;;       mov     sp, x28
 ;;       stur    w1, [x28]
-;;       sub     x28, x28, #4
-;;       mov     sp, x28
-;;       stur    w2, [x28]
-;;       ldur    w0, [x28]
-;;       add     x28, x28, #4
-;;       mov     sp, x28
-;;       ldur    x1, [x9, #8]
-;;       ldur    x2, [x1, #0x28]
-;;       ldur    x1, [x1, #0x20]
-;;       cmp     x0, x2, uxtx
-;;       b.ls    #0xdc
-;;       b       #0xb4
-;;   b4: sub     x0, x0, x2, uxtx
 ;;       sub     x28, x28, #8
 ;;       mov     sp, x28
-;;       stur    x0, [x28]
 ;;       mov     x0, x9
-;;       ldur    x1, [x28]
-;;       bl      #0x284
-;;   d0: add     x28, x28, #8
+;;       mov     x1, #0x4000000
+;;       ldur    w2, [x28, #8]
+;;       mov     x3, #0x28
+;;       mov     x4, #8
+;;       bl      #0x20c
+;;   8c: add     x28, x28, #8
 ;;       mov     sp, x28
-;;       ldur    x9, [x28, #0x10]
-;;       ldur    w0, [x28]
 ;;       add     x28, x28, #4
 ;;       mov     sp, x28
+;;       ldur    x9, [x28, #0xc]
 ;;       ldur    x1, [x9, #8]
 ;;       ldur    x2, [x1, #0x28]
 ;;       ldur    x1, [x1, #0x20]
 ;;       mov     x2, x1
 ;;       add     x2, x2, x0, uxtx
-;;       mov     w16, #0x18
-;;       movk    w16, #0x400, lsl #16
-;;       stur    w16, [x2]
-;;       ldur    x16, [x9, #0x28]
-;;       ldur    w16, [x16, #8]
-;;       stur    w16, [x2, #4]
-;;       ldur    x1, [x9, #0x20]
-;;       mov     w16, w0
-;;       add     w16, w16, #0x18
-;;       stur    w16, [x1]
 ;;       ldur    w1, [x28]
 ;;       add     x28, x28, #4
 ;;       mov     sp, x28
-;;       stur    w1, [x2, #8]
+;;       stur    w1, [x2, #0x18]
 ;;       mov     x16, #0
-;;       stur    w16, [x2, #0xc]
+;;       stur    w16, [x2, #0x1c]
 ;;       mov     x16, #0x2a
-;;       stur    w16, [x2, #0x10]
+;;       stur    w16, [x2, #0x20]
 ;;       sub     x28, x28, #4
 ;;       mov     sp, x28
 ;;       stur    w0, [x28]
@@ -99,8 +71,8 @@
 ;;       mov     sp, x28
 ;;       mov     x0, x9
 ;;       ldur    w1, [x28, #0xc]
-;;       bl      #0x308
-;;  164: add     x28, x28, #0xc
+;;       bl      #0x28c
+;;   f4: add     x28, x28, #0xc
 ;;       mov     sp, x28
 ;;       add     x28, x28, #4
 ;;       mov     sp, x28
@@ -111,6 +83,4 @@
 ;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;  190: udf     #0xc11f
-;;  194: udf     #0xc11f
-;;  198: udf     #0xc11f
+;;  120: udf     #0xc11f

--- a/tests/disas/winch/aarch64/exceptions/throw-externref-drc.wat
+++ b/tests/disas/winch/aarch64/exceptions/throw-externref-drc.wat
@@ -1,11 +1,11 @@
 ;;! target = "aarch64"
 ;;! test = "winch"
-;;! flags = "-W exceptions -C collector=copying"
+;;! flags = "-W exceptions -C collector=drc"
 
-;; A function reference is interned before it is stored in the exception.
+;; Store an external reference in an exception payload.
 (module
-  (tag $e (param funcref))
-  (func (param funcref)
+  (tag $e (param externref))
+  (func (param externref)
     (throw $e (local.get 0))))
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
@@ -24,14 +24,19 @@
 ;;       mov     sp, x28
 ;;       stur    x0, [x28, #0x10]
 ;;       stur    x1, [x28, #8]
-;;       stur    x2, [x28]
-;;       ldur    x16, [x28]
-;;       sub     x28, x28, #8
+;;       stur    w2, [x28, #4]
+;;       ldur    w16, [x28, #4]
+;;       sub     x28, x28, #4
 ;;       mov     sp, x28
-;;       stur    x16, [x28]
+;;       stur    w16, [x28]
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
 ;;       mov     x0, x9
-;;       bl      #0x2a0
-;;   5c: ldur    x9, [x28, #0x18]
+;;       bl      #0x274
+;;   64: add     x28, x28, #4
+;;       ╰─╼ stack_map: frame_size=48, frame_offsets=[4, 12]
+;;       mov     sp, x28
+;;       ldur    x9, [x28, #0x14]
 ;;       ldur    x1, [x9, #0x28]
 ;;       ldur    w1, [x1, #4]
 ;;       sub     x28, x28, #4
@@ -40,20 +45,20 @@
 ;;       sub     x28, x28, #4
 ;;       mov     sp, x28
 ;;       stur    w1, [x28]
-;;       sub     x28, x28, #8
+;;       sub     x28, x28, #0xc
 ;;       mov     sp, x28
 ;;       mov     x0, x9
-;;       mov     w1, #2
-;;       movk    w1, #0x400, lsl #16
-;;       ldur    w2, [x28, #8]
-;;       mov     x3, #0x20
-;;       mov     x4, #0x10
-;;       bl      #0x220
-;;   a4: add     x28, x28, #8
+;;       mov     x1, #0x4000000
+;;       ldur    w2, [x28, #0xc]
+;;       mov     x3, #0x28
+;;       mov     x4, #8
+;;       bl      #0x224
+;;   b0: add     x28, x28, #0xc
+;;       ╰─╼ stack_map: frame_size=64, frame_offsets=[20, 28]
 ;;       mov     sp, x28
 ;;       add     x28, x28, #4
 ;;       mov     sp, x28
-;;       ldur    x9, [x28, #0x1c]
+;;       ldur    x9, [x28, #0x18]
 ;;       ldur    x1, [x9, #8]
 ;;       ldur    x2, [x1, #0x28]
 ;;       ldur    x1, [x1, #0x20]
@@ -62,47 +67,45 @@
 ;;       ldur    w1, [x28]
 ;;       add     x28, x28, #4
 ;;       mov     sp, x28
-;;       stur    w1, [x2, #0x10]
+;;       stur    w1, [x2, #0x18]
 ;;       mov     x16, #0
-;;       stur    w16, [x2, #0x14]
-;;       ldur    x1, [x28]
-;;       add     x28, x28, #8
-;;       mov     sp, x28
-;;       sub     x28, x28, #8
-;;       mov     sp, x28
-;;       stur    x2, [x28]
-;;       sub     x28, x28, #4
-;;       mov     sp, x28
-;;       stur    w0, [x28]
-;;       sub     x28, x28, #8
-;;       mov     sp, x28
-;;       stur    x1, [x28]
-;;       sub     x28, x28, #4
-;;       mov     sp, x28
-;;       mov     x0, x9
-;;       ldur    x1, [x28, #4]
-;;       bl      #0x270
-;;  128: add     x28, x28, #4
-;;       mov     sp, x28
-;;       add     x28, x28, #8
-;;       mov     sp, x28
-;;       ldur    x9, [x28, #0x1c]
+;;       stur    w16, [x2, #0x1c]
 ;;       ldur    w1, [x28]
 ;;       add     x28, x28, #4
 ;;       mov     sp, x28
-;;       ldur    x2, [x28]
-;;       add     x28, x28, #8
-;;       mov     sp, x28
-;;       stur    w0, [x2, #0x18]
+;;       tst     w1, w1
+;;       b.eq    #0x154
+;;       b       #0x108
+;;  108: mov     w16, w1
+;;       and     w16, w16, #1
+;;       tst     w16, w16
+;;       b.ne    #0x154
+;;       b       #0x11c
+;;  11c: ldur    x3, [x9, #8]
+;;       ldur    x4, [x3, #0x28]
+;;       ldur    x3, [x3, #0x20]
+;;       mov     x16, x1
+;;       add     x16, x16, #0x10
+;;       cmp     x16, x4, uxtx
+;;       sub     sp, x28, #8
+;;       b.hi    #0x1a8
+;;  13c: mov     sp, x28
+;;       mov     x5, x3
+;;       add     x5, x5, x1, uxtx
+;;       ldur    x6, [x5, #8]
+;;       add     x6, x6, #1
+;;       stur    x6, [x5, #8]
+;;       stur    w1, [x2, #0x20]
 ;;       sub     x28, x28, #4
 ;;       mov     sp, x28
-;;       stur    w1, [x28]
+;;       stur    w0, [x28]
 ;;       sub     x28, x28, #4
 ;;       mov     sp, x28
 ;;       mov     x0, x9
 ;;       ldur    w1, [x28, #4]
-;;       bl      #0x2d0
+;;       bl      #0x2a4
 ;;  178: add     x28, x28, #4
+;;       ╰─╼ stack_map: frame_size=48, frame_offsets=[12]
 ;;       mov     sp, x28
 ;;       add     x28, x28, #4
 ;;       mov     sp, x28
@@ -114,3 +117,4 @@
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
 ;;  1a4: udf     #0xc11f
+;;  1a8: udf     #0xc11f

--- a/tests/disas/winch/aarch64/exceptions/throw-externref-null.wat
+++ b/tests/disas/winch/aarch64/exceptions/throw-externref-null.wat
@@ -2,14 +2,11 @@
 ;;! test = "winch"
 ;;! flags = "-W exceptions -C collector=null"
 
-;; `throw` builds an exception that escapes to the host, while `try_table`
-;; still compiles as a plain block.
+;; Store an external reference in an exception payload.
 (module
-  (tag $e (param i32))
-  (func (result i32)
-    (block $h (result i32)
-      (try_table (result i32) (catch $e $h)
-        (throw $e (i32.const 42))))))
+  (tag $e (param externref))
+  (func (param externref)
+    (throw $e (local.get 0))))
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
@@ -18,27 +15,41 @@
 ;;       ldur    x16, [x0, #8]
 ;;       ldur    x16, [x16, #0x18]
 ;;       mov     x17, #0
-;;       movk    x17, #0x20
+;;       movk    x17, #0x30
 ;;       add     x16, x16, x17
 ;;       cmp     sp, x16
-;;       b.lo    #0x190
+;;       b.lo    #0x1dc
 ;;   2c: mov     x9, x0
-;;       sub     x28, x28, #0x10
+;;       sub     x28, x28, #0x18
 ;;       mov     sp, x28
-;;       stur    x0, [x28, #8]
-;;       stur    x1, [x28]
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       stur    w2, [x28, #4]
+;;       ldur    w16, [x28, #4]
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
+;;       stur    w16, [x28]
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
 ;;       mov     x0, x9
-;;       bl      #0x2d8
-;;   48: ldur    x9, [x28, #8]
+;;       bl      #0x2b4
+;;   64: add     x28, x28, #4
+;;       ╰─╼ stack_map: frame_size=48, frame_offsets=[4, 12]
+;;       mov     sp, x28
+;;       ldur    x9, [x28, #0x14]
 ;;       ldur    x16, [x9, #0x20]
 ;;       ldur    w1, [x16]
+;;       sub     sp, x28, #4
 ;;       adds    w1, w1, #7
-;;       b.hs    #0x194
-;;   5c: and     w1, w1, #0xfffffff8
+;;       b.hs    #0x1e0
+;;   84: mov     sp, x28
+;;       and     w1, w1, #0xfffffff8
 ;;       mov     w2, w1
+;;       sub     sp, x28, #4
 ;;       adds    w2, w2, #0x18
-;;       b.hs    #0x198
-;;   6c: sub     x28, x28, #4
+;;       b.hs    #0x1e4
+;;   9c: mov     sp, x28
+;;       sub     x28, x28, #4
 ;;       mov     sp, x28
 ;;       stur    w0, [x28]
 ;;       sub     x28, x28, #4
@@ -54,18 +65,23 @@
 ;;       ldur    x2, [x1, #0x28]
 ;;       ldur    x1, [x1, #0x20]
 ;;       cmp     x0, x2, uxtx
-;;       b.ls    #0xdc
-;;       b       #0xb4
-;;   b4: sub     x0, x0, x2, uxtx
+;;       b.ls    #0x120
+;;       b       #0xe8
+;;   e8: sub     x0, x0, x2, uxtx
 ;;       sub     x28, x28, #8
 ;;       mov     sp, x28
 ;;       stur    x0, [x28]
-;;       mov     x0, x9
-;;       ldur    x1, [x28]
-;;       bl      #0x284
-;;   d0: add     x28, x28, #8
+;;       sub     x28, x28, #4
 ;;       mov     sp, x28
-;;       ldur    x9, [x28, #0x10]
+;;       mov     x0, x9
+;;       ldur    x1, [x28, #4]
+;;       bl      #0x260
+;;  10c: add     x28, x28, #4
+;;       ╰─╼ stack_map: frame_size=64, frame_offsets=[20, 28]
+;;       mov     sp, x28
+;;       add     x28, x28, #8
+;;       mov     sp, x28
+;;       ldur    x9, [x28, #0x1c]
 ;;       ldur    w0, [x28]
 ;;       add     x28, x28, #4
 ;;       mov     sp, x28
@@ -78,7 +94,7 @@
 ;;       movk    w16, #0x400, lsl #16
 ;;       stur    w16, [x2]
 ;;       ldur    x16, [x9, #0x28]
-;;       ldur    w16, [x16, #8]
+;;       ldur    w16, [x16, #4]
 ;;       stur    w16, [x2, #4]
 ;;       ldur    x1, [x9, #0x20]
 ;;       mov     w16, w0
@@ -90,27 +106,30 @@
 ;;       stur    w1, [x2, #8]
 ;;       mov     x16, #0
 ;;       stur    w16, [x2, #0xc]
-;;       mov     x16, #0x2a
+;;       ldur    w16, [x28]
+;;       add     x28, x28, #4
+;;       mov     sp, x28
 ;;       stur    w16, [x2, #0x10]
 ;;       sub     x28, x28, #4
 ;;       mov     sp, x28
 ;;       stur    w0, [x28]
-;;       sub     x28, x28, #0xc
+;;       sub     x28, x28, #4
 ;;       mov     sp, x28
 ;;       mov     x0, x9
-;;       ldur    w1, [x28, #0xc]
-;;       bl      #0x308
-;;  164: add     x28, x28, #0xc
+;;       ldur    w1, [x28, #4]
+;;       bl      #0x2e4
+;;  1b0: add     x28, x28, #4
+;;       ╰─╼ stack_map: frame_size=48, frame_offsets=[12]
 ;;       mov     sp, x28
 ;;       add     x28, x28, #4
 ;;       mov     sp, x28
-;;       ldur    x9, [x28, #8]
-;;       add     x28, x28, #0x10
+;;       ldur    x9, [x28, #0x10]
+;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
 ;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;  190: udf     #0xc11f
-;;  194: udf     #0xc11f
-;;  198: udf     #0xc11f
+;;  1dc: udf     #0xc11f
+;;  1e0: udf     #0xc11f
+;;  1e4: udf     #0xc11f

--- a/tests/disas/winch/aarch64/exceptions/throw-externref.wat
+++ b/tests/disas/winch/aarch64/exceptions/throw-externref.wat
@@ -2,14 +2,11 @@
 ;;! test = "winch"
 ;;! flags = "-W exceptions -C collector=copying"
 
-;; `throw` builds an exception that escapes to the host, while `try_table`
-;; still compiles as a plain block.
+;; Store an external reference in an exception payload.
 (module
-  (tag $e (param i32))
-  (func (result i32)
-    (block $h (result i32)
-      (try_table (result i32) (catch $e $h)
-        (throw $e (i32.const 42))))))
+  (tag $e (param externref))
+  (func (param externref)
+    (throw $e (local.get 0))))
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
@@ -18,40 +15,51 @@
 ;;       ldur    x16, [x0, #8]
 ;;       ldur    x16, [x16, #0x18]
 ;;       mov     x17, #0
-;;       movk    x17, #0x20
+;;       movk    x17, #0x30
 ;;       add     x16, x16, x17
 ;;       cmp     sp, x16
-;;       b.lo    #0x124
+;;       b.lo    #0x150
 ;;   2c: mov     x9, x0
-;;       sub     x28, x28, #0x10
+;;       sub     x28, x28, #0x18
 ;;       mov     sp, x28
-;;       stur    x0, [x28, #8]
-;;       stur    x1, [x28]
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       stur    w2, [x28, #4]
+;;       ldur    w16, [x28, #4]
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
+;;       stur    w16, [x28]
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
 ;;       mov     x0, x9
-;;       bl      #0x260
-;;   48: ldur    x9, [x28, #8]
+;;       bl      #0x21c
+;;   64: add     x28, x28, #4
+;;       ╰─╼ stack_map: frame_size=48, frame_offsets=[4, 12]
+;;       mov     sp, x28
+;;       ldur    x9, [x28, #0x14]
 ;;       ldur    x1, [x9, #0x28]
-;;       ldur    w1, [x1, #8]
+;;       ldur    w1, [x1, #4]
 ;;       sub     x28, x28, #4
 ;;       mov     sp, x28
 ;;       stur    w0, [x28]
 ;;       sub     x28, x28, #4
 ;;       mov     sp, x28
 ;;       stur    w1, [x28]
-;;       sub     x28, x28, #8
+;;       sub     x28, x28, #0xc
 ;;       mov     sp, x28
 ;;       mov     x0, x9
-;;       mov     w1, #2
+;;       mov     w1, #0x22
 ;;       movk    w1, #0x400, lsl #16
-;;       ldur    w2, [x28, #8]
+;;       ldur    w2, [x28, #0xc]
 ;;       mov     x3, #0x20
 ;;       mov     x4, #0x10
-;;       bl      #0x210
-;;   90: add     x28, x28, #8
+;;       bl      #0x1cc
+;;   b4: add     x28, x28, #0xc
+;;       ╰─╼ stack_map: frame_size=64, frame_offsets=[20, 28]
 ;;       mov     sp, x28
 ;;       add     x28, x28, #4
 ;;       mov     sp, x28
-;;       ldur    x9, [x28, #0xc]
+;;       ldur    x9, [x28, #0x18]
 ;;       ldur    x1, [x9, #8]
 ;;       ldur    x2, [x1, #0x28]
 ;;       ldur    x1, [x1, #0x20]
@@ -63,25 +71,28 @@
 ;;       stur    w1, [x2, #0x10]
 ;;       mov     x16, #0
 ;;       stur    w16, [x2, #0x14]
-;;       mov     x16, #0x2a
+;;       ldur    w16, [x28]
+;;       add     x28, x28, #4
+;;       mov     sp, x28
 ;;       stur    w16, [x2, #0x18]
 ;;       sub     x28, x28, #4
 ;;       mov     sp, x28
 ;;       stur    w0, [x28]
-;;       sub     x28, x28, #0xc
+;;       sub     x28, x28, #4
 ;;       mov     sp, x28
 ;;       mov     x0, x9
-;;       ldur    w1, [x28, #0xc]
-;;       bl      #0x290
-;;   f8: add     x28, x28, #0xc
+;;       ldur    w1, [x28, #4]
+;;       bl      #0x24c
+;;  124: add     x28, x28, #4
+;;       ╰─╼ stack_map: frame_size=48, frame_offsets=[12]
 ;;       mov     sp, x28
 ;;       add     x28, x28, #4
 ;;       mov     sp, x28
-;;       ldur    x9, [x28, #8]
-;;       add     x28, x28, #0x10
+;;       ldur    x9, [x28, #0x10]
+;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
 ;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;  124: udf     #0xc11f
+;;  150: udf     #0xc11f

--- a/tests/disas/winch/aarch64/exceptions/throw-funcref-drc.wat
+++ b/tests/disas/winch/aarch64/exceptions/throw-funcref-drc.wat
@@ -1,6 +1,6 @@
 ;;! target = "aarch64"
 ;;! test = "winch"
-;;! flags = "-W exceptions -C collector=copying"
+;;! flags = "-W exceptions -C collector=drc"
 
 ;; A function reference is interned before it is stored in the exception.
 (module
@@ -18,7 +18,7 @@
 ;;       movk    x17, #0x30
 ;;       add     x16, x16, x17
 ;;       cmp     sp, x16
-;;       b.lo    #0x1a4
+;;       b.lo    #0x1a0
 ;;   2c: mov     x9, x0
 ;;       sub     x28, x28, #0x18
 ;;       mov     sp, x28
@@ -30,7 +30,7 @@
 ;;       mov     sp, x28
 ;;       stur    x16, [x28]
 ;;       mov     x0, x9
-;;       bl      #0x2a0
+;;       bl      #0x29c
 ;;   5c: ldur    x9, [x28, #0x18]
 ;;       ldur    x1, [x9, #0x28]
 ;;       ldur    w1, [x1, #4]
@@ -43,13 +43,12 @@
 ;;       sub     x28, x28, #8
 ;;       mov     sp, x28
 ;;       mov     x0, x9
-;;       mov     w1, #2
-;;       movk    w1, #0x400, lsl #16
+;;       mov     x1, #0x4000000
 ;;       ldur    w2, [x28, #8]
-;;       mov     x3, #0x20
-;;       mov     x4, #0x10
-;;       bl      #0x220
-;;   a4: add     x28, x28, #8
+;;       mov     x3, #0x28
+;;       mov     x4, #8
+;;       bl      #0x21c
+;;   a0: add     x28, x28, #8
 ;;       mov     sp, x28
 ;;       add     x28, x28, #4
 ;;       mov     sp, x28
@@ -62,9 +61,9 @@
 ;;       ldur    w1, [x28]
 ;;       add     x28, x28, #4
 ;;       mov     sp, x28
-;;       stur    w1, [x2, #0x10]
+;;       stur    w1, [x2, #0x18]
 ;;       mov     x16, #0
-;;       stur    w16, [x2, #0x14]
+;;       stur    w16, [x2, #0x1c]
 ;;       ldur    x1, [x28]
 ;;       add     x28, x28, #8
 ;;       mov     sp, x28
@@ -81,8 +80,8 @@
 ;;       mov     sp, x28
 ;;       mov     x0, x9
 ;;       ldur    x1, [x28, #4]
-;;       bl      #0x270
-;;  128: add     x28, x28, #4
+;;       bl      #0x26c
+;;  124: add     x28, x28, #4
 ;;       mov     sp, x28
 ;;       add     x28, x28, #8
 ;;       mov     sp, x28
@@ -93,7 +92,7 @@
 ;;       ldur    x2, [x28]
 ;;       add     x28, x28, #8
 ;;       mov     sp, x28
-;;       stur    w0, [x2, #0x18]
+;;       stur    w0, [x2, #0x20]
 ;;       sub     x28, x28, #4
 ;;       mov     sp, x28
 ;;       stur    w1, [x28]
@@ -101,8 +100,8 @@
 ;;       mov     sp, x28
 ;;       mov     x0, x9
 ;;       ldur    w1, [x28, #4]
-;;       bl      #0x2d0
-;;  178: add     x28, x28, #4
+;;       bl      #0x2cc
+;;  174: add     x28, x28, #4
 ;;       mov     sp, x28
 ;;       add     x28, x28, #4
 ;;       mov     sp, x28
@@ -113,4 +112,4 @@
 ;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;  1a4: udf     #0xc11f
+;;  1a0: udf     #0xc11f

--- a/tests/disas/winch/aarch64/exceptions/throw-funcref-null.wat
+++ b/tests/disas/winch/aarch64/exceptions/throw-funcref-null.wat
@@ -2,14 +2,11 @@
 ;;! test = "winch"
 ;;! flags = "-W exceptions -C collector=null"
 
-;; `throw` builds an exception that escapes to the host, while `try_table`
-;; still compiles as a plain block.
+;; A function reference is interned before it is stored in the exception.
 (module
-  (tag $e (param i32))
-  (func (result i32)
-    (block $h (result i32)
-      (try_table (result i32) (catch $e $h)
-        (throw $e (i32.const 42))))))
+  (tag $e (param funcref))
+  (func (param funcref)
+    (throw $e (local.get 0))))
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
@@ -18,27 +15,32 @@
 ;;       ldur    x16, [x0, #8]
 ;;       ldur    x16, [x16, #0x18]
 ;;       mov     x17, #0
-;;       movk    x17, #0x20
+;;       movk    x17, #0x30
 ;;       add     x16, x16, x17
 ;;       cmp     sp, x16
-;;       b.lo    #0x190
+;;       b.lo    #0x210
 ;;   2c: mov     x9, x0
-;;       sub     x28, x28, #0x10
+;;       sub     x28, x28, #0x18
 ;;       mov     sp, x28
-;;       stur    x0, [x28, #8]
-;;       stur    x1, [x28]
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       stur    x2, [x28]
+;;       ldur    x16, [x28]
+;;       sub     x28, x28, #8
+;;       mov     sp, x28
+;;       stur    x16, [x28]
 ;;       mov     x0, x9
-;;       bl      #0x2d8
-;;   48: ldur    x9, [x28, #8]
+;;       bl      #0x318
+;;   5c: ldur    x9, [x28, #0x18]
 ;;       ldur    x16, [x9, #0x20]
 ;;       ldur    w1, [x16]
 ;;       adds    w1, w1, #7
-;;       b.hs    #0x194
-;;   5c: and     w1, w1, #0xfffffff8
+;;       b.hs    #0x214
+;;   70: and     w1, w1, #0xfffffff8
 ;;       mov     w2, w1
 ;;       adds    w2, w2, #0x18
-;;       b.hs    #0x198
-;;   6c: sub     x28, x28, #4
+;;       b.hs    #0x218
+;;   80: sub     x28, x28, #4
 ;;       mov     sp, x28
 ;;       stur    w0, [x28]
 ;;       sub     x28, x28, #4
@@ -54,18 +56,18 @@
 ;;       ldur    x2, [x1, #0x28]
 ;;       ldur    x1, [x1, #0x20]
 ;;       cmp     x0, x2, uxtx
-;;       b.ls    #0xdc
-;;       b       #0xb4
-;;   b4: sub     x0, x0, x2, uxtx
+;;       b.ls    #0xf0
+;;       b       #0xc8
+;;   c8: sub     x0, x0, x2, uxtx
 ;;       sub     x28, x28, #8
 ;;       mov     sp, x28
 ;;       stur    x0, [x28]
 ;;       mov     x0, x9
 ;;       ldur    x1, [x28]
-;;       bl      #0x284
-;;   d0: add     x28, x28, #8
+;;       bl      #0x294
+;;   e4: add     x28, x28, #8
 ;;       mov     sp, x28
-;;       ldur    x9, [x28, #0x10]
+;;       ldur    x9, [x28, #0x20]
 ;;       ldur    w0, [x28]
 ;;       add     x28, x28, #4
 ;;       mov     sp, x28
@@ -78,7 +80,7 @@
 ;;       movk    w16, #0x400, lsl #16
 ;;       stur    w16, [x2]
 ;;       ldur    x16, [x9, #0x28]
-;;       ldur    w16, [x16, #8]
+;;       ldur    w16, [x16, #4]
 ;;       stur    w16, [x2, #4]
 ;;       ldur    x1, [x9, #0x20]
 ;;       mov     w16, w0
@@ -90,27 +92,54 @@
 ;;       stur    w1, [x2, #8]
 ;;       mov     x16, #0
 ;;       stur    w16, [x2, #0xc]
-;;       mov     x16, #0x2a
-;;       stur    w16, [x2, #0x10]
+;;       ldur    x1, [x28]
+;;       add     x28, x28, #8
+;;       mov     sp, x28
+;;       sub     x28, x28, #8
+;;       mov     sp, x28
+;;       stur    x2, [x28]
 ;;       sub     x28, x28, #4
 ;;       mov     sp, x28
 ;;       stur    w0, [x28]
-;;       sub     x28, x28, #0xc
+;;       sub     x28, x28, #8
+;;       mov     sp, x28
+;;       stur    x1, [x28]
+;;       sub     x28, x28, #4
 ;;       mov     sp, x28
 ;;       mov     x0, x9
-;;       ldur    w1, [x28, #0xc]
-;;       bl      #0x308
-;;  164: add     x28, x28, #0xc
+;;       ldur    x1, [x28, #4]
+;;       bl      #0x2e8
+;;  194: add     x28, x28, #4
+;;       mov     sp, x28
+;;       add     x28, x28, #8
+;;       mov     sp, x28
+;;       ldur    x9, [x28, #0x1c]
+;;       ldur    w1, [x28]
+;;       add     x28, x28, #4
+;;       mov     sp, x28
+;;       ldur    x2, [x28]
+;;       add     x28, x28, #8
+;;       mov     sp, x28
+;;       stur    w0, [x2, #0x10]
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
+;;       stur    w1, [x28]
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
+;;       mov     x0, x9
+;;       ldur    w1, [x28, #4]
+;;       bl      #0x348
+;;  1e4: add     x28, x28, #4
 ;;       mov     sp, x28
 ;;       add     x28, x28, #4
 ;;       mov     sp, x28
-;;       ldur    x9, [x28, #8]
-;;       add     x28, x28, #0x10
+;;       ldur    x9, [x28, #0x10]
+;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
 ;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;  190: udf     #0xc11f
-;;  194: udf     #0xc11f
-;;  198: udf     #0xc11f
+;;  210: udf     #0xc11f
+;;  214: udf     #0xc11f
+;;  218: udf     #0xc11f

--- a/tests/disas/winch/aarch64/exceptions/throw-funcref.wat
+++ b/tests/disas/winch/aarch64/exceptions/throw-funcref.wat
@@ -2,14 +2,11 @@
 ;;! test = "winch"
 ;;! flags = ["-W", "exceptions"]
 
-;; `throw` builds an exception that escapes to the host, while `try_table`
-;; still compiles as a plain block.
+;; A function reference is interned before it is stored in the exception.
 (module
-  (tag $e (param i32))
-  (func (result i32)
-    (block $h (result i32)
-      (try_table (result i32) (catch $e $h)
-        (throw $e (i32.const 42))))))
+  (tag $e (param funcref))
+  (func (param funcref)
+    (throw $e (local.get 0))))
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
@@ -18,20 +15,25 @@
 ;;       ldur    x16, [x0, #8]
 ;;       ldur    x16, [x16, #0x18]
 ;;       mov     x17, #0
-;;       movk    x17, #0x20
+;;       movk    x17, #0x30
 ;;       add     x16, x16, x17
 ;;       cmp     sp, x16
-;;       b.lo    #0x124
+;;       b.lo    #0x1a4
 ;;   2c: mov     x9, x0
-;;       sub     x28, x28, #0x10
+;;       sub     x28, x28, #0x18
 ;;       mov     sp, x28
-;;       stur    x0, [x28, #8]
-;;       stur    x1, [x28]
+;;       stur    x0, [x28, #0x10]
+;;       stur    x1, [x28, #8]
+;;       stur    x2, [x28]
+;;       ldur    x16, [x28]
+;;       sub     x28, x28, #8
+;;       mov     sp, x28
+;;       stur    x16, [x28]
 ;;       mov     x0, x9
-;;       bl      #0x260
-;;   48: ldur    x9, [x28, #8]
+;;       bl      #0x2a0
+;;   5c: ldur    x9, [x28, #0x18]
 ;;       ldur    x1, [x9, #0x28]
-;;       ldur    w1, [x1, #8]
+;;       ldur    w1, [x1, #4]
 ;;       sub     x28, x28, #4
 ;;       mov     sp, x28
 ;;       stur    w0, [x28]
@@ -46,12 +48,12 @@
 ;;       ldur    w2, [x28, #8]
 ;;       mov     x3, #0x20
 ;;       mov     x4, #0x10
-;;       bl      #0x210
-;;   90: add     x28, x28, #8
+;;       bl      #0x220
+;;   a4: add     x28, x28, #8
 ;;       mov     sp, x28
 ;;       add     x28, x28, #4
 ;;       mov     sp, x28
-;;       ldur    x9, [x28, #0xc]
+;;       ldur    x9, [x28, #0x1c]
 ;;       ldur    x1, [x9, #8]
 ;;       ldur    x2, [x1, #0x28]
 ;;       ldur    x1, [x1, #0x20]
@@ -63,25 +65,52 @@
 ;;       stur    w1, [x2, #0x10]
 ;;       mov     x16, #0
 ;;       stur    w16, [x2, #0x14]
-;;       mov     x16, #0x2a
-;;       stur    w16, [x2, #0x18]
+;;       ldur    x1, [x28]
+;;       add     x28, x28, #8
+;;       mov     sp, x28
+;;       sub     x28, x28, #8
+;;       mov     sp, x28
+;;       stur    x2, [x28]
 ;;       sub     x28, x28, #4
 ;;       mov     sp, x28
 ;;       stur    w0, [x28]
-;;       sub     x28, x28, #0xc
+;;       sub     x28, x28, #8
+;;       mov     sp, x28
+;;       stur    x1, [x28]
+;;       sub     x28, x28, #4
 ;;       mov     sp, x28
 ;;       mov     x0, x9
-;;       ldur    w1, [x28, #0xc]
-;;       bl      #0x290
-;;   f8: add     x28, x28, #0xc
+;;       ldur    x1, [x28, #4]
+;;       bl      #0x270
+;;  128: add     x28, x28, #4
+;;       mov     sp, x28
+;;       add     x28, x28, #8
+;;       mov     sp, x28
+;;       ldur    x9, [x28, #0x1c]
+;;       ldur    w1, [x28]
+;;       add     x28, x28, #4
+;;       mov     sp, x28
+;;       ldur    x2, [x28]
+;;       add     x28, x28, #8
+;;       mov     sp, x28
+;;       stur    w0, [x2, #0x18]
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
+;;       stur    w1, [x28]
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
+;;       mov     x0, x9
+;;       ldur    w1, [x28, #4]
+;;       bl      #0x2d0
+;;  178: add     x28, x28, #4
 ;;       mov     sp, x28
 ;;       add     x28, x28, #4
 ;;       mov     sp, x28
-;;       ldur    x9, [x28, #8]
-;;       add     x28, x28, #0x10
+;;       ldur    x9, [x28, #0x10]
+;;       add     x28, x28, #0x18
 ;;       mov     sp, x28
 ;;       mov     sp, x28
 ;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;  124: udf     #0xc11f
+;;  1a4: udf     #0xc11f

--- a/tests/disas/winch/aarch64/exceptions/throw-null.wat
+++ b/tests/disas/winch/aarch64/exceptions/throw-null.wat
@@ -1,15 +1,12 @@
 ;;! target = "aarch64"
 ;;! test = "winch"
-;;! flags = ["-W", "exceptions"]
+;;! flags = "-W exceptions -C collector=null"
 
-;; `throw` builds an exception that escapes to the host, while `try_table`
-;; still compiles as a plain block.
+;; Exercise the Null collector's inline exception allocation path.
 (module
   (tag $e (param i32))
-  (func (result i32)
-    (block $h (result i32)
-      (try_table (result i32) (catch $e $h)
-        (throw $e (i32.const 42))))))
+  (func
+    (throw $e (i32.const 42))))
 ;; wasm[0]::function[0]:
 ;;       stp     x29, x30, [sp, #-0x10]!
 ;;       mov     x29, sp
@@ -21,50 +18,77 @@
 ;;       movk    x17, #0x20
 ;;       add     x16, x16, x17
 ;;       cmp     sp, x16
-;;       b.lo    #0x124
+;;       b.lo    #0x190
 ;;   2c: mov     x9, x0
 ;;       sub     x28, x28, #0x10
 ;;       mov     sp, x28
 ;;       stur    x0, [x28, #8]
 ;;       stur    x1, [x28]
 ;;       mov     x0, x9
-;;       bl      #0x260
+;;       bl      #0x2cc
 ;;   48: ldur    x9, [x28, #8]
-;;       ldur    x1, [x9, #0x28]
-;;       ldur    w1, [x1, #8]
-;;       sub     x28, x28, #4
+;;       ldur    x16, [x9, #0x20]
+;;       ldur    w1, [x16]
+;;       adds    w1, w1, #7
+;;       b.hs    #0x194
+;;   5c: and     w1, w1, #0xfffffff8
+;;       mov     w2, w1
+;;       adds    w2, w2, #0x18
+;;       b.hs    #0x198
+;;   6c: sub     x28, x28, #4
 ;;       mov     sp, x28
 ;;       stur    w0, [x28]
 ;;       sub     x28, x28, #4
 ;;       mov     sp, x28
 ;;       stur    w1, [x28]
-;;       sub     x28, x28, #8
+;;       sub     x28, x28, #4
 ;;       mov     sp, x28
-;;       mov     x0, x9
-;;       mov     w1, #2
-;;       movk    w1, #0x400, lsl #16
-;;       ldur    w2, [x28, #8]
-;;       mov     x3, #0x20
-;;       mov     x4, #0x10
-;;       bl      #0x210
-;;   90: add     x28, x28, #8
-;;       mov     sp, x28
+;;       stur    w2, [x28]
+;;       ldur    w0, [x28]
 ;;       add     x28, x28, #4
 ;;       mov     sp, x28
-;;       ldur    x9, [x28, #0xc]
+;;       ldur    x1, [x9, #8]
+;;       ldur    x2, [x1, #0x28]
+;;       ldur    x1, [x1, #0x20]
+;;       cmp     x0, x2, uxtx
+;;       b.ls    #0xdc
+;;       b       #0xb4
+;;   b4: sub     x0, x0, x2, uxtx
+;;       sub     x28, x28, #8
+;;       mov     sp, x28
+;;       stur    x0, [x28]
+;;       mov     x0, x9
+;;       ldur    x1, [x28]
+;;       bl      #0x278
+;;   d0: add     x28, x28, #8
+;;       mov     sp, x28
+;;       ldur    x9, [x28, #0x10]
+;;       ldur    w0, [x28]
+;;       add     x28, x28, #4
+;;       mov     sp, x28
 ;;       ldur    x1, [x9, #8]
 ;;       ldur    x2, [x1, #0x28]
 ;;       ldur    x1, [x1, #0x20]
 ;;       mov     x2, x1
 ;;       add     x2, x2, x0, uxtx
+;;       mov     w16, #0x18
+;;       movk    w16, #0x400, lsl #16
+;;       stur    w16, [x2]
+;;       ldur    x16, [x9, #0x28]
+;;       ldur    w16, [x16, #8]
+;;       stur    w16, [x2, #4]
+;;       ldur    x1, [x9, #0x20]
+;;       mov     w16, w0
+;;       add     w16, w16, #0x18
+;;       stur    w16, [x1]
 ;;       ldur    w1, [x28]
 ;;       add     x28, x28, #4
 ;;       mov     sp, x28
-;;       stur    w1, [x2, #0x10]
+;;       stur    w1, [x2, #8]
 ;;       mov     x16, #0
-;;       stur    w16, [x2, #0x14]
+;;       stur    w16, [x2, #0xc]
 ;;       mov     x16, #0x2a
-;;       stur    w16, [x2, #0x18]
+;;       stur    w16, [x2, #0x10]
 ;;       sub     x28, x28, #4
 ;;       mov     sp, x28
 ;;       stur    w0, [x28]
@@ -72,8 +96,8 @@
 ;;       mov     sp, x28
 ;;       mov     x0, x9
 ;;       ldur    w1, [x28, #0xc]
-;;       bl      #0x290
-;;   f8: add     x28, x28, #0xc
+;;       bl      #0x2fc
+;;  164: add     x28, x28, #0xc
 ;;       mov     sp, x28
 ;;       add     x28, x28, #4
 ;;       mov     sp, x28
@@ -84,4 +108,6 @@
 ;;       ldr     x28, [sp], #0x10
 ;;       ldp     x29, x30, [sp], #0x10
 ;;       ret
-;;  124: udf     #0xc11f
+;;  190: udf     #0xc11f
+;;  194: udf     #0xc11f
+;;  198: udf     #0xc11f

--- a/tests/disas/winch/x64/exceptions/throw-drc.wat
+++ b/tests/disas/winch/x64/exceptions/throw-drc.wat
@@ -1,6 +1,6 @@
 ;;! target = "x86_64"
 ;;! test = "winch"
-;;! flags = "-W exceptions -C collector=null"
+;;! flags = "-W exceptions -C collector=drc"
 
 ;; `throw` builds an exception that escapes to the host, while `try_table`
 ;; still compiles as a plain block.
@@ -17,74 +17,50 @@
 ;;       movq    0x18(%r11), %r11
 ;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x14f
+;;       ja      0xf3
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
 ;;       movq    %r14, %rdi
-;;       callq   0x250
+;;       callq   0x1f8
 ;;       movq    8(%rsp), %r14
-;;       movq    0x20(%r14), %r11
-;;       movl    (%r11), %ecx
-;;       addl    $7, %ecx
-;;       jb      0x151
-;;   4f: andl    $0xfffffff8, %ecx
-;;       movl    %ecx, %edx
-;;       addl    $0x18, %edx
-;;       jb      0x153
-;;   63: subq    $4, %rsp
+;;       movq    0x28(%r14), %rcx
+;;       movl    8(%rcx), %ecx
+;;       subq    $4, %rsp
 ;;       movl    %eax, (%rsp)
 ;;       subq    $4, %rsp
 ;;       movl    %ecx, (%rsp)
-;;       subq    $4, %rsp
-;;       movl    %edx, (%rsp)
-;;       movl    (%rsp), %eax
-;;       addq    $4, %rsp
-;;       movq    8(%r14), %rcx
-;;       movq    0x28(%rcx), %rdx
-;;       movq    0x20(%rcx), %rcx
-;;       cmpq    %rdx, %rax
-;;       jbe     0xbc
-;;   a0: subq    %rdx, %rax
-;;       pushq   %rax
+;;       subq    $8, %rsp
 ;;       movq    %r14, %rdi
-;;       movq    (%rsp), %rsi
-;;       callq   0x209
+;;       movl    $0x4000000, %esi
+;;       movl    8(%rsp), %edx
+;;       movl    $0x28, %ecx
+;;       movl    $8, %r8d
+;;       callq   0x1a9
 ;;       addq    $8, %rsp
-;;       movq    0x10(%rsp), %r14
-;;       movl    (%rsp), %eax
 ;;       addq    $4, %rsp
+;;       movq    0xc(%rsp), %r14
 ;;       movq    8(%r14), %rcx
 ;;       movq    0x28(%rcx), %rdx
 ;;       movq    0x20(%rcx), %rcx
 ;;       movq    %rcx, %rdx
 ;;       addq    %rax, %rdx
-;;       movl    $0x4000018, (%rdx)
-;;       movq    0x28(%r14), %r11
-;;       movl    8(%r11), %r11d
-;;       movl    %r11d, 4(%rdx)
-;;       movq    0x20(%r14), %rcx
-;;       movl    %eax, %r11d
-;;       addl    $0x18, %r11d
-;;       movl    %r11d, (%rcx)
 ;;       movl    (%rsp), %ecx
 ;;       addq    $4, %rsp
-;;       movl    %ecx, 8(%rdx)
-;;       movl    $0, 0xc(%rdx)
-;;       movl    $0x2a, 0x10(%rdx)
+;;       movl    %ecx, 0x18(%rdx)
+;;       movl    $0, 0x1c(%rdx)
+;;       movl    $0x2a, 0x20(%rdx)
 ;;       subq    $4, %rsp
 ;;       movl    %eax, (%rsp)
 ;;       subq    $0xc, %rsp
 ;;       movq    %r14, %rdi
 ;;       movl    0xc(%rsp), %esi
-;;       callq   0x27d
+;;       callq   0x225
 ;;       addq    $0xc, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    8(%rsp), %r14
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;  14f: ud2
-;;  151: ud2
-;;  153: ud2
+;;   f3: ud2

--- a/tests/disas/winch/x64/exceptions/throw-externref-drc.wat
+++ b/tests/disas/winch/x64/exceptions/throw-externref-drc.wat
@@ -1,0 +1,93 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = "-W exceptions -C collector=drc"
+
+;; Store an external reference in an exception payload.
+(module
+  (tag $e (param externref))
+  (func (param externref)
+    (throw $e (local.get 0))))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x18(%r11), %r11
+;;       addq    $0x30, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x16b
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x20, %rsp
+;;       movq    %rdi, 0x18(%rsp)
+;;       movq    %rsi, 0x10(%rsp)
+;;       movl    %edx, 0xc(%rsp)
+;;       movl    0xc(%rsp), %r11d
+;;       subq    $4, %rsp
+;;       movl    %r11d, (%rsp)
+;;       subq    $0xc, %rsp
+;;       movq    %r14, %rdi
+;;       callq   0x21b
+;;       addq    $0xc, %rsp
+;;       ╰─╼ stack_map: frame_size=48, frame_offsets=[12, 28]
+;;       movq    0x1c(%rsp), %r14
+;;       movq    0x28(%r14), %rcx
+;;       movl    4(%rcx), %ecx
+;;       subq    $4, %rsp
+;;       movl    %eax, (%rsp)
+;;       subq    $4, %rsp
+;;       movl    %ecx, (%rsp)
+;;       subq    $4, %rsp
+;;       movq    %r14, %rdi
+;;       movl    $0x4000000, %esi
+;;       movl    4(%rsp), %edx
+;;       movl    $0x28, %ecx
+;;       movl    $8, %r8d
+;;       callq   0x1cc
+;;       addq    $4, %rsp
+;;       ╰─╼ stack_map: frame_size=48, frame_offsets=[12, 28]
+;;       addq    $4, %rsp
+;;       movq    0x20(%rsp), %r14
+;;       movq    8(%r14), %rcx
+;;       movq    0x28(%rcx), %rdx
+;;       movq    0x20(%rcx), %rcx
+;;       movq    %rcx, %rdx
+;;       addq    %rax, %rdx
+;;       movl    (%rsp), %ecx
+;;       addq    $4, %rsp
+;;       movl    %ecx, 0x18(%rdx)
+;;       movl    $0, 0x1c(%rdx)
+;;       movl    (%rsp), %ecx
+;;       addq    $4, %rsp
+;;       testl   %ecx, %ecx
+;;       je      0x12f
+;;   e8: movl    %ecx, %r11d
+;;       andl    $1, %r11d
+;;       testl   %r11d, %r11d
+;;       jne     0x12f
+;;   fb: movq    8(%r14), %rbx
+;;       movq    0x28(%rbx), %rsi
+;;       movq    0x20(%rbx), %rbx
+;;       movq    %rcx, %r11
+;;       addq    $0x10, %r11
+;;       cmpq    %rsi, %r11
+;;       ja      0x16d
+;;  11a: movq    %rbx, %rdi
+;;       addq    %rcx, %rdi
+;;       movq    8(%rdi), %r8
+;;       addq    $1, %r8
+;;       movq    %r8, 8(%rdi)
+;;       movl    %ecx, 0x20(%rdx)
+;;       subq    $4, %rsp
+;;       movl    %eax, (%rsp)
+;;       subq    $0xc, %rsp
+;;       movq    %r14, %rdi
+;;       movl    0xc(%rsp), %esi
+;;       callq   0x248
+;;       addq    $0xc, %rsp
+;;       ╰─╼ stack_map: frame_size=48, frame_offsets=[28]
+;;       addq    $4, %rsp
+;;       movq    0x18(%rsp), %r14
+;;       addq    $0x20, %rsp
+;;       popq    %rbp
+;;       retq
+;;  16b: ud2
+;;  16d: ud2

--- a/tests/disas/winch/x64/exceptions/throw-externref-null.wat
+++ b/tests/disas/winch/x64/exceptions/throw-externref-null.wat
@@ -2,38 +2,42 @@
 ;;! test = "winch"
 ;;! flags = "-W exceptions -C collector=null"
 
-;; `throw` builds an exception that escapes to the host, while `try_table`
-;; still compiles as a plain block.
+;; Store an external reference in an exception payload.
 (module
-  (tag $e (param i32))
-  (func (result i32)
-    (block $h (result i32)
-      (try_table (result i32) (catch $e $h)
-        (throw $e (i32.const 42))))))
+  (tag $e (param externref))
+  (func (param externref)
+    (throw $e (local.get 0))))
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x18(%r11), %r11
-;;       addq    $0x20, %r11
+;;       addq    $0x40, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x14f
+;;       ja      0x189
 ;;   1c: movq    %rdi, %r14
-;;       subq    $0x10, %rsp
-;;       movq    %rdi, 8(%rsp)
-;;       movq    %rsi, (%rsp)
+;;       subq    $0x20, %rsp
+;;       movq    %rdi, 0x18(%rsp)
+;;       movq    %rsi, 0x10(%rsp)
+;;       movl    %edx, 0xc(%rsp)
+;;       movl    0xc(%rsp), %r11d
+;;       subq    $4, %rsp
+;;       movl    %r11d, (%rsp)
+;;       subq    $0xc, %rsp
 ;;       movq    %r14, %rdi
-;;       callq   0x250
-;;       movq    8(%rsp), %r14
+;;       callq   0x233
+;;       addq    $0xc, %rsp
+;;       ╰─╼ stack_map: frame_size=48, frame_offsets=[12, 28]
+;;       movq    0x1c(%rsp), %r14
 ;;       movq    0x20(%r14), %r11
 ;;       movl    (%r11), %ecx
 ;;       addl    $7, %ecx
-;;       jb      0x151
-;;   4f: andl    $0xfffffff8, %ecx
+;;       jb      0x18b
+;;   72: andl    $0xfffffff8, %ecx
 ;;       movl    %ecx, %edx
 ;;       addl    $0x18, %edx
-;;       jb      0x153
-;;   63: subq    $4, %rsp
+;;       jb      0x18d
+;;   86: subq    $4, %rsp
 ;;       movl    %eax, (%rsp)
 ;;       subq    $4, %rsp
 ;;       movl    %ecx, (%rsp)
@@ -45,14 +49,17 @@
 ;;       movq    0x28(%rcx), %rdx
 ;;       movq    0x20(%rcx), %rcx
 ;;       cmpq    %rdx, %rax
-;;       jbe     0xbc
-;;   a0: subq    %rdx, %rax
+;;       jbe     0xee
+;;   c3: subq    %rdx, %rax
 ;;       pushq   %rax
+;;       subq    $0xc, %rsp
 ;;       movq    %r14, %rdi
-;;       movq    (%rsp), %rsi
-;;       callq   0x209
+;;       movq    0xc(%rsp), %rsi
+;;       callq   0x1ec
+;;       addq    $0xc, %rsp
+;;       ╰─╼ stack_map: frame_size=64, frame_offsets=[28, 44]
 ;;       addq    $8, %rsp
-;;       movq    0x10(%rsp), %r14
+;;       movq    0x24(%rsp), %r14
 ;;       movl    (%rsp), %eax
 ;;       addq    $4, %rsp
 ;;       movq    8(%r14), %rcx
@@ -62,7 +69,7 @@
 ;;       addq    %rax, %rdx
 ;;       movl    $0x4000018, (%rdx)
 ;;       movq    0x28(%r14), %r11
-;;       movl    8(%r11), %r11d
+;;       movl    4(%r11), %r11d
 ;;       movl    %r11d, 4(%rdx)
 ;;       movq    0x20(%r14), %rcx
 ;;       movl    %eax, %r11d
@@ -72,19 +79,22 @@
 ;;       addq    $4, %rsp
 ;;       movl    %ecx, 8(%rdx)
 ;;       movl    $0, 0xc(%rdx)
-;;       movl    $0x2a, 0x10(%rdx)
+;;       movl    (%rsp), %r11d
+;;       addq    $4, %rsp
+;;       movl    %r11d, 0x10(%rdx)
 ;;       subq    $4, %rsp
 ;;       movl    %eax, (%rsp)
 ;;       subq    $0xc, %rsp
 ;;       movq    %r14, %rdi
 ;;       movl    0xc(%rsp), %esi
-;;       callq   0x27d
+;;       callq   0x260
 ;;       addq    $0xc, %rsp
+;;       ╰─╼ stack_map: frame_size=48, frame_offsets=[28]
 ;;       addq    $4, %rsp
-;;       movq    8(%rsp), %r14
-;;       addq    $0x10, %rsp
+;;       movq    0x18(%rsp), %r14
+;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;  14f: ud2
-;;  151: ud2
-;;  153: ud2
+;;  189: ud2
+;;  18b: ud2
+;;  18d: ud2

--- a/tests/disas/winch/x64/exceptions/throw-externref.wat
+++ b/tests/disas/winch/x64/exceptions/throw-externref.wat
@@ -2,45 +2,50 @@
 ;;! test = "winch"
 ;;! flags = "-W exceptions -C collector=copying"
 
-;; A function reference is interned before it is stored in the exception.
+;; Store an external reference in an exception payload.
 (module
-  (tag $e (param funcref))
-  (func (param funcref)
+  (tag $e (param externref))
+  (func (param externref)
     (throw $e (local.get 0))))
 ;; wasm[0]::function[0]:
 ;;       pushq   %rbp
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x18(%r11), %r11
-;;       addq    $0x40, %r11
+;;       addq    $0x30, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x13a
+;;       ja      0x11e
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
 ;;       movq    %rsi, 0x10(%rsp)
-;;       movq    %rdx, 8(%rsp)
-;;       movq    8(%rsp), %r11
-;;       pushq   %r11
-;;       subq    $8, %rsp
+;;       movl    %edx, 0xc(%rsp)
+;;       movl    0xc(%rsp), %r11d
+;;       subq    $4, %rsp
+;;       movl    %r11d, (%rsp)
+;;       subq    $0xc, %rsp
 ;;       movq    %r14, %rdi
-;;       callq   0x216
-;;       addq    $8, %rsp
-;;       movq    0x20(%rsp), %r14
+;;       callq   0x1cc
+;;       addq    $0xc, %rsp
+;;       ╰─╼ stack_map: frame_size=48, frame_offsets=[12, 28]
+;;       movq    0x1c(%rsp), %r14
 ;;       movq    0x28(%r14), %rcx
 ;;       movl    4(%rcx), %ecx
 ;;       subq    $4, %rsp
 ;;       movl    %eax, (%rsp)
 ;;       subq    $4, %rsp
 ;;       movl    %ecx, (%rsp)
+;;       subq    $4, %rsp
 ;;       movq    %r14, %rdi
-;;       movl    $0x4000002, %esi
-;;       movl    (%rsp), %edx
+;;       movl    $0x4000022, %esi
+;;       movl    4(%rsp), %edx
 ;;       movl    $0x20, %ecx
 ;;       movl    $0x10, %r8d
-;;       callq   0x19a
+;;       callq   0x17d
 ;;       addq    $4, %rsp
-;;       movq    0x24(%rsp), %r14
+;;       ╰─╼ stack_map: frame_size=48, frame_offsets=[12, 28]
+;;       addq    $4, %rsp
+;;       movq    0x20(%rsp), %r14
 ;;       movq    8(%r14), %rcx
 ;;       movq    0x28(%rcx), %rdx
 ;;       movq    0x20(%rcx), %rcx
@@ -50,32 +55,20 @@
 ;;       addq    $4, %rsp
 ;;       movl    %ecx, 0x10(%rdx)
 ;;       movl    $0, 0x14(%rdx)
-;;       popq    %rcx
-;;       pushq   %rdx
+;;       movl    (%rsp), %r11d
+;;       addq    $4, %rsp
+;;       movl    %r11d, 0x18(%rdx)
 ;;       subq    $4, %rsp
 ;;       movl    %eax, (%rsp)
-;;       pushq   %rcx
-;;       subq    $0xc, %rsp
-;;       movq    %r14, %rdi
-;;       movq    0xc(%rsp), %rsi
-;;       callq   0x1e9
-;;       addq    $0xc, %rsp
-;;       addq    $8, %rsp
-;;       movq    0x24(%rsp), %r14
-;;       movl    (%rsp), %ecx
-;;       addq    $4, %rsp
-;;       popq    %rdx
-;;       movl    %eax, 0x18(%rdx)
-;;       subq    $4, %rsp
-;;       movl    %ecx, (%rsp)
 ;;       subq    $0xc, %rsp
 ;;       movq    %r14, %rdi
 ;;       movl    0xc(%rsp), %esi
-;;       callq   0x243
+;;       callq   0x1f9
 ;;       addq    $0xc, %rsp
+;;       ╰─╼ stack_map: frame_size=48, frame_offsets=[28]
 ;;       addq    $4, %rsp
 ;;       movq    0x18(%rsp), %r14
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;  13a: ud2
+;;  11e: ud2

--- a/tests/disas/winch/x64/exceptions/throw-funcref-drc.wat
+++ b/tests/disas/winch/x64/exceptions/throw-funcref-drc.wat
@@ -1,6 +1,6 @@
 ;;! target = "x86_64"
 ;;! test = "winch"
-;;! flags = "-W exceptions -C collector=copying"
+;;! flags = "-W exceptions -C collector=drc"
 
 ;; A function reference is interned before it is stored in the exception.
 (module
@@ -34,10 +34,10 @@
 ;;       subq    $4, %rsp
 ;;       movl    %ecx, (%rsp)
 ;;       movq    %r14, %rdi
-;;       movl    $0x4000002, %esi
+;;       movl    $0x4000000, %esi
 ;;       movl    (%rsp), %edx
-;;       movl    $0x20, %ecx
-;;       movl    $0x10, %r8d
+;;       movl    $0x28, %ecx
+;;       movl    $8, %r8d
 ;;       callq   0x19a
 ;;       addq    $4, %rsp
 ;;       movq    0x24(%rsp), %r14
@@ -48,8 +48,8 @@
 ;;       addq    %rax, %rdx
 ;;       movl    (%rsp), %ecx
 ;;       addq    $4, %rsp
-;;       movl    %ecx, 0x10(%rdx)
-;;       movl    $0, 0x14(%rdx)
+;;       movl    %ecx, 0x18(%rdx)
+;;       movl    $0, 0x1c(%rdx)
 ;;       popq    %rcx
 ;;       pushq   %rdx
 ;;       subq    $4, %rsp
@@ -65,7 +65,7 @@
 ;;       movl    (%rsp), %ecx
 ;;       addq    $4, %rsp
 ;;       popq    %rdx
-;;       movl    %eax, 0x18(%rdx)
+;;       movl    %eax, 0x20(%rdx)
 ;;       subq    $4, %rsp
 ;;       movl    %ecx, (%rsp)
 ;;       subq    $0xc, %rsp

--- a/tests/disas/winch/x64/exceptions/throw-funcref-null.wat
+++ b/tests/disas/winch/x64/exceptions/throw-funcref-null.wat
@@ -1,6 +1,6 @@
 ;;! target = "x86_64"
 ;;! test = "winch"
-;;! flags = "-W exceptions -C collector=copying"
+;;! flags = "-W exceptions -C collector=null"
 
 ;; A function reference is interned before it is stored in the exception.
 (module
@@ -14,7 +14,7 @@
 ;;       movq    0x18(%r11), %r11
 ;;       addq    $0x40, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x13a
+;;       ja      0x1b4
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x20, %rsp
 ;;       movq    %rdi, 0x18(%rsp)
@@ -24,32 +24,58 @@
 ;;       pushq   %r11
 ;;       subq    $8, %rsp
 ;;       movq    %r14, %rdi
-;;       callq   0x216
+;;       callq   0x28c
 ;;       addq    $8, %rsp
 ;;       movq    0x20(%rsp), %r14
-;;       movq    0x28(%r14), %rcx
-;;       movl    4(%rcx), %ecx
-;;       subq    $4, %rsp
+;;       movq    0x20(%r14), %r11
+;;       movl    (%r11), %ecx
+;;       addl    $7, %ecx
+;;       jb      0x1b6
+;;   6a: andl    $0xfffffff8, %ecx
+;;       movl    %ecx, %edx
+;;       addl    $0x18, %edx
+;;       jb      0x1b8
+;;   7e: subq    $4, %rsp
 ;;       movl    %eax, (%rsp)
 ;;       subq    $4, %rsp
 ;;       movl    %ecx, (%rsp)
-;;       movq    %r14, %rdi
-;;       movl    $0x4000002, %esi
-;;       movl    (%rsp), %edx
-;;       movl    $0x20, %ecx
-;;       movl    $0x10, %r8d
-;;       callq   0x19a
+;;       subq    $4, %rsp
+;;       movl    %edx, (%rsp)
+;;       movl    (%rsp), %eax
 ;;       addq    $4, %rsp
-;;       movq    0x24(%rsp), %r14
+;;       movq    8(%r14), %rcx
+;;       movq    0x28(%rcx), %rdx
+;;       movq    0x20(%rcx), %rcx
+;;       cmpq    %rdx, %rax
+;;       jbe     0xe6
+;;   bb: subq    %rdx, %rax
+;;       pushq   %rax
+;;       subq    $8, %rsp
+;;       movq    %r14, %rdi
+;;       movq    8(%rsp), %rsi
+;;       callq   0x218
+;;       addq    $8, %rsp
+;;       addq    $8, %rsp
+;;       movq    0x28(%rsp), %r14
+;;       movl    (%rsp), %eax
+;;       addq    $4, %rsp
 ;;       movq    8(%r14), %rcx
 ;;       movq    0x28(%rcx), %rdx
 ;;       movq    0x20(%rcx), %rcx
 ;;       movq    %rcx, %rdx
 ;;       addq    %rax, %rdx
+;;       movl    $0x4000018, (%rdx)
+;;       movq    0x28(%r14), %r11
+;;       movl    4(%r11), %r11d
+;;       movl    %r11d, 4(%rdx)
+;;       movq    0x20(%r14), %rcx
+;;       movl    %eax, %r11d
+;;       addl    $0x18, %r11d
+;;       movl    %r11d, (%rcx)
 ;;       movl    (%rsp), %ecx
 ;;       addq    $4, %rsp
-;;       movl    %ecx, 0x10(%rdx)
-;;       movl    $0, 0x14(%rdx)
+;;       movl    %ecx, 8(%rdx)
+;;       movl    $0, 0xc(%rdx)
 ;;       popq    %rcx
 ;;       pushq   %rdx
 ;;       subq    $4, %rsp
@@ -58,24 +84,26 @@
 ;;       subq    $0xc, %rsp
 ;;       movq    %r14, %rdi
 ;;       movq    0xc(%rsp), %rsi
-;;       callq   0x1e9
+;;       callq   0x25f
 ;;       addq    $0xc, %rsp
 ;;       addq    $8, %rsp
 ;;       movq    0x24(%rsp), %r14
 ;;       movl    (%rsp), %ecx
 ;;       addq    $4, %rsp
 ;;       popq    %rdx
-;;       movl    %eax, 0x18(%rdx)
+;;       movl    %eax, 0x10(%rdx)
 ;;       subq    $4, %rsp
 ;;       movl    %ecx, (%rsp)
 ;;       subq    $0xc, %rsp
 ;;       movq    %r14, %rdi
 ;;       movl    0xc(%rsp), %esi
-;;       callq   0x243
+;;       callq   0x2b9
 ;;       addq    $0xc, %rsp
 ;;       addq    $4, %rsp
 ;;       movq    0x18(%rsp), %r14
 ;;       addq    $0x20, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;  13a: ud2
+;;  1b4: ud2
+;;  1b6: ud2
+;;  1b8: ud2

--- a/tests/disas/winch/x64/exceptions/throw-funcref.wat
+++ b/tests/disas/winch/x64/exceptions/throw-funcref.wat
@@ -1,0 +1,81 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = ["-W", "exceptions"]
+
+;; A function reference is interned before it is stored in the exception.
+(module
+  (tag $e (param funcref))
+  (func (param funcref)
+    (throw $e (local.get 0))))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x18(%r11), %r11
+;;       addq    $0x40, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x13a
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x20, %rsp
+;;       movq    %rdi, 0x18(%rsp)
+;;       movq    %rsi, 0x10(%rsp)
+;;       movq    %rdx, 8(%rsp)
+;;       movq    8(%rsp), %r11
+;;       pushq   %r11
+;;       subq    $8, %rsp
+;;       movq    %r14, %rdi
+;;       callq   0x216
+;;       addq    $8, %rsp
+;;       movq    0x20(%rsp), %r14
+;;       movq    0x28(%r14), %rcx
+;;       movl    4(%rcx), %ecx
+;;       subq    $4, %rsp
+;;       movl    %eax, (%rsp)
+;;       subq    $4, %rsp
+;;       movl    %ecx, (%rsp)
+;;       movq    %r14, %rdi
+;;       movl    $0x4000002, %esi
+;;       movl    (%rsp), %edx
+;;       movl    $0x20, %ecx
+;;       movl    $0x10, %r8d
+;;       callq   0x19a
+;;       addq    $4, %rsp
+;;       movq    0x24(%rsp), %r14
+;;       movq    8(%r14), %rcx
+;;       movq    0x28(%rcx), %rdx
+;;       movq    0x20(%rcx), %rcx
+;;       movq    %rcx, %rdx
+;;       addq    %rax, %rdx
+;;       movl    (%rsp), %ecx
+;;       addq    $4, %rsp
+;;       movl    %ecx, 0x10(%rdx)
+;;       movl    $0, 0x14(%rdx)
+;;       popq    %rcx
+;;       pushq   %rdx
+;;       subq    $4, %rsp
+;;       movl    %eax, (%rsp)
+;;       pushq   %rcx
+;;       subq    $0xc, %rsp
+;;       movq    %r14, %rdi
+;;       movq    0xc(%rsp), %rsi
+;;       callq   0x1e9
+;;       addq    $0xc, %rsp
+;;       addq    $8, %rsp
+;;       movq    0x24(%rsp), %r14
+;;       movl    (%rsp), %ecx
+;;       addq    $4, %rsp
+;;       popq    %rdx
+;;       movl    %eax, 0x18(%rdx)
+;;       subq    $4, %rsp
+;;       movl    %ecx, (%rsp)
+;;       subq    $0xc, %rsp
+;;       movq    %r14, %rdi
+;;       movl    0xc(%rsp), %esi
+;;       callq   0x243
+;;       addq    $0xc, %rsp
+;;       addq    $4, %rsp
+;;       movq    0x18(%rsp), %r14
+;;       addq    $0x20, %rsp
+;;       popq    %rbp
+;;       retq
+;;  13a: ud2

--- a/tests/disas/winch/x64/exceptions/throw-null.wat
+++ b/tests/disas/winch/x64/exceptions/throw-null.wat
@@ -1,0 +1,87 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = "-W exceptions -C collector=null"
+
+;; Exercise the Null collector's inline exception allocation path.
+(module
+  (tag $e (param i32))
+  (func
+    (throw $e (i32.const 42))))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x18(%r11), %r11
+;;       addq    $0x20, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x14f
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x10, %rsp
+;;       movq    %rdi, 8(%rsp)
+;;       movq    %rsi, (%rsp)
+;;       movq    %r14, %rdi
+;;       callq   0x243
+;;       movq    8(%rsp), %r14
+;;       movq    0x20(%r14), %r11
+;;       movl    (%r11), %ecx
+;;       addl    $7, %ecx
+;;       jb      0x151
+;;   4f: andl    $0xfffffff8, %ecx
+;;       movl    %ecx, %edx
+;;       addl    $0x18, %edx
+;;       jb      0x153
+;;   63: subq    $4, %rsp
+;;       movl    %eax, (%rsp)
+;;       subq    $4, %rsp
+;;       movl    %ecx, (%rsp)
+;;       subq    $4, %rsp
+;;       movl    %edx, (%rsp)
+;;       movl    (%rsp), %eax
+;;       addq    $4, %rsp
+;;       movq    8(%r14), %rcx
+;;       movq    0x28(%rcx), %rdx
+;;       movq    0x20(%rcx), %rcx
+;;       cmpq    %rdx, %rax
+;;       jbe     0xbc
+;;   a0: subq    %rdx, %rax
+;;       pushq   %rax
+;;       movq    %r14, %rdi
+;;       movq    (%rsp), %rsi
+;;       callq   0x1fc
+;;       addq    $8, %rsp
+;;       movq    0x10(%rsp), %r14
+;;       movl    (%rsp), %eax
+;;       addq    $4, %rsp
+;;       movq    8(%r14), %rcx
+;;       movq    0x28(%rcx), %rdx
+;;       movq    0x20(%rcx), %rcx
+;;       movq    %rcx, %rdx
+;;       addq    %rax, %rdx
+;;       movl    $0x4000018, (%rdx)
+;;       movq    0x28(%r14), %r11
+;;       movl    8(%r11), %r11d
+;;       movl    %r11d, 4(%rdx)
+;;       movq    0x20(%r14), %rcx
+;;       movl    %eax, %r11d
+;;       addl    $0x18, %r11d
+;;       movl    %r11d, (%rcx)
+;;       movl    (%rsp), %ecx
+;;       addq    $4, %rsp
+;;       movl    %ecx, 8(%rdx)
+;;       movl    $0, 0xc(%rdx)
+;;       movl    $0x2a, 0x10(%rdx)
+;;       subq    $4, %rsp
+;;       movl    %eax, (%rsp)
+;;       subq    $0xc, %rsp
+;;       movq    %r14, %rdi
+;;       movl    0xc(%rsp), %esi
+;;       callq   0x270
+;;       addq    $0xc, %rsp
+;;       addq    $4, %rsp
+;;       movq    8(%rsp), %r14
+;;       addq    $0x10, %rsp
+;;       popq    %rbp
+;;       retq
+;;  14f: ud2
+;;  151: ud2
+;;  153: ud2

--- a/tests/disas/winch/x64/exceptions/throw.wat
+++ b/tests/disas/winch/x64/exceptions/throw.wat
@@ -1,6 +1,6 @@
 ;;! target = "x86_64"
 ;;! test = "winch"
-;;! flags = ["-W", "exceptions"]
+;;! flags = "-W exceptions -C collector=copying"
 
 ;; `throw` builds an exception that escapes to the host, while `try_table`
 ;; still compiles as a plain block.

--- a/tests/disas/winch/x64/exceptions/throw.wat
+++ b/tests/disas/winch/x64/exceptions/throw.wat
@@ -2,8 +2,8 @@
 ;;! test = "winch"
 ;;! flags = ["-W", "exceptions"]
 
-;; Currently exceptions trap on throw: `throw` becomes a trap and
-;; `try_table` compiles as a plain block.
+;; `throw` builds an exception that escapes to the host, while `try_table`
+;; still compiles as a plain block.
 (module
   (tag $e (param i32))
   (func (result i32)
@@ -15,15 +15,52 @@
 ;;       movq    %rsp, %rbp
 ;;       movq    8(%rdi), %r11
 ;;       movq    0x18(%r11), %r11
-;;       addq    $0x10, %r11
+;;       addq    $0x20, %r11
 ;;       cmpq    %rsp, %r11
-;;       ja      0x3a
+;;       ja      0xf3
 ;;   1c: movq    %rdi, %r14
 ;;       subq    $0x10, %rsp
 ;;       movq    %rdi, 8(%rsp)
 ;;       movq    %rsi, (%rsp)
-;;       ud2
+;;       movq    %r14, %rdi
+;;       callq   0x1f8
+;;       movq    8(%rsp), %r14
+;;       movq    0x28(%r14), %rcx
+;;       movl    8(%rcx), %ecx
+;;       subq    $4, %rsp
+;;       movl    %eax, (%rsp)
+;;       subq    $4, %rsp
+;;       movl    %ecx, (%rsp)
+;;       subq    $8, %rsp
+;;       movq    %r14, %rdi
+;;       movl    $0x4000002, %esi
+;;       movl    8(%rsp), %edx
+;;       movl    $0x20, %ecx
+;;       movl    $0x10, %r8d
+;;       callq   0x1a9
+;;       addq    $8, %rsp
+;;       addq    $4, %rsp
+;;       movq    0xc(%rsp), %r14
+;;       movq    8(%r14), %rcx
+;;       movq    0x28(%rcx), %rdx
+;;       movq    0x20(%rcx), %rcx
+;;       movq    %rcx, %rdx
+;;       addq    %rax, %rdx
+;;       movl    (%rsp), %ecx
+;;       addq    $4, %rsp
+;;       movl    %ecx, 0x10(%rdx)
+;;       movl    $0, 0x14(%rdx)
+;;       movl    $0x2a, 0x18(%rdx)
+;;       subq    $4, %rsp
+;;       movl    %eax, (%rsp)
+;;       subq    $0xc, %rsp
+;;       movq    %r14, %rdi
+;;       movl    0xc(%rsp), %esi
+;;       callq   0x225
+;;       addq    $0xc, %rsp
+;;       addq    $4, %rsp
+;;       movq    8(%rsp), %r14
 ;;       addq    $0x10, %rsp
 ;;       popq    %rbp
 ;;       retq
-;;   3a: ud2
+;;   f3: ud2

--- a/tests/misc_testsuite/throw-payloads.wast
+++ b/tests/misc_testsuite/throw-payloads.wast
@@ -1,0 +1,46 @@
+;;! exceptions = true
+;;! reference_types = true
+;;! bulk_memory = true
+;;! simd = true
+
+;; Cover several payload shapes: empty, scalar, mixed, vector, and reference
+;; values.
+
+(module
+  (tag $empty)
+  (tag $one (param i32))
+  (tag $mixed (param i32 i64 f64))
+
+  (func (export "throw-empty") (throw $empty))
+  (func (export "throw-one") (throw $one (i32.const 42)))
+  (func (export "throw-mixed") (param i32 i64 f64)
+    (throw $mixed (local.get 0) (local.get 1) (local.get 2)))
+
+  ;; `v128` payloads occupy a full slot.
+  (tag $vec (param i32 v128 f64))
+  (func (export "throw-vec")
+    (throw $vec (i32.const 1) (v128.const i64x2 2 3) (f64.const 4))))
+
+(assert_exception (invoke "throw-empty"))
+(assert_exception (invoke "throw-one"))
+(assert_exception
+  (invoke "throw-mixed" (i32.const 1) (i64.const 2) (f64.const 3)))
+(assert_exception (invoke "throw-vec"))
+
+;; A reference payload remains live across the exception allocation.
+(module
+  (tag $eref (param externref))
+  (func (export "throw-ref") (param externref)
+    (throw $eref (local.get 0))))
+
+(assert_exception (invoke "throw-ref" (ref.extern 5)))
+
+;; A function reference is interned before it is stored in the GC heap.
+(module
+  (tag $fref (param funcref))
+  (func $f)
+  (elem declare func $f)
+  (func (export "throw-funcref")
+    (throw $fref (ref.func $f))))
+
+(assert_exception (invoke "throw-funcref"))

--- a/winch/codegen/src/codegen/drc.rs
+++ b/winch/codegen/src/codegen/drc.rs
@@ -21,6 +21,38 @@ impl<'a, 'translation, 'data, M> CodeGen<'a, 'translation, 'data, M, Emission>
 where
     M: MacroAssembler,
 {
+    /// Emits a DRC initialization barrier for a reference stored at `addr`.
+    ///
+    /// A newly initialized field has no old reference to release. Non-null,
+    /// non-i31 heap references are retained before the field is initialized.
+    pub(crate) fn emit_drc_init_barrier(
+        &mut self,
+        ty: WasmValType,
+        addr: M::Address,
+    ) -> Result<()> {
+        let new_ref = self.context.pop_to_reg(self.masm, None)?;
+        let skip_inc = self.masm.get_label()?;
+        self.emit_skip_if_gc_ref_is_null_or_i31(new_ref.reg, skip_inc)?;
+
+        let (heap_reg, bound_reg) = self.emit_load_gc_heap_base_and_bound()?;
+        let ref_count_offset = self.env.vmoffsets.vm_drc_header_ref_count();
+        let header_extent = i64::from(ref_count_offset) + 8;
+        self.emit_gc_ref_bounds_check(new_ref.reg, bound_reg, header_extent)?;
+        self.context.free_reg(bound_reg);
+
+        let object_addr = self.emit_gc_ref_addr(new_ref.reg, heap_reg)?;
+        let count = self.emit_mutate_ref_count(object_addr, RefCountMutation::Increment)?;
+        self.emit_store_ref_count(object_addr, count)?;
+        self.context.free_reg(count);
+        self.context.free_reg(object_addr);
+        self.context.free_reg(heap_reg);
+
+        self.masm.bind(skip_inc)?;
+        self.masm.store(new_ref.reg.into(), addr, ty.try_into()?)?;
+        self.context.free_reg(new_ref.reg);
+        Ok(())
+    }
+
     /// Emits a DRC read barrier for a value loaded from `addr`.
     ///
     /// The loaded reference is first pushed and spilled so it is represented

--- a/winch/codegen/src/codegen/drc.rs
+++ b/winch/codegen/src/codegen/drc.rs
@@ -11,6 +11,9 @@ use wasmtime_environ::{
     WasmValType,
 };
 
+/// The DRC header stores its reference count as a `u64`.
+const DRC_REF_COUNT_SIZE: u32 = 8;
+
 #[derive(Clone, Copy)]
 enum RefCountMutation {
     Increment,
@@ -35,16 +38,8 @@ where
         self.emit_skip_if_gc_ref_is_null_or_i31(new_ref.reg, skip_inc)?;
 
         let (heap_reg, bound_reg) = self.emit_load_gc_heap_base_and_bound()?;
-        let ref_count_offset = self.env.vmoffsets.vm_drc_header_ref_count();
-        let header_extent = i64::from(ref_count_offset) + 8;
-        self.emit_gc_ref_bounds_check(new_ref.reg, bound_reg, header_extent)?;
+        self.emit_drc_retain_gc_ref(new_ref.reg, heap_reg, bound_reg)?;
         self.context.free_reg(bound_reg);
-
-        let object_addr = self.emit_gc_ref_addr(new_ref.reg, heap_reg)?;
-        let count = self.emit_mutate_ref_count(object_addr, RefCountMutation::Increment)?;
-        self.emit_store_ref_count(object_addr, count)?;
-        self.context.free_reg(count);
-        self.context.free_reg(object_addr);
         self.context.free_reg(heap_reg);
 
         self.masm.bind(skip_inc)?;
@@ -154,18 +149,13 @@ where
         self.masm.load(addr, writable!(old_reg), OperandSize::S32)?;
 
         let ref_count_offset = self.env.vmoffsets.vm_drc_header_ref_count();
-        let header_extent = i64::from(ref_count_offset) + 8;
+        let header_extent = i64::from(ref_count_offset + DRC_REF_COUNT_SIZE);
 
         // Retain the new heap reference before publishing it. This ordering
         // keeps self-assignment from temporarily dropping the final owner.
         let skip_inc = self.masm.get_label()?;
         self.emit_skip_if_gc_ref_is_null_or_i31(new_ref.reg, skip_inc)?;
-        self.emit_gc_ref_bounds_check(new_ref.reg, bound_reg, header_extent)?;
-        let new_addr = self.emit_gc_ref_addr(new_ref.reg, heap_reg)?;
-        let count = self.emit_mutate_ref_count(new_addr, RefCountMutation::Increment)?;
-        self.emit_store_ref_count(new_addr, count)?;
-        self.context.free_reg(count);
-        self.context.free_reg(new_addr);
+        self.emit_drc_retain_gc_ref(new_ref.reg, heap_reg, bound_reg)?;
 
         self.masm.bind(skip_inc)?;
         // Publish the new value before releasing the old one because the
@@ -316,9 +306,7 @@ where
         })?;
 
         // Retain the object for the list's ownership.
-        let count = self.emit_mutate_ref_count(object_addr, RefCountMutation::Increment)?;
-        self.emit_store_ref_count(object_addr, count)?;
-        self.context.free_reg(count);
+        self.emit_increment_ref_count(object_addr)?;
 
         // Publish the new head, then the updated length. The length outlives
         // this helper, so it gets its own allocated register.
@@ -407,6 +395,34 @@ where
         self.context.pop_and_free(self.masm)?;
 
         self.masm.bind(skip_gc)
+    }
+
+    /// Retains a non-null, non-i31 GC reference.
+    ///
+    /// The bounds check covers the complete `u64` reference-count field. The
+    /// caller retains ownership of all register arguments.
+    fn emit_drc_retain_gc_ref(
+        &mut self,
+        gc_ref: Reg,
+        heap_base: Reg,
+        heap_bound: Reg,
+    ) -> Result<()> {
+        let ref_count_offset = self.env.vmoffsets.vm_drc_header_ref_count();
+        let header_extent = i64::from(ref_count_offset + DRC_REF_COUNT_SIZE);
+        self.emit_gc_ref_bounds_check(gc_ref, heap_bound, header_extent)?;
+
+        let object_addr = self.emit_gc_ref_addr(gc_ref, heap_base)?;
+        self.emit_increment_ref_count(object_addr)?;
+        self.context.free_reg(object_addr);
+        Ok(())
+    }
+
+    /// Increments and stores the reference count at `object_addr`.
+    fn emit_increment_ref_count(&mut self, object_addr: Reg) -> Result<()> {
+        let count = self.emit_mutate_ref_count(object_addr, RefCountMutation::Increment)?;
+        self.emit_store_ref_count(object_addr, count)?;
+        self.context.free_reg(count);
+        Ok(())
     }
 
     /// Loads a reference count and applies `mutation`, returning the register

--- a/winch/codegen/src/codegen/env.rs
+++ b/winch/codegen/src/codegen/env.rs
@@ -13,8 +13,9 @@ use std::mem;
 use wasmparser::BlockType;
 use wasmtime_environ::{
     BuiltinFunctionIndex, DefinedFuncIndex, FuncIndex, FuncKey, GlobalIndex, IndexType, Memory,
-    MemoryIndex, ModuleTranslation, ModuleTypesBuilder, PrimaryMap, PtrSize, Table, TableIndex,
-    TypeConvert, TypeIndex, VMOffsets, WasmHeapType, WasmValType, collections::TryClone as _,
+    MemoryIndex, ModuleInternedTypeIndex, ModuleTranslation, ModuleTypesBuilder, PrimaryMap,
+    PtrSize, Table, TableIndex, TypeConvert, TypeIndex, VMOffsets, WasmHeapType, WasmValType,
+    collections::TryClone as _,
 };
 
 #[derive(Debug, Clone, Copy)]
@@ -175,6 +176,14 @@ impl<'a, 'translation, 'data, P: PtrSize> FuncEnv<'a, 'translation, 'data, P> {
     /// Derive the [`WasmType`] from the pointer size.
     pub(crate) fn ptr_type(&self) -> WasmValType {
         self.ptr_type
+    }
+
+    /// Returns the byte offset of `index` in the module's shared type-ID array.
+    pub(crate) fn shared_type_index_offset(&self, index: ModuleInternedTypeIndex) -> u32 {
+        index
+            .as_u32()
+            .checked_mul(u32::from(self.vmoffsets.size_of_vmshared_type_index()))
+            .unwrap()
     }
 
     /// Resolves a [`Callee::FuncRef`] from a type index.

--- a/winch/codegen/src/codegen/error.rs
+++ b/winch/codegen/src/codegen/error.rs
@@ -32,6 +32,9 @@ pub(crate) enum CodeGenError {
     /// Unsupported eager initialization of tables.
     #[error("Unsupported eager initialization of tables")]
     UnsupportedTableEagerInit,
+    /// An allocation is too large to represent.
+    #[error("Allocation size is too large")]
+    AllocationTooLarge,
     /// An internal error.
     ///
     /// This error means that an internal invariant was not met and usually
@@ -111,6 +114,10 @@ impl CodeGenError {
 
     pub(crate) const fn unsupported_32_bit_platform() -> Self {
         Self::Unsupported32BitPlatform
+    }
+
+    pub(crate) const fn allocation_too_large() -> Self {
+        Self::AllocationTooLarge
     }
 
     pub(crate) const fn unexpected_function_call() -> Self {

--- a/winch/codegen/src/codegen/exceptions.rs
+++ b/winch/codegen/src/codegen/exceptions.rs
@@ -106,7 +106,7 @@ where
         mut gc_ref: TypedReg,
         mut object_addr: Reg,
     ) -> Result<TypedReg> {
-        debug_assert_eq!(field_types.len(), field_offsets.len());
+        assert_eq!(field_types.len(), field_offsets.len());
 
         for (field_ty, field_offset) in field_types
             .iter()

--- a/winch/codegen/src/codegen/exceptions.rs
+++ b/winch/codegen/src/codegen/exceptions.rs
@@ -48,13 +48,8 @@ where
             Some(Collector::Copying) => InlineTraceInfo::r#struct(layout).encode(),
             _ => 0,
         };
-        let (gc_ref, object_addr) = self.emit_gc_raw_alloc(
-            VMGcKind::ExnRef,
-            interned,
-            layout.size,
-            layout.align,
-            reserved_bits,
-        )?;
+        let (gc_ref, object_addr) =
+            self.emit_gc_raw_alloc(VMGcKind::ExnRef, interned, &layout.layout(), reserved_bits)?;
 
         // Store the tag as its defining instance ID and its index within that
         // instance.

--- a/winch/codegen/src/codegen/exceptions.rs
+++ b/winch/codegen/src/codegen/exceptions.rs
@@ -1,0 +1,176 @@
+use super::{Callee, CodeGen, Emission, FnCall};
+use crate::{
+    Result,
+    masm::{IntScratch, MacroAssembler, OperandSize, RegImm},
+    reg::Reg,
+    stack::TypedReg,
+};
+use wasmtime_environ::copying::InlineTraceInfo;
+use wasmtime_environ::{
+    Collector, GcStructLayout, GcTypeLayouts, ModuleInternedTypeIndex, PtrSize, TagIndex, VMGcKind,
+    WasmHeapType, WasmStorageType, WasmValType,
+};
+
+impl<'a, 'translation, 'data, M> CodeGen<'a, 'translation, 'data, M, Emission>
+where
+    M: MacroAssembler,
+{
+    /// Allocates an exception and initializes its tag identity.
+    ///
+    /// Exception tags are identified by the defining instance and the tag's
+    /// index within that instance. Imported tags therefore use the exporting
+    /// instance's VMContext when resolving the instance ID.
+    ///
+    /// The returned GC reference and object address are allocated from the
+    /// code-generation context and owned by the caller. Payload operands remain
+    /// on the value stack.
+    pub(crate) fn emit_exception_alloc(
+        &mut self,
+        tag_index: TagIndex,
+        interned: ModuleInternedTypeIndex,
+        layout: &GcStructLayout,
+        layouts: &dyn GcTypeLayouts,
+    ) -> Result<(TypedReg, Reg)> {
+        let get_instance_id = self.env.builtins.get_instance_id::<M::ABI>()?;
+        let defined_tag = self.env.translation.module.defined_tag_index(tag_index);
+        let get_instance_id = match defined_tag {
+            Some(_) => Callee::Builtin(get_instance_id),
+            None => {
+                let vmimport = self.env.vmoffsets.imported_tags().at(tag_index);
+                let vmctx_offset =
+                    vmimport + u32::from(self.env.vmoffsets.ptr.vm_tag_import().vmctx());
+                Callee::BuiltinWithDifferentVmctx(get_instance_id, vmctx_offset)
+            }
+        };
+        FnCall::emit::<M>(&mut self.env, self.masm, &mut self.context, get_instance_id)?;
+
+        let reserved_bits = match self.tunables.collector {
+            Some(Collector::Copying) => InlineTraceInfo::r#struct(layout).encode(),
+            _ => 0,
+        };
+        let (gc_ref, object_addr) = self.emit_gc_raw_alloc(
+            VMGcKind::ExnRef,
+            interned,
+            layout.size,
+            layout.align,
+            reserved_bits,
+        )?;
+
+        // Store the tag as its defining instance ID and its index within that
+        // instance.
+        let instance_id = self.context.pop_to_reg(self.masm, None)?;
+        self.masm.store(
+            instance_id.reg.into(),
+            self.masm
+                .address_at_reg(object_addr, layouts.exception_tag_instance_offset())?,
+            OperandSize::S32,
+        )?;
+        self.context.free_reg(instance_id.reg);
+
+        let tag_addr = self
+            .masm
+            .address_at_reg(object_addr, layouts.exception_tag_defined_offset())?;
+        match defined_tag {
+            Some(defined) => self.masm.store(
+                RegImm::i32(defined.as_u32().cast_signed()),
+                tag_addr,
+                OperandSize::S32,
+            )?,
+            None => {
+                let vmimport = self.env.vmoffsets.imported_tags().at(tag_index);
+                let index_offset =
+                    vmimport + u32::from(self.env.vmoffsets.ptr.vm_tag_import().index());
+                self.masm
+                    .with_scratch::<IntScratch, _>(|masm, defined_tag_id| {
+                        masm.load(
+                            masm.address_at_vmctx(index_offset)?,
+                            defined_tag_id.writable(),
+                            OperandSize::S32,
+                        )?;
+                        masm.store(defined_tag_id.inner().into(), tag_addr, OperandSize::S32)
+                    })?;
+            }
+        }
+
+        Ok((gc_ref, object_addr))
+    }
+
+    /// Initializes an exception's payload fields from the value stack.
+    ///
+    /// Payload operands are stored on the value stack in declaration order, so
+    /// this method initializes fields from last to first. Function references
+    /// are interned before being written into the GC heap, and DRC-managed
+    /// references use an initialization barrier.
+    ///
+    /// This method consumes and frees `object_addr`. It returns `gc_ref`, which
+    /// remains owned by the caller.
+    pub(crate) fn emit_exception_payload_fields(
+        &mut self,
+        field_types: &[WasmStorageType],
+        field_offsets: &[u32],
+        mut gc_ref: TypedReg,
+        mut object_addr: Reg,
+    ) -> Result<TypedReg> {
+        debug_assert_eq!(field_types.len(), field_offsets.len());
+
+        for (field_ty, field_offset) in field_types
+            .iter()
+            .copied()
+            .zip(field_offsets.iter().copied())
+            .rev()
+        {
+            match field_ty {
+                WasmStorageType::I8 => {
+                    let value = self.context.pop_to_reg(self.masm, None)?;
+                    let addr = self.masm.address_at_reg(object_addr, field_offset)?;
+                    self.masm.store(value.reg.into(), addr, OperandSize::S8)?;
+                    self.context.free_reg(value.reg);
+                }
+                WasmStorageType::I16 => {
+                    let value = self.context.pop_to_reg(self.masm, None)?;
+                    let addr = self.masm.address_at_reg(object_addr, field_offset)?;
+                    self.masm.store(value.reg.into(), addr, OperandSize::S16)?;
+                    self.context.free_reg(value.reg);
+                }
+                WasmStorageType::Val(WasmValType::Ref(r)) if r.heap_type == WasmHeapType::Func => {
+                    let func_ref = self.context.pop_to_reg(self.masm, None)?;
+
+                    // The call can clobber allocated registers, so preserve the
+                    // allocation results beneath its argument.
+                    self.context.stack.push(TypedReg::i64(object_addr).into());
+                    self.context.stack.push(gc_ref.into());
+                    self.context.stack.push(func_ref.into());
+
+                    let intern = self.env.builtins.intern_func_ref_for_gc_heap::<M::ABI>()?;
+                    FnCall::emit::<M>(
+                        &mut self.env,
+                        self.masm,
+                        &mut self.context,
+                        Callee::Builtin(intern),
+                    )?;
+
+                    let func_ref_id = self.context.pop_to_reg(self.masm, None)?;
+                    gc_ref = self.context.pop_to_reg(self.masm, None)?;
+                    object_addr = self.context.pop_to_reg(self.masm, None)?.reg;
+                    let addr = self.masm.address_at_reg(object_addr, field_offset)?;
+                    self.masm
+                        .store(func_ref_id.reg.into(), addr, OperandSize::S32)?;
+                    self.context.free_reg(func_ref_id.reg);
+                }
+                WasmStorageType::Val(ty @ WasmValType::Ref(_))
+                    if self.tunables.collector == Some(Collector::DeferredReferenceCounting) =>
+                {
+                    let addr = self.masm.address_at_reg(object_addr, field_offset)?;
+                    self.emit_drc_init_barrier(ty, addr)?;
+                }
+                WasmStorageType::Val(_) => {
+                    let addr = self.masm.address_at_reg(object_addr, field_offset)?;
+                    self.context.pop_to_addr(self.masm, addr)?;
+                }
+            }
+        }
+
+        self.context.free_reg(object_addr);
+        Ok(gc_ref)
+    }
+}

--- a/winch/codegen/src/codegen/exceptions.rs
+++ b/winch/codegen/src/codegen/exceptions.rs
@@ -1,6 +1,6 @@
-use super::{Callee, CodeGen, Emission, FnCall};
+use super::{Callee, CodeGen, CodeGenError, Emission, FnCall};
 use crate::{
-    Result,
+    Result, format_err,
     masm::{IntScratch, MacroAssembler, OperandSize, RegImm},
     reg::Reg,
     stack::TypedReg,
@@ -8,7 +8,7 @@ use crate::{
 use wasmtime_environ::copying::InlineTraceInfo;
 use wasmtime_environ::{
     Collector, GcStructLayout, GcTypeLayouts, ModuleInternedTypeIndex, PtrSize, TagIndex, VMGcKind,
-    WasmHeapType, WasmStorageType, WasmValType,
+    WasmExnType, WasmHeapType, WasmStorageType, WasmValType,
 };
 
 impl<'a, 'translation, 'data, M> CodeGen<'a, 'translation, 'data, M, Emission>
@@ -101,19 +101,16 @@ where
     /// remains owned by the caller.
     pub(crate) fn emit_exception_payload_fields(
         &mut self,
-        field_types: &[WasmStorageType],
-        field_offsets: &[u32],
+        exn_ty: &WasmExnType,
+        layout: &GcStructLayout,
         mut gc_ref: TypedReg,
         mut object_addr: Reg,
     ) -> Result<TypedReg> {
-        assert_eq!(field_types.len(), field_offsets.len());
+        assert_eq!(exn_ty.fields.len(), layout.fields.len());
 
-        for (field_ty, field_offset) in field_types
-            .iter()
-            .copied()
-            .zip(field_offsets.iter().copied())
-            .rev()
-        {
+        for (field, field_layout) in exn_ty.fields.iter().zip(layout.fields.iter()).rev() {
+            let field_ty = field.element_type;
+            let field_offset = field_layout.offset;
             match field_ty {
                 WasmStorageType::I8 => {
                     let value = self.context.pop_to_reg(self.masm, None)?;
@@ -127,37 +124,45 @@ where
                     self.masm.store(value.reg.into(), addr, OperandSize::S16)?;
                     self.context.free_reg(value.reg);
                 }
-                WasmStorageType::Val(WasmValType::Ref(r)) if r.heap_type == WasmHeapType::Func => {
-                    let func_ref = self.context.pop_to_reg(self.masm, None)?;
+                WasmStorageType::Val(ty @ WasmValType::Ref(r)) => match r.heap_type {
+                    WasmHeapType::Func => {
+                        let func_ref = self.context.pop_to_reg(self.masm, None)?;
 
-                    // The call can clobber allocated registers, so preserve the
-                    // allocation results beneath its argument.
-                    self.context.stack.push(TypedReg::i64(object_addr).into());
-                    self.context.stack.push(gc_ref.into());
-                    self.context.stack.push(func_ref.into());
+                        // The call can clobber allocated registers, so preserve the
+                        // allocation results beneath its argument.
+                        self.context.stack.push(TypedReg::i64(object_addr).into());
+                        self.context.stack.push(gc_ref.into());
+                        self.context.stack.push(func_ref.into());
 
-                    let intern = self.env.builtins.intern_func_ref_for_gc_heap::<M::ABI>()?;
-                    FnCall::emit::<M>(
-                        &mut self.env,
-                        self.masm,
-                        &mut self.context,
-                        Callee::Builtin(intern),
-                    )?;
+                        let intern = self.env.builtins.intern_func_ref_for_gc_heap::<M::ABI>()?;
+                        FnCall::emit::<M>(
+                            &mut self.env,
+                            self.masm,
+                            &mut self.context,
+                            Callee::Builtin(intern),
+                        )?;
 
-                    let func_ref_id = self.context.pop_to_reg(self.masm, None)?;
-                    gc_ref = self.context.pop_to_reg(self.masm, None)?;
-                    object_addr = self.context.pop_to_reg(self.masm, None)?.reg;
-                    let addr = self.masm.address_at_reg(object_addr, field_offset)?;
-                    self.masm
-                        .store(func_ref_id.reg.into(), addr, OperandSize::S32)?;
-                    self.context.free_reg(func_ref_id.reg);
-                }
-                WasmStorageType::Val(ty @ WasmValType::Ref(_))
-                    if self.tunables.collector == Some(Collector::DeferredReferenceCounting) =>
-                {
-                    let addr = self.masm.address_at_reg(object_addr, field_offset)?;
-                    self.emit_drc_init_barrier(ty, addr)?;
-                }
+                        let func_ref_id = self.context.pop_to_reg(self.masm, None)?;
+                        gc_ref = self.context.pop_to_reg(self.masm, None)?;
+                        object_addr = self.context.pop_to_reg(self.masm, None)?.reg;
+                        let addr = self.masm.address_at_reg(object_addr, field_offset)?;
+                        self.masm
+                            .store(func_ref_id.reg.into(), addr, OperandSize::S32)?;
+                        self.context.free_reg(func_ref_id.reg);
+                    }
+                    WasmHeapType::Extern
+                        if self.tunables.collector
+                            == Some(Collector::DeferredReferenceCounting) =>
+                    {
+                        let addr = self.masm.address_at_reg(object_addr, field_offset)?;
+                        self.emit_drc_init_barrier(ty, addr)?;
+                    }
+                    WasmHeapType::Extern => {
+                        let addr = self.masm.address_at_reg(object_addr, field_offset)?;
+                        self.context.pop_to_addr(self.masm, addr)?;
+                    }
+                    _ => return Err(format_err!(CodeGenError::unsupported_wasm_type())),
+                },
                 WasmStorageType::Val(_) => {
                     let addr = self.masm.address_at_reg(object_addr, field_offset)?;
                     self.context.pop_to_addr(self.masm, addr)?;

--- a/winch/codegen/src/codegen/gc.rs
+++ b/winch/codegen/src/codegen/gc.rs
@@ -1,4 +1,4 @@
-use super::{CodeGen, Emission};
+use super::{CodeGen, CodeGenError, Emission};
 use crate::{
     Result,
     codegen::{Callee, FnCall},
@@ -61,11 +61,14 @@ where
         &mut self,
         kind: VMGcKind,
         interned: ModuleInternedTypeIndex,
-        size: u32,
-        align: u32,
+        layout: &core::alloc::Layout,
         reserved_bits: u32,
     ) -> Result<(TypedReg, Reg)> {
         let kind = kind.as_u32() | reserved_bits;
+        let size =
+            u32::try_from(layout.size()).map_err(|_| CodeGenError::allocation_too_large())?;
+        let align =
+            u32::try_from(layout.align()).map_err(|_| CodeGenError::allocation_too_large())?;
         match self.require_gc_codegen_config().collector() {
             Collector::Null => self.emit_null_gc_raw_alloc(kind, interned, size, align),
             Collector::DeferredReferenceCounting | Collector::Copying => {

--- a/winch/codegen/src/codegen/gc.rs
+++ b/winch/codegen/src/codegen/gc.rs
@@ -200,10 +200,7 @@ where
             OperandSize::S32,
         )?;
         let shared_ty_size = self.env.vmoffsets.size_of_vmshared_type_index();
-        let shared_ty_offset = interned
-            .as_u32()
-            .checked_mul(u32::from(shared_ty_size))
-            .unwrap();
+        let shared_ty_offset = self.env.shared_type_index_offset(interned);
         let type_ids_offset = self.env.vmoffsets.ptr.vmctx().type_ids();
         self.masm.with_scratch::<IntScratch, _>(|masm, shared_ty| {
             masm.load_ptr(
@@ -256,10 +253,7 @@ where
         align: u32,
     ) -> Result<(TypedReg, Reg)> {
         let shared_ty_size = self.env.vmoffsets.size_of_vmshared_type_index();
-        let shared_ty_offset = interned
-            .as_u32()
-            .checked_mul(u32::from(shared_ty_size))
-            .unwrap();
+        let shared_ty_offset = self.env.shared_type_index_offset(interned);
 
         // The shared type ID is a call argument, so allocate it here and let
         // call emission consume it rather than keeping a caller-owned register

--- a/winch/codegen/src/codegen/gc.rs
+++ b/winch/codegen/src/codegen/gc.rs
@@ -1,8 +1,7 @@
-use super::{CodeGen, CodeGenError, Emission};
+use super::{CodeGen, Emission};
 use crate::{
     Result,
     codegen::{Callee, FnCall},
-    format_err,
     masm::{IntCmpKind, IntScratch, MacroAssembler, OperandSize, RegImm},
     reg::{Reg, writable},
     stack::{TypedReg, Val},
@@ -10,14 +9,48 @@ use crate::{
 use cranelift_codegen::MachLabel;
 use wasmtime_cranelift::{TRAP_ALLOCATION_TOO_LARGE, TRAP_GC_HEAP_CORRUPT};
 use wasmtime_environ::{
-    Collector, I31_DISCRIMINANT, ModuleInternedTypeIndex, PtrSize, VM_GC_HEADER_KIND_OFFSET,
-    VM_GC_HEADER_TYPE_INDEX_OFFSET, VMGcKind,
+    Collector, GcTypeLayouts, I31_DISCRIMINANT, ModuleInternedTypeIndex, PtrSize,
+    VM_GC_HEADER_KIND_OFFSET, VM_GC_HEADER_TYPE_INDEX_OFFSET, VMGcKind,
+    copying::CopyingTypeLayouts, drc::DrcTypeLayouts, null::NullTypeLayouts,
 };
+
+/// Collector-specific configuration used while generating GC operations.
+#[derive(Clone, Copy)]
+pub(crate) struct GcCodegenConfig {
+    collector: Collector,
+    layouts: &'static dyn GcTypeLayouts,
+}
+
+impl GcCodegenConfig {
+    pub(super) fn new(collector: Collector) -> Self {
+        let layouts = match collector {
+            Collector::DeferredReferenceCounting => &DrcTypeLayouts as &dyn GcTypeLayouts,
+            Collector::Null => &NullTypeLayouts,
+            Collector::Copying => &CopyingTypeLayouts,
+        };
+        Self { collector, layouts }
+    }
+
+    pub(crate) fn collector(self) -> Collector {
+        self.collector
+    }
+
+    pub(crate) fn layouts(self) -> &'static dyn GcTypeLayouts {
+        self.layouts
+    }
+}
 
 impl<'a, 'translation, 'data, M> CodeGen<'a, 'translation, 'data, M, Emission>
 where
     M: MacroAssembler,
 {
+    /// Returns the collector configuration required by a GC operation.
+    pub(crate) fn require_gc_codegen_config(&self) -> GcCodegenConfig {
+        self.gc_codegen_config.expect(
+            "attempted GC code generation when GC support was not enabled at configuration time",
+        )
+    }
+
     /// Allocates an uninitialized GC object and returns both its encoded heap
     /// reference and native address.
     ///
@@ -33,12 +66,11 @@ where
         reserved_bits: u32,
     ) -> Result<(TypedReg, Reg)> {
         let kind = kind.as_u32() | reserved_bits;
-        match self.tunables.collector {
-            Some(Collector::Null) => self.emit_null_gc_raw_alloc(kind, interned, size, align),
-            Some(Collector::DeferredReferenceCounting) | Some(Collector::Copying) => {
+        match self.require_gc_codegen_config().collector() {
+            Collector::Null => self.emit_null_gc_raw_alloc(kind, interned, size, align),
+            Collector::DeferredReferenceCounting | Collector::Copying => {
                 self.emit_builtin_gc_raw_alloc(kind, interned, size, align)
             }
-            None => Err(format_err!(CodeGenError::unsupported_wasm_type())),
         }
     }
 

--- a/winch/codegen/src/codegen/gc.rs
+++ b/winch/codegen/src/codegen/gc.rs
@@ -1,17 +1,260 @@
-use super::{CodeGen, Emission};
+use super::{CodeGen, CodeGenError, Emission};
 use crate::{
     Result,
+    codegen::{Callee, FnCall},
+    format_err,
     masm::{IntCmpKind, IntScratch, MacroAssembler, OperandSize, RegImm},
     reg::{Reg, writable},
+    stack::{TypedReg, Val},
 };
 use cranelift_codegen::MachLabel;
-use wasmtime_cranelift::TRAP_GC_HEAP_CORRUPT;
-use wasmtime_environ::{I31_DISCRIMINANT, PtrSize};
+use wasmtime_cranelift::{TRAP_ALLOCATION_TOO_LARGE, TRAP_GC_HEAP_CORRUPT};
+use wasmtime_environ::{
+    Collector, I31_DISCRIMINANT, ModuleInternedTypeIndex, PtrSize, VM_GC_HEADER_KIND_OFFSET,
+    VM_GC_HEADER_TYPE_INDEX_OFFSET, VMGcKind,
+};
 
 impl<'a, 'translation, 'data, M> CodeGen<'a, 'translation, 'data, M, Emission>
 where
     M: MacroAssembler,
 {
+    /// Allocates an uninitialized GC object and returns both its encoded heap
+    /// reference and native address.
+    ///
+    /// The returned registers are allocated from the code-generation context
+    /// and are owned by the caller, which must eventually free them. All other
+    /// registers used during allocation are allocated and released here.
+    pub(crate) fn emit_gc_raw_alloc(
+        &mut self,
+        kind: VMGcKind,
+        interned: ModuleInternedTypeIndex,
+        size: u32,
+        align: u32,
+        reserved_bits: u32,
+    ) -> Result<(TypedReg, Reg)> {
+        let kind = kind.as_u32() | reserved_bits;
+        match self.tunables.collector {
+            Some(Collector::Null) => self.emit_null_gc_raw_alloc(kind, interned, size, align),
+            Some(Collector::DeferredReferenceCounting) | Some(Collector::Copying) => {
+                self.emit_builtin_gc_raw_alloc(kind, interned, size, align)
+            }
+            None => Err(format_err!(CodeGenError::unsupported_wasm_type())),
+        }
+    }
+
+    /// Allocates an uninitialized object with the null collector's bump pointer.
+    fn emit_null_gc_raw_alloc(
+        &mut self,
+        kind: u32,
+        interned: ModuleInternedTypeIndex,
+        size: u32,
+        align: u32,
+    ) -> Result<(TypedReg, Reg)> {
+        let heap_data_offset = self.env.vmoffsets.ptr.vmctx().gc_heap_data();
+        let bump = self.context.any_gpr(self.masm)?;
+        self.masm.with_scratch::<IntScratch, _>(|masm, heap_data| {
+            masm.load_ptr(
+                masm.address_at_vmctx(u32::from(heap_data_offset))?,
+                heap_data.writable(),
+            )?;
+            masm.load(
+                masm.address_at_reg(heap_data.inner(), 0)?,
+                writable!(bump),
+                OperandSize::S32,
+            )
+        })?;
+
+        debug_assert!(align.is_power_of_two());
+
+        // Round the bump pointer up to `align`:
+        //
+        //     (bump + (align - 1)) & !(align - 1)
+        //
+        // Trap if the addition overflows the GC heap's 32-bit offset space.
+        let align_minus_one = align - 1;
+        self.masm.checked_uadd(
+            writable!(bump),
+            bump,
+            RegImm::i32(align_minus_one.cast_signed()),
+            OperandSize::S32,
+            TRAP_ALLOCATION_TOO_LARGE,
+        )?;
+
+        self.masm.and(
+            writable!(bump),
+            bump,
+            RegImm::i32(!align_minus_one.cast_signed()),
+            OperandSize::S32,
+        )?;
+
+        // Compute the first byte after the allocation. An overflow cannot
+        // describe a valid GC object, so trap before comparing the end against
+        // the heap bound.
+        let end = self.context.any_gpr(self.masm)?;
+        self.masm
+            .mov(writable!(end), bump.into(), OperandSize::S32)?;
+        self.masm.checked_uadd(
+            writable!(end),
+            end,
+            RegImm::i32(size.cast_signed()),
+            OperandSize::S32,
+            TRAP_ALLOCATION_TOO_LARGE,
+        )?;
+
+        self.context.stack.push(TypedReg::i32(bump).into());
+        self.context.stack.push(TypedReg::i32(end).into());
+        self.context.spill(self.masm)?;
+        let end = self.context.pop_to_reg(self.masm, None)?;
+        let (heap_reg, heap_bound) = self.emit_load_gc_heap_base_and_bound()?;
+        self.context.free_reg(heap_reg);
+
+        // If the allocation extends beyond the current heap, grow it by the
+        // difference (`end - heap_bound`). The subtraction is only reached when
+        // `end > heap_bound`, so it cannot underflow. The builtin either grows
+        // the heap by at least this amount or traps.
+        let in_bounds = self.masm.get_label()?;
+        self.masm.branch(
+            IntCmpKind::LeU,
+            end.reg,
+            heap_bound.into(),
+            in_bounds,
+            OperandSize::S64,
+        )?;
+        self.masm.sub(
+            writable!(end.reg),
+            end.reg,
+            heap_bound.into(),
+            OperandSize::S64,
+        )?;
+        self.context.free_reg(heap_bound);
+        self.context.stack.push(TypedReg::i64(end.reg).into());
+        let grow_gc_heap = self.env.builtins.grow_gc_heap::<M::ABI>()?;
+        FnCall::emit::<M>(
+            &mut self.env,
+            self.masm,
+            &mut self.context,
+            Callee::Builtin(grow_gc_heap),
+        )?;
+        self.context.pop_and_free(self.masm)?;
+
+        self.masm.bind(in_bounds)?;
+        let aligned = self.context.pop_to_reg(self.masm, None)?;
+
+        // Heap growth may relocate the backing memory. Reload the heap base
+        // and add the aligned heap offset to obtain the native address used to
+        // initialize the object.
+        let (heap_reg, heap_bound) = self.emit_load_gc_heap_base_and_bound()?;
+        self.context.free_reg(heap_bound);
+        let object_addr = self.emit_gc_ref_addr(aligned.reg, heap_reg)?;
+        self.context.free_reg(heap_reg);
+
+        // The null collector stores the object's kind and size in the first
+        // header word. `VMGcKind::MASK` reserves the upper six bits for the
+        // kind; the size occupies the remaining lower 26 bits, so bitwise OR
+        // packs both values without overlap.
+        let kind_and_size = kind | size;
+        self.masm.store(
+            RegImm::i32(kind_and_size.cast_signed()),
+            self.masm
+                .address_at_reg(object_addr, VM_GC_HEADER_KIND_OFFSET)?,
+            OperandSize::S32,
+        )?;
+        let shared_ty_size = self.env.vmoffsets.size_of_vmshared_type_index();
+        let shared_ty_offset = interned
+            .as_u32()
+            .checked_mul(u32::from(shared_ty_size))
+            .unwrap();
+        let type_ids_offset = self.env.vmoffsets.ptr.vmctx().type_ids();
+        self.masm.with_scratch::<IntScratch, _>(|masm, shared_ty| {
+            masm.load_ptr(
+                masm.address_at_vmctx(type_ids_offset.into())?,
+                shared_ty.writable(),
+            )?;
+            masm.load(
+                masm.address_at_reg(shared_ty.inner(), shared_ty_offset)?,
+                shared_ty.writable(),
+                OperandSize::from_bytes(shared_ty_size),
+            )?;
+            masm.store(
+                shared_ty.inner().into(),
+                masm.address_at_reg(object_addr, VM_GC_HEADER_TYPE_INDEX_OFFSET)?,
+                OperandSize::from_bytes(shared_ty_size),
+            )
+        })?;
+        let heap_data = self.context.any_gpr(self.masm)?;
+        self.masm.load_ptr(
+            self.masm.address_at_vmctx(u32::from(heap_data_offset))?,
+            writable!(heap_data),
+        )?;
+        self.masm.with_scratch::<IntScratch, _>(|masm, end| {
+            // The checked addition above established that this cannot
+            // overflow.
+            masm.mov(end.writable(), aligned.reg.into(), OperandSize::S32)?;
+            masm.add(
+                end.writable(),
+                end.inner(),
+                RegImm::i32(size.cast_signed()),
+                OperandSize::S32,
+            )?;
+            masm.store(
+                end.inner().into(),
+                masm.address_at_reg(heap_data, 0)?,
+                OperandSize::S32,
+            )
+        })?;
+        self.context.free_reg(heap_data);
+        Ok((aligned, object_addr))
+    }
+
+    /// Allocates an uninitialized object with the collector's allocation
+    /// builtin.
+    fn emit_builtin_gc_raw_alloc(
+        &mut self,
+        kind: u32,
+        interned: ModuleInternedTypeIndex,
+        size: u32,
+        align: u32,
+    ) -> Result<(TypedReg, Reg)> {
+        let shared_ty_size = self.env.vmoffsets.size_of_vmshared_type_index();
+        let shared_ty_offset = interned
+            .as_u32()
+            .checked_mul(u32::from(shared_ty_size))
+            .unwrap();
+
+        // The shared type ID is a call argument, so allocate it here and let
+        // call emission consume it rather than keeping a caller-owned register
+        // live across this helper.
+        let shared_ty = self.context.any_gpr(self.masm)?;
+        self.masm.load_ptr(
+            self.masm
+                .address_at_vmctx(self.env.vmoffsets.ptr.vmctx().type_ids().into())?,
+            writable!(shared_ty),
+        )?;
+        self.masm.load(
+            self.masm.address_at_reg(shared_ty, shared_ty_offset)?,
+            writable!(shared_ty),
+            OperandSize::from_bytes(shared_ty_size),
+        )?;
+        self.context.stack.push(Val::i32(kind.cast_signed()));
+        self.context.stack.push(TypedReg::i32(shared_ty).into());
+        self.context.stack.push(Val::i32(size.cast_signed()));
+        self.context.stack.push(Val::i32(align.cast_signed()));
+        let gc_alloc_raw = self.env.builtins.gc_alloc_raw::<M::ABI>()?;
+        FnCall::emit::<M>(
+            &mut self.env,
+            self.masm,
+            &mut self.context,
+            Callee::Builtin(gc_alloc_raw),
+        )?;
+
+        let gc_ref = self.context.pop_to_reg(self.masm, None)?;
+        let (heap_base, heap_bound) = self.emit_load_gc_heap_base_and_bound()?;
+        self.context.free_reg(heap_bound);
+        let object_addr = self.emit_gc_ref_addr(gc_ref.reg, heap_base)?;
+        self.context.free_reg(heap_base);
+        Ok((gc_ref, object_addr))
+    }
+
     /// Branches to `skip` when `gc_ref` is null or an unboxed i31 reference.
     ///
     /// A `VMGcRef` is null when all its bits are zero. The first branch tests
@@ -57,7 +300,8 @@ where
     ///
     /// Both returned registers are allocated from the code-generation context
     /// and are owned by the caller. The caller must eventually free them.
-    pub(super) fn emit_load_gc_heap_base_and_bound(&mut self) -> Result<(Reg, Reg)> {
+    pub(crate) fn emit_load_gc_heap_base_and_bound(&mut self) -> Result<(Reg, Reg)> {
+        self.needs_gc_heap = true;
         let store_context_offset = self.env.vmoffsets.ptr.vmctx().store_context();
         let gc_heap_base_offset = self.env.vmoffsets.ptr.vm_store_context().gc_heap_base();
         let gc_heap_len_offset = self
@@ -129,7 +373,7 @@ where
     /// otherwise clobber. Callers that want the address to reuse a register
     /// that is dead by this point should free that register first and let the
     /// allocator hand it back.
-    pub(super) fn emit_gc_ref_addr(&mut self, gc_ref: Reg, heap_base: Reg) -> Result<Reg> {
+    pub(crate) fn emit_gc_ref_addr(&mut self, gc_ref: Reg, heap_base: Reg) -> Result<Reg> {
         let dst = self.context.any_gpr(self.masm)?;
         self.masm
             .mov(writable!(dst), heap_base.into(), OperandSize::S64)?;

--- a/winch/codegen/src/codegen/gc.rs
+++ b/winch/codegen/src/codegen/gc.rs
@@ -2,6 +2,7 @@ use super::{CodeGen, CodeGenError, Emission};
 use crate::{
     Result,
     codegen::{Callee, FnCall},
+    ensure,
     masm::{IntCmpKind, IntScratch, MacroAssembler, OperandSize, RegImm},
     reg::{Reg, writable},
     stack::{TypedReg, Val},
@@ -188,6 +189,10 @@ where
         // kind; the size occupies the remaining lower 26 bits, so bitwise OR
         // packs both values without overlap.
         let kind_and_size = kind | size;
+        ensure!(
+            VMGcKind::value_fits_in_unused_bits(size),
+            CodeGenError::allocation_too_large()
+        );
         self.masm.store(
             RegImm::i32(kind_and_size.cast_signed()),
             self.masm

--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -41,6 +41,7 @@ mod builtin;
 pub use builtin::*;
 pub(crate) mod bounds;
 mod drc;
+mod exceptions;
 mod gc;
 
 use bounds::{Bounds, ImmOffset, Index};
@@ -120,6 +121,9 @@ where
 
     /// Local counter to track fuel consumption.
     pub fuel_consumed: i64,
+
+    /// Whether this function accesses the store's GC heap.
+    pub needs_gc_heap: bool,
     phase: PhantomData<P>,
 }
 
@@ -144,6 +148,7 @@ where
             control_frames: Default::default(),
             // Empty functions should consume at least 1 fuel unit.
             fuel_consumed: 1,
+            needs_gc_heap: false,
             phase: PhantomData,
         }
     }
@@ -205,6 +210,7 @@ where
             source_location: self.source_location,
             control_frames: self.control_frames,
             fuel_consumed: self.fuel_consumed,
+            needs_gc_heap: self.needs_gc_heap,
             phase: PhantomData,
         })
     }

--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -20,13 +20,13 @@ use smallvec::SmallVec;
 use std::marker::PhantomData;
 use wasmparser::{
     BinaryReader, FuncValidator, MemArg, Operator, OperatorsReader, ValidatorResources,
-    VisitOperator, VisitSimdOperator,
+    VisitOperator, VisitSimdOperator, WasmFeatures,
 };
 use wasmtime_cranelift::{TRAP_BAD_SIGNATURE, TRAP_HEAP_MISALIGNED, TRAP_TABLE_OUT_OF_BOUNDS};
 use wasmtime_environ::{
     DataIndex, ElemIndex, FUNCREF_INIT_BIT, FUNCREF_MASK, GlobalIndex, IndexType, MemoryIndex,
     MemoryKind, MemoryTunables, PtrSize, TableIndex, Tunables, TypeIndex, WasmHeapType,
-    WasmValType,
+    WasmValType, wasm_unsupported,
 };
 
 mod context;
@@ -43,6 +43,7 @@ pub(crate) mod bounds;
 mod drc;
 mod exceptions;
 mod gc;
+use gc::GcCodegenConfig;
 
 use bounds::{Bounds, ImmOffset, Index};
 
@@ -124,6 +125,9 @@ where
 
     /// Whether this function accesses the store's GC heap.
     pub needs_gc_heap: bool,
+
+    /// Collector-specific configuration for generating GC operations.
+    gc_codegen_config: Option<GcCodegenConfig>,
     phase: PhantomData<P>,
 }
 
@@ -137,8 +141,19 @@ where
         context: CodeGenContext<'a, Prologue>,
         env: FuncEnv<'a, 'translation, 'data, M::Ptr>,
         sig: ABISig,
-    ) -> CodeGen<'a, 'translation, 'data, M, Prologue> {
-        Self {
+        wasm_features: &WasmFeatures,
+    ) -> Result<CodeGen<'a, 'translation, 'data, M, Prologue>> {
+        let gc_codegen_config = match tunables.collector {
+            Some(collector) => Some(GcCodegenConfig::new(collector)),
+            None if wasm_features.contains(WasmFeatures::EXCEPTIONS) => {
+                return Err(format_err!(wasm_unsupported!(
+                    "support for GC types disabled at configuration time"
+                )));
+            }
+            None => None,
+        };
+
+        Ok(Self {
             sig,
             context,
             masm,
@@ -149,8 +164,9 @@ where
             // Empty functions should consume at least 1 fuel unit.
             fuel_consumed: 1,
             needs_gc_heap: false,
+            gc_codegen_config,
             phase: PhantomData,
-        }
+        })
     }
 
     /// Code generation prologue.
@@ -211,6 +227,7 @@ where
             control_frames: self.control_frames,
             fuel_consumed: self.fuel_consumed,
             needs_gc_heap: self.needs_gc_heap,
+            gc_codegen_config: self.gc_codegen_config,
             phase: PhantomData,
         })
     }

--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -533,10 +533,7 @@ where
         let sig_index_bytes = self.env.vmoffsets.size_of_vmshared_type_index();
         let sig_size = OperandSize::from_bytes(sig_index_bytes);
         let sig_index = self.env.translation.module.types[type_index].unwrap_module_type_index();
-        let sig_offset = sig_index
-            .as_u32()
-            .checked_mul(sig_index_bytes.into())
-            .unwrap();
+        let sig_offset = self.env.shared_type_index_offset(sig_index);
         let signatures_base_offset = self.env.vmoffsets.ptr.vmctx().type_ids();
         let funcref_sig_offset = self.env.vmoffsets.ptr.vm_func_ref().type_index();
         // Get the caller id.

--- a/winch/codegen/src/isa/aarch64/mod.rs
+++ b/winch/codegen/src/isa/aarch64/mod.rs
@@ -114,7 +114,14 @@ impl TargetIsa for Aarch64 {
         let frame = Frame::new::<abi::Aarch64ABI>(&abi_sig, &defined_locals)?;
         let regalloc = RegAlloc::from(gpr_bit_set(), fpr_bit_set());
         let codegen_context = CodeGenContext::new(regalloc, stack, frame, &vmoffsets);
-        let codegen = CodeGen::new(tunables, &mut masm, codegen_context, env, abi_sig);
+        let codegen = CodeGen::new(
+            tunables,
+            &mut masm,
+            codegen_context,
+            env,
+            abi_sig,
+            validator.features(),
+        )?;
 
         let mut body_codegen = codegen.emit_prologue()?;
         body_codegen.emit(body, validator)?;

--- a/winch/codegen/src/isa/aarch64/mod.rs
+++ b/winch/codegen/src/isa/aarch64/mod.rs
@@ -88,7 +88,7 @@ impl TargetIsa for Aarch64 {
         builtins: &mut BuiltinFunctions,
         validator: &mut FuncValidator<ValidatorResources>,
         tunables: &Tunables,
-    ) -> Result<CompiledFunction> {
+    ) -> Result<(CompiledFunction, bool)> {
         let pointer_bytes = self.pointer_bytes();
         let vmoffsets = VMOffsets::new(pointer_bytes, &translation.module);
         let mut body = body.get_binary_reader();
@@ -118,12 +118,12 @@ impl TargetIsa for Aarch64 {
 
         let mut body_codegen = codegen.emit_prologue()?;
         body_codegen.emit(body, validator)?;
+        let needs_gc_heap = body_codegen.needs_gc_heap;
         let names = body_codegen.env.take_name_map();
         let base = body_codegen.source_location.base;
-        Ok(CompiledFunction::new(
-            masm.finalize(base)?,
-            names,
-            self.function_alignment(),
+        Ok((
+            CompiledFunction::new(masm.finalize(base)?, names, self.function_alignment()),
+            needs_gc_heap,
         ))
     }
 

--- a/winch/codegen/src/isa/mod.rs
+++ b/winch/codegen/src/isa/mod.rs
@@ -174,7 +174,7 @@ pub trait TargetIsa: Send + Sync {
         builtins: &mut BuiltinFunctions,
         validator: &mut FuncValidator<ValidatorResources>,
         tunables: &Tunables,
-    ) -> Result<CompiledFunction>;
+    ) -> Result<(CompiledFunction, bool)>;
 
     /// Get the default calling convention of the underlying target triple.
     fn default_call_conv(&self) -> CallConv {

--- a/winch/codegen/src/isa/x64/mod.rs
+++ b/winch/codegen/src/isa/x64/mod.rs
@@ -91,7 +91,7 @@ impl TargetIsa for X64 {
         builtins: &mut BuiltinFunctions,
         validator: &mut FuncValidator<ValidatorResources>,
         tunables: &Tunables,
-    ) -> Result<CompiledFunction> {
+    ) -> Result<(CompiledFunction, bool)> {
         let pointer_bytes = self.pointer_bytes();
         let vmoffsets = VMOffsets::new(pointer_bytes, &translation.module);
 
@@ -124,13 +124,13 @@ impl TargetIsa for X64 {
         let mut body_codegen = codegen.emit_prologue()?;
 
         body_codegen.emit(body, validator)?;
+        let needs_gc_heap = body_codegen.needs_gc_heap;
         let base = body_codegen.source_location.base;
 
         let names = body_codegen.env.take_name_map();
-        Ok(CompiledFunction::new(
-            masm.finalize(base)?,
-            names,
-            self.function_alignment(),
+        Ok((
+            CompiledFunction::new(masm.finalize(base)?, names, self.function_alignment()),
+            needs_gc_heap,
         ))
     }
 

--- a/winch/codegen/src/isa/x64/mod.rs
+++ b/winch/codegen/src/isa/x64/mod.rs
@@ -119,7 +119,14 @@ impl TargetIsa for X64 {
         let frame = Frame::new::<abi::X64ABI>(&abi_sig, &defined_locals)?;
         let regalloc = RegAlloc::from(gpr_bit_set(), fpr_bit_set());
         let codegen_context = CodeGenContext::new(regalloc, stack, frame, &vmoffsets);
-        let codegen = CodeGen::new(tunables, &mut masm, codegen_context, env, abi_sig);
+        let codegen = CodeGen::new(
+            tunables,
+            &mut masm,
+            codegen_context,
+            env,
+            abi_sig,
+            validator.features(),
+        )?;
 
         let mut body_codegen = codegen.emit_prologue()?;
 

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -27,13 +27,9 @@ use wasmparser::{
     VisitSimdOperator,
 };
 use wasmtime_cranelift::TRAP_INDIRECT_CALL_TO_NULL;
-use wasmtime_environ::copying::CopyingTypeLayouts;
-use wasmtime_environ::drc::DrcTypeLayouts;
-use wasmtime_environ::null::NullTypeLayouts;
 use wasmtime_environ::{
-    Collector, DataIndex, ElemIndex, FuncIndex, GcTypeLayouts, GlobalIndex, MemoryIndex,
-    TableIndex, TagIndex, TypeIndex, WasmCompositeInnerType, WasmHeapType, WasmStorageType,
-    WasmValType,
+    DataIndex, ElemIndex, FuncIndex, GlobalIndex, MemoryIndex, TableIndex, TagIndex, TypeIndex,
+    WasmCompositeInnerType, WasmHeapType, WasmStorageType, WasmValType,
 };
 
 /// A macro to define unsupported WebAssembly operators.
@@ -1874,12 +1870,7 @@ where
             WasmCompositeInnerType::Exn(exn_ty) => exn_ty,
             _ => return Err(format_err!(CodeGenError::unsupported_wasm_type())),
         };
-        let layouts: &dyn GcTypeLayouts = match self.tunables.collector {
-            Some(Collector::DeferredReferenceCounting) => &DrcTypeLayouts,
-            Some(Collector::Null) => &NullTypeLayouts,
-            Some(Collector::Copying) => &CopyingTypeLayouts,
-            None => return Err(format_err!(CodeGenError::unsupported_wasm_type())),
-        };
+        let layouts = self.require_gc_codegen_config().layouts();
 
         let layout = layouts
             .exn_layout(exn_ty)

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -29,7 +29,7 @@ use wasmparser::{
 use wasmtime_cranelift::TRAP_INDIRECT_CALL_TO_NULL;
 use wasmtime_environ::{
     DataIndex, ElemIndex, FuncIndex, GlobalIndex, MemoryIndex, TableIndex, TagIndex, TypeIndex,
-    WasmCompositeInnerType, WasmHeapType, WasmStorageType, WasmValType,
+    WasmCompositeInnerType, WasmHeapType, WasmValType,
 };
 
 /// A macro to define unsupported WebAssembly operators.
@@ -1866,7 +1866,8 @@ where
         let interned = self.env.translation.module.tags[tag_index]
             .exception
             .unwrap_module_type_index();
-        let exn_ty = match &self.env.types[interned].composite_type.inner {
+        let types = self.env.types;
+        let exn_ty = match &types[interned].composite_type.inner {
             WasmCompositeInnerType::Exn(exn_ty) => exn_ty,
             _ => return Err(format_err!(CodeGenError::unsupported_wasm_type())),
         };
@@ -1875,32 +1876,10 @@ where
         let layout = layouts
             .exn_layout(exn_ty)
             .map_err(|_| format_err!(CodeGenError::unsupported_wasm_type()))?;
-        let field_types: SmallVec<[_; 8]> = exn_ty
-            .fields
-            .iter()
-            .map(|field| field.element_type)
-            .collect();
-        let field_offsets: SmallVec<[_; 8]> =
-            layout.fields.iter().map(|field| field.offset).collect();
-
-        // Winch represents `funcref` as a pointer on the value stack and as an
-        // interned ID in the GC heap. Other supported references already use
-        // the GC heap's representation.
-        for field_ty in &field_types {
-            let WasmStorageType::Val(WasmValType::Ref(r)) = field_ty else {
-                continue;
-            };
-
-            match r.heap_type {
-                WasmHeapType::Func | WasmHeapType::Extern => {}
-                _ => return Err(format_err!(CodeGenError::unsupported_wasm_type())),
-            }
-        }
 
         let (gc_ref, object_addr) =
             self.emit_exception_alloc(tag_index, interned, &layout, layouts)?;
-        let gc_ref =
-            self.emit_exception_payload_fields(&field_types, &field_offsets, gc_ref, object_addr)?;
+        let gc_ref = self.emit_exception_payload_fields(exn_ty, &layout, gc_ref, object_addr)?;
         self.context.stack.push(gc_ref.into());
         self.visit_throw_ref()
     }

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -26,9 +26,13 @@ use wasmparser::{
     BlockType, BrTable, HeapType, Ieee32, Ieee64, MemArg, TryTable, V128, ValType, VisitOperator,
     VisitSimdOperator,
 };
-use wasmtime_cranelift::{TRAP_INDIRECT_CALL_TO_NULL, TRAP_UNHANDLED_TAG};
+use wasmtime_cranelift::TRAP_INDIRECT_CALL_TO_NULL;
+use wasmtime_environ::copying::CopyingTypeLayouts;
+use wasmtime_environ::drc::DrcTypeLayouts;
+use wasmtime_environ::null::NullTypeLayouts;
 use wasmtime_environ::{
-    DataIndex, ElemIndex, FuncIndex, GlobalIndex, MemoryIndex, TableIndex, TypeIndex, WasmHeapType,
+    Collector, DataIndex, ElemIndex, FuncIndex, GcTypeLayouts, GlobalIndex, MemoryIndex,
+    TableIndex, TagIndex, TypeIndex, WasmCompositeInnerType, WasmHeapType, WasmStorageType,
     WasmValType,
 };
 
@@ -1848,9 +1852,9 @@ where
         Ok(())
     }
 
-    // Exceptions currently trap on throw, so a `try_table` compiles like
-    // a `block`. The catch clauses are unreachable and no handler metadata
-    // is emitted.
+    // Winch does not implement exception handlers yet, so a `try_table`
+    // compiles like a `block`. Thrown exceptions escape to the host, and no
+    // handler metadata is emitted.
     fn visit_try_table(&mut self, try_table: TryTable) -> Self::Output {
         self.control_frames.push(ControlStackFrame::block(
             self.env.resolve_block_sig(try_table.ty)?,
@@ -1861,25 +1865,69 @@ where
         Ok(())
     }
 
-    // A thrown exception is compiled as an unhandled-tag trap; see
-    // `visit_try_table`.
-    fn visit_throw(&mut self, _tag_index: u32) -> Self::Output {
-        self.masm.trap(TRAP_UNHANDLED_TAG)?;
-        self.context.reachable = false;
-        let outermost = &mut self.control_frames[0];
-        outermost.set_as_target();
+    fn visit_throw(&mut self, tag_index: u32) -> Self::Output {
+        let tag_index = TagIndex::from_u32(tag_index);
+        let interned = self.env.translation.module.tags[tag_index]
+            .exception
+            .unwrap_module_type_index();
+        let exn_ty = match &self.env.types[interned].composite_type.inner {
+            WasmCompositeInnerType::Exn(exn_ty) => exn_ty,
+            _ => return Err(format_err!(CodeGenError::unsupported_wasm_type())),
+        };
+        let layouts: &dyn GcTypeLayouts = match self.tunables.collector {
+            Some(Collector::DeferredReferenceCounting) => &DrcTypeLayouts,
+            Some(Collector::Null) => &NullTypeLayouts,
+            Some(Collector::Copying) => &CopyingTypeLayouts,
+            None => return Err(format_err!(CodeGenError::unsupported_wasm_type())),
+        };
 
-        Ok(())
+        let layout = layouts
+            .exn_layout(exn_ty)
+            .map_err(|_| format_err!(CodeGenError::unsupported_wasm_type()))?;
+        let field_types: SmallVec<[_; 8]> = exn_ty
+            .fields
+            .iter()
+            .map(|field| field.element_type)
+            .collect();
+        let field_offsets: SmallVec<[_; 8]> =
+            layout.fields.iter().map(|field| field.offset).collect();
+
+        // Winch represents `funcref` as a pointer on the value stack and as an
+        // interned ID in the GC heap. Other supported references already use
+        // the GC heap's representation.
+        for field_ty in &field_types {
+            let WasmStorageType::Val(WasmValType::Ref(r)) = field_ty else {
+                continue;
+            };
+
+            match r.heap_type {
+                WasmHeapType::Func | WasmHeapType::Extern => {}
+                _ => return Err(format_err!(CodeGenError::unsupported_wasm_type())),
+            }
+        }
+
+        let (gc_ref, object_addr) =
+            self.emit_exception_alloc(tag_index, interned, &layout, layouts)?;
+        let gc_ref =
+            self.emit_exception_payload_fields(&field_types, &field_offsets, gc_ref, object_addr)?;
+        self.context.stack.push(gc_ref.into());
+        self.visit_throw_ref()
     }
 
-    // A rethrown exception is compiled as an unhandled-tag trap; see
-    // `visit_try_table`.
+    // The exception reference is on top of the value stack. Forward it to the
+    // runtime, then mark the remaining Wasm code unreachable because throwing
+    // does not return to this function.
     fn visit_throw_ref(&mut self) -> Self::Output {
-        self.masm.trap(TRAP_UNHANDLED_TAG)?;
+        let throw_ref = self.env.builtins.throw_ref::<M::ABI>()?;
+        FnCall::emit::<M>(
+            &mut self.env,
+            self.masm,
+            &mut self.context,
+            Callee::Builtin(throw_ref),
+        )?;
         self.context.reachable = false;
         let outermost = &mut self.control_frames[0];
         outermost.set_as_target();
-
         Ok(())
     }
 


### PR DESCRIPTION
This PR adds implementations for `visit_throw` and `visit_throw_ref` rather than trapping.

The `gc_alloc_raw` builtin supports the only DRC and copying collectors, so I also added
an inline allocation path for the null collector, following Cranelift's pattern.

Reference fields in a newly allocated exception have no old value to
release, so I add a DRC initialization barrier that retains the new
reference before storing it.

This PR restricts reference-typed exception payloads to `funcref` and
`externref`, which are the heap types Winch currently supports.
Other reference heap types are reported as unsupported
