### PR TITLE
Fix typos in comments and docs

### DIFF
--- a/cranelift/isle/veri/docs/language.md
+++ b/cranelift/isle/veri/docs/language.md
@@ -283,7 +283,7 @@ Spec macros may be declared:
 ```
 
 Macro expansions are of the form `(<name>! <args...>)`. The body of the macro is
-evaluated in a scope with paramters set to argument values, and the result
+evaluated in a scope with parameters set to argument values, and the result
 substituted for the expansion expression.
 
 ## Type Instantiation

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -4504,7 +4504,7 @@ impl FuncEnvironment<'_> {
                 | WasmHeapTopType::Cont => ty.heap_type.is_vmgcref_type_and_not_i31(),
 
                 // `funcref` is stored differently in tables and the GC heap, so
-                // futher inspection is necessary of where the copy is
+                // further inspection is necessary of where the copy is
                 // happening.
                 WasmHeapTopType::Func => match src_entity {
                     // Tables of funcrefs might be lazily initialized which
@@ -6097,7 +6097,7 @@ impl FuncEnvironment<'_> {
         Ok(())
     }
 
-    /// Peform initialization of an active data segment in a module.
+    /// Perform initialization of an active data segment in a module.
     fn module_initialize_memory_segment(
         &mut self,
         builder: &mut FunctionBuilder,

--- a/docs/examples-minimal-cwasm.md
+++ b/docs/examples-minimal-cwasm.md
@@ -163,7 +163,7 @@ The steps you'll want to use when minimizing `*.cwasm` size are:
     Rust's libstd, etc.
 * Pass `-Daddress-map=n` to disable the ability to generate backtraces with wasm
   pc's in the backtrace.
-* Pass `-Dsymbols=n` to diasble symbols used for debugging/profiling in the
+* Pass `-Dsymbols=n` to disable symbols used for debugging/profiling in the
   output artifact.
 * Pass `-Omemory-init-cow=n` to disable page-aligned data sections and
   precomputation of a memory image that may have holes in it.

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -52,7 +52,7 @@ pub struct RunCommand {
     /// e.g. `wasi:cli/run.run@0.2.0()` or
     /// `your:pkg/iface.func("arguments in wave encoding")`. Bare function
     /// names (e.g. `run()`) are accepted and searched for in all exported
-    /// instances, and must be unambigious.
+    /// instances, and must be unambiguous.
     #[arg(long, value_name = "FUNCTION")]
     pub invoke: Option<String>,
 

--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -2393,7 +2393,7 @@ where
         // value stack can't be spilled, so an untracked address register would make any request
         // for a fixed register fail if the address happened to be allocated to it. For this
         // reason, the address is pushed as a register to be dereferenced prior to emission, after
-        // all the ISA-specifc constraints have been solved.
+        // all the ISA-specific constraints have been solved.
         let operand = self.context.pop_to_reg(self.masm, None)?;
         if let Some(addr) = self.emit_compute_heap_address_align_checked(&heap, arg, size)? {
             self.context

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -2100,7 +2100,7 @@ pub(crate) trait MacroAssembler {
     /// stack before returning.
     ///
     /// Note that the address is passed through the context's stack rather than
-    /// as a register to ensure that any spills can be perfomed when solving
+    /// as a register to ensure that any spills can be performed when solving
     /// ISA-specific constraints prior to emission.
     fn atomic_rmw(
         &mut self,


### PR DESCRIPTION
Comment and documentation spelling fixes only:

- `unambigious` -> `unambiguous` (`--invoke` help text, `src/commands/run.rs`)
- `perfomed` -> `performed` (`winch/codegen/src/masm.rs`)
- `ISA-specifc` -> `ISA-specific` (`winch/codegen/src/codegen/mod.rs`)
- `futher` -> `further` and `Peform` -> `Perform` (`crates/cranelift/src/func_environ.rs`)
- `diasble` -> `disable` (`docs/examples-minimal-cwasm.md`)
- `paramters` -> `parameters` (`cranelift/isle/veri/docs/language.md`)

No identifiers or behaviour touched. I deliberately left the `equivelant` typo in `crates/wasi/src/p2/wit/deps/io.wit` alone since that file is synced from the WASI spec.