### PR TITLE
docs: add security warning to 'wasmtime serve' command

### DIFF
--- a/docs/cli-options.md
+++ b/docs/cli-options.md
@@ -170,6 +170,22 @@ Furthermore, an address can be specified via:
 wasmtime serve --addr=0.0.0.0:8081 foo.wasm
 ```
 
+### ⚠️ Security Warning
+
+> **Not recommended for production use**
+>
+> The `wasmtime serve` command is intended solely for local development and
+> testing. It **does not** implement safeguards against:
+> - Unbounded outbound HTTP requests
+> - Rate limiting or connection throttling
+> - DDoS protections
+> - Request size limits
+> - TLS/HTTPS termination
+>
+> **Do not deploy `wasmtime serve` in a production environment** without an
+> additional reverse proxy or gateway layer (e.g., Nginx, Envoy, or a dedicated
+> WASI host) that enforces request limits, authentication, and security controls.
+
 At the time of writing, the `wasi:http/proxy` world is still experimental and
 requires setup of some `wit` dependencies. For more information, see
 the [hello-wasi-http](https://github.com/sunfishcode/hello-wasi-http/) example.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -22,3 +22,35 @@ wasmtime --invoke _start foo.wasm
 For more information be sure to check out [how to install the
 CLI](cli-install.md), [the list of options you can
 pass](cli-options.md), and [how to enable logging](cli-logging.md).
+
+## `wasmtime serve` command
+
+The `wasmtime serve` command runs a WASI HTTP component as a local HTTP server
+for development and testing purposes.
+
+```console
+wasmtime serve app.wasm
+```
+
+This starts an HTTP server on `http://0.0.0.0:8080` that routes incoming requests
+to your component.
+
+### ⚠️ Security Warning
+
+> **Not recommended for production use**
+>
+> The `wasmtime serve` command is intended solely for local development and
+> testing. It **does not** implement safeguards against:
+> - Unbounded outbound HTTP requests
+> - Rate limiting or connection throttling
+> - DDoS protections
+> - Request size limits
+> - TLS/HTTPS termination
+>
+> **Do not deploy `wasmtime serve` in a production environment** without an
+> additional reverse proxy or gateway layer (e.g., Nginx, Envoy, or a dedicated
+> WASI host) that enforces request limits, authentication, and security controls.
+
+### Options
+
+Run `wasmtime serve --help` for a complete list of options.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -22,35 +22,3 @@ wasmtime --invoke _start foo.wasm
 For more information be sure to check out [how to install the
 CLI](cli-install.md), [the list of options you can
 pass](cli-options.md), and [how to enable logging](cli-logging.md).
-
-## `wasmtime serve` command
-
-The `wasmtime serve` command runs a WASI HTTP component as a local HTTP server
-for development and testing purposes.
-
-```console
-wasmtime serve app.wasm
-```
-
-This starts an HTTP server on `http://0.0.0.0:8080` that routes incoming requests
-to your component.
-
-### ⚠️ Security Warning
-
-> **Not recommended for production use**
->
-> The `wasmtime serve` command is intended solely for local development and
-> testing. It **does not** implement safeguards against:
-> - Unbounded outbound HTTP requests
-> - Rate limiting or connection throttling
-> - DDoS protections
-> - Request size limits
-> - TLS/HTTPS termination
->
-> **Do not deploy `wasmtime serve` in a production environment** without an
-> additional reverse proxy or gateway layer (e.g., Nginx, Envoy, or a dedicated
-> WASI host) that enforces request limits, authentication, and security controls.
-
-### Options
-
-Run `wasmtime serve --help` for a complete list of options.


### PR DESCRIPTION
This PR addresses #14118 by adding dedicated documentation for the `wasmtime serve` command with an explicit security warning.

### Problem
`wasmtime serve` lacks safeguards against:
- Unbounded outbound HTTP requests
- Rate limiting or connection throttling
- DDoS protections
- Request size limits
- TLS/HTTPS termination

It is intended only for **development and testing purposes**, yet the documentation provided no guidance or disclaimer about its limitations, potentially leading to accidental production deployment.

### Solution
Added a new section in `docs/cli.md`:
- Description of `wasmtime serve` usage with example
- Clear security warning in callout format
- Explicit list of missing security features
- Recommendation to use a reverse proxy for production
- Pointer to `--help` for additional options

### Related Issue
Closes #14118

### Testing
- [x] Documentation renders correctly with mdBook
- [x] Links are functional
- [x] Formatting is consistent with existing docs