### PR TITLE
cranelift-module: fix the no_std build and cover it in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -420,8 +420,6 @@ jobs:
           - name: cranelift-module
             checks: |
               -p cranelift-module --no-default-features
-              -p cranelift-module --no-default-features --features core
-              -p cranelift-module --no-default-features --features core,enable-serde
 
           - name: wasmtime-bench-api
             checks: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -417,6 +417,12 @@ jobs:
               -p cranelift-entity --no-default-features
               -p cranelift-entity --no-default-features --features enable-serde
 
+          - name: cranelift-module
+            checks: |
+              -p cranelift-module --no-default-features
+              -p cranelift-module --no-default-features --features core
+              -p cranelift-module --no-default-features --features core,enable-serde
+
           - name: wasmtime-bench-api
             checks: |
               -p wasmtime-bench-api

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 [dependencies]
 cranelift-codegen = { workspace = true }
 cranelift-control = { workspace = true }
-hashbrown = { workspace = true, optional = true }
+hashbrown = { workspace = true }
 anyhow = { workspace = true, features = ['std'] }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
@@ -25,7 +25,7 @@ serde_derive = { workspace = true, optional = true }
 [features]
 default = ["std"]
 std = ["cranelift-codegen/std"]
-core = ["hashbrown", "cranelift-codegen/core"]
+core = ["cranelift-codegen/core"]
 
 # For dependent crates that want to serialize some parts of cranelift
 enable-serde = ["serde", "serde_derive", "cranelift-codegen/enable-serde"]

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -25,7 +25,9 @@ serde_derive = { workspace = true, optional = true }
 [features]
 default = ["std"]
 std = ["cranelift-codegen/std"]
-core = ["cranelift-codegen/core"]
+# The "core" feature no longer does anything here either: hashbrown is now an
+# unconditional dependency. Kept, empty, for backward compatibility.
+core = []
 
 # For dependent crates that want to serialize some parts of cranelift
 enable-serde = ["serde", "serde_derive", "cranelift-codegen/enable-serde"]

--- a/cranelift/module/src/module.rs
+++ b/cranelift/module/src/module.rs
@@ -290,6 +290,11 @@ pub enum ModuleError {
     Compilation(CodegenError),
 
     /// Memory allocation failure from a backend
+    ///
+    /// Only the `std` builds carry this variant: the payload is a
+    /// `std::io::Error` and the only producer is `cranelift-jit`, which needs
+    /// `std` anyway.
+    #[cfg(feature = "std")]
     Allocation {
         /// Io error the allocation failed with
         err: std::io::Error,
@@ -310,8 +315,8 @@ impl<'a> From<CompileError<'a>> for ModuleError {
 
 // This is manually implementing Error and Display instead of using thiserror to reduce the amount
 // of dependencies used by Cranelift.
-impl std::error::Error for ModuleError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for ModuleError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         match self {
             Self::Undeclared { .. }
             | Self::IncompatibleDeclaration { .. }
@@ -319,6 +324,7 @@ impl std::error::Error for ModuleError {
             | Self::DuplicateDefinition { .. }
             | Self::InvalidImportDefinition { .. } => None,
             Self::Compilation(source) => Some(source),
+            #[cfg(feature = "std")]
             Self::Allocation { err: source } => Some(source),
             Self::Backend(source) => Some(&**source),
             Self::Flag(source) => Some(source),
@@ -353,6 +359,7 @@ impl std::fmt::Display for ModuleError {
             Self::Compilation(err) => {
                 write!(f, "Compilation error: {err}")
             }
+            #[cfg(feature = "std")]
             Self::Allocation { err } => {
                 write!(f, "Allocation error: {err}")
             }
@@ -362,13 +369,13 @@ impl std::fmt::Display for ModuleError {
     }
 }
 
-impl std::convert::From<CodegenError> for ModuleError {
+impl From<CodegenError> for ModuleError {
     fn from(source: CodegenError) -> Self {
         Self::Compilation { 0: source }
     }
 }
 
-impl std::convert::From<SetError> for ModuleError {
+impl From<SetError> for ModuleError {
     fn from(source: SetError) -> Self {
         Self::Flag { 0: source }
     }


### PR DESCRIPTION
`cargo check -p cranelift-module --no-default-features` fails on main with 11 errors, and `--no-default-features --features core` fails with 6. Both have been broken since #5173 (2022-11-03).

## What is broken

`cranelift/module/src/lib.rs` is `#![no_std]` and aliases `alloc` as `std` when the `std` feature is off:

```rust
#[cfg(not(feature = "std"))]
extern crate alloc as std;
```

`module.rs` then uses three paths that only exist in real `std`:

| site | path |
| --- | --- |
| `ModuleError::Allocation` payload | `std::io::Error` |
| the `Error` impl and its `source()` | `std::error::Error` |
| two `From` impls | `std::convert::From` |

`--features core` does not help — it only pulls in `hashbrown`, so the same three paths still fail. Bare `--no-default-features` fails on those plus `hashbrown` itself, which the manifest only supplies through `core`.

## Why it went unnoticed

`cranelift-module` appears in no file under `.github/`, so no job builds it in any non-default configuration.

The one configuration that forwards to it cannot catch it either. `cranelift`'s `core` feature lists `cranelift-module?/core`, but the umbrella declares

```toml
cranelift-module = { workspace = true, optional = true }
```

without `default-features = false`, and the workspace entry does not set it either, so `cranelift-module/std` is on whenever the dep is. `cargo tree -e features -p cranelift --no-default-features --features core,module` shows `core` and `std` both active. `cranelift-codegen` is declared with `default-features = false` at the workspace level; `cranelift-frontend` and `cranelift-module` are not.

I have left that alone — whether `cranelift`'s `core` should actually mean core is a separate call, and it would need this fix first anyway.

## The change

- `Allocation` is gated on `std`. The payload is a `std::io::Error` and the only producer is `cranelift-jit` (`compiled_blob.rs`), which needs `std` regardless.
- `core::error::Error` instead of `std::error::Error` — stable since 1.81, MSRV here is 1.95. Plain `From` instead of `std::convert::From`.
- `hashbrown` becomes non-optional, matching `cranelift-frontend`, which has the identical `#[cfg(not(feature = "std"))] use hashbrown::...` and a non-optional `hashbrown`. The `hashbrown` feature is dropped from `core` as a result.

That last one removes the `cranelift-module/hashbrown` feature. Nothing in the workspace names it; the umbrella only forwards `?/std` and `?/core`.

## Testing

Three checks added to the `micro_checks` matrix. On unpatched main they fail:

| check | main | with this PR |
| --- | --- | --- |
| `-p cranelift-module --no-default-features` | 11 errors | ok |
| `-p cranelift-module --no-default-features --features core` | 6 errors | ok |
| `-p cranelift-module --no-default-features --features core,enable-serde` | 6 errors | ok |

Also run locally, all clean: `-p cranelift-module --all-features`, `cargo test -p cranelift-module`, `cargo clippy -p cranelift-module --all-targets` and the same with `--no-default-features`, `cargo fmt --all -- --check`, and `cargo check` for `cranelift-jit`, `cranelift-object`, `cranelift`, `cranelift-filetests` and `cranelift-tools`. `Cargo.lock` is unchanged.

This does not make the crate buildable for a bare-metal target on its own — `anyhow` is a hard dependency carrying `features = ['std']`. It makes the configurations the crate already advertises compile again.
