### PR TITLE
c-api: fix the component-model build without async

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -427,6 +427,7 @@ jobs:
               -p wasmtime-c-api --no-default-features --features wat
               -p wasmtime-c-api --no-default-features --features wasi
               -p wasmtime-c-api --no-default-features --features gc
+              -p wasmtime-c-api --no-default-features --features component-model
 
           - name: wasmtime-wasi-http
             checks: |

--- a/crates/c-api/src/component/component.rs
+++ b/crates/c-api/src/component/component.rs
@@ -1,6 +1,7 @@
-use crate::{
-    wasm_byte_vec_t, wasm_config_t, wasm_engine_t, wasmtime_component_type_t, wasmtime_error_t,
-};
+use crate::{wasm_config_t, wasm_engine_t, wasmtime_component_type_t, wasmtime_error_t};
+// Only `wasmtime_component_serialize` uses this, and it is gated the same way.
+#[cfg(any(feature = "cranelift", feature = "winch"))]
+use crate::wasm_byte_vec_t;
 use std::ffi::{CStr, c_char};
 use wasmtime::component::{Component, ComponentExportIndex};
 use wasmtime::error::Context;

--- a/crates/c-api/src/component/component.rs
+++ b/crates/c-api/src/component/component.rs
@@ -1,7 +1,6 @@
-use crate::{wasm_config_t, wasm_engine_t, wasmtime_component_type_t, wasmtime_error_t};
-// Only `wasmtime_component_serialize` uses this, and it is gated the same way.
 #[cfg(any(feature = "cranelift", feature = "winch"))]
 use crate::wasm_byte_vec_t;
+use crate::{wasm_config_t, wasm_engine_t, wasmtime_component_type_t, wasmtime_error_t};
 use std::ffi::{CStr, c_char};
 use wasmtime::component::{Component, ComponentExportIndex};
 use wasmtime::error::Context;

--- a/crates/c-api/src/vec.rs
+++ b/crates/c-api/src/vec.rs
@@ -148,7 +148,7 @@ macro_rules! declare_vecs {
     )*};
 }
 
-#[cfg(feature = "async")]
+#[cfg(feature = "component-model")]
 pub(crate) use declare_vecs;
 
 declare_vecs! {


### PR DESCRIPTION
`cargo check -p wasmtime-c-api --no-default-features --features component-model` fails on main with 23 diagnostics, starting with:

```
error[E0433]: cannot find `declare_vecs` in `crate`
error[E0425]: cannot find type `wasmtime_component_vallist_t` in this scope
...
```

## What is broken

`crates/c-api/src/component/val.rs:11` calls `crate::declare_vecs!`. `declare_vecs` is a plain `macro_rules!`, so that path only resolves because of the re-export at the bottom of `vec.rs` — and the re-export is gated on the wrong feature:

```rust
#[cfg(feature = "async")]
pub(crate) use declare_vecs;
```

`component/val.rs` is behind `#[cfg(feature = "component-model")]` (`lib.rs:104`), and `component-model` does not imply `async`. Enable one without the other and the macro is not in scope, taking every vec type it declares with it.

`crate::declare_vecs!` has exactly one caller, `component/val.rs`. Nothing under `async` uses the path form.

## How it got here

`#10697` added the re-export for this consumer with no cfg at all:

```diff
+pub(crate) use declare_vecs;
```

`4f2fa1541` ("Update nightly Rust used in CI") later added the `#[cfg(feature = "async")]` line — the shape of a fix for an unused-import warning from a newer lint, with the feature picked incorrectly.

CI did not catch it because the `wasmtime-c-api` matrix entry covers `--no-default-features` and then `wat`, `wasi` and `gc`. `component-model` alone was never built.

## The change

One line: the re-export is gated on `component-model`, matching its only consumer.

## Testing

Feature matrix for `wasmtime-c-api-impl`, before and after:

| features | main | with this PR |
| --- | --- | --- |
| `component-model` | 24 errors | ok |
| `component-model,async` | ok | ok |
| `async` | ok | ok |
| `component-model,cranelift` | 24 errors | ok |
| none, `wat`, `wasi`, `gc` | ok | ok |

`-p wasmtime-c-api --no-default-features --features component-model` is added to the `wasmtime-c-api` checks. It fails on unpatched main with 23 diagnostics and passes here.

Also clean, run twice: the four existing `wasmtime-c-api` checks, `-p wasmtime-c-api-impl --all-features`, `cargo clippy -p wasmtime-c-api-impl --no-default-features --features component-model`, `cargo test -p wasmtime-c-api-impl`, `cargo fmt --all -- --check`.

One more thing had to come with it. `component/component.rs` imports `wasm_byte_vec_t` unconditionally, but the only use is in `wasmtime_component_serialize`, which is gated on `cranelift` or `winch`. Under `component-model` alone the import is unused, and CI runs with `RUSTFLAGS=-D warnings`, so the new check fails on it. The import is now gated the same way as its use.

The warning is not from this change — it is on main today under `component-model,async` as well. Nothing built either configuration, which is why it had never surfaced. I first pushed this without the import fix and CI caught it, which is the check doing its job.
