### PR TITLE
Alias analysis: do not eliminate loads with different byte orders

### DIFF
--- a/cranelift/codegen/src/alias_analysis.rs
+++ b/cranelift/codegen/src/alias_analysis.rs
@@ -38,10 +38,10 @@
 //! To get this must-alias property, we compute a sparse table of
 //! "memory values": these are known equivalences between SSA `Value`s
 //! and particular locations in memory. The memory-values table is a
-//! mapping from (last store, address expression, type) to SSA
-//! value. At a store, we can insert into this table directly. At a
-//! load, we can also insert, if we don't already have a value (from
-//! the store that produced the load's value).
+//! mapping from a memory location (address, type, byte order, etc...)
+//! to a known value. At a store, we can insert into this table
+//! directly. At a load, we can also insert, if we don't already have a
+//! value (from the store that produced the load's value).
 //!
 //! Then we do a few optimizations at once given this table:
 //!
@@ -80,7 +80,9 @@ use crate::{
     dominator_tree::DominatorTree,
     flowgraph::ControlFlowGraph,
     inst_predicates::{inst_addr_offset_type, inst_store_data, visit_block_succs},
-    ir::{AliasRegion, Block, Function, Inst, Opcode, Type, Value, immediates::Offset32},
+    ir::{
+        AliasRegion, Block, Endianness, Function, Inst, Opcode, Type, Value, immediates::Offset32,
+    },
     post_dominator_tree::PostDominatorTree,
     trace,
 };
@@ -542,8 +544,9 @@ impl LastStores {
 /// instruction to touch the disjoint category of abstract state we're
 /// accessing); (ii) the address must be the same (here ensured by
 /// having the same SSA value, which doesn't change after computed);
-/// (iii) the offset must be the same; and (iv) the accessed type and
-/// extension mode (e.g., 8-to-32, signed) must be the same.
+/// (iii) the offset must be the same; (iv) the accessed type and
+/// extension mode (e.g., 8-to-32, signed) must be the same; and (v)
+/// the byte order of the two accesses must be the same.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 struct MemoryLoc {
     last_store: PackedOption<Inst>,
@@ -562,6 +565,21 @@ struct MemoryLoc {
     /// in place of extending loads when we know the memory value, but
     /// we haven't yet done this.
     extending_opcode: Option<Opcode>,
+    /// The byte order of this access, as explicitly specified in its memory
+    /// flags, or `None` when the access uses the target's native byte order.
+    ///
+    /// Without this, two accesses to the same address that disagree about byte
+    /// order would share a key, and we would happily forward a value from one
+    /// to the other, dropping the byte swap that the mismatch implies.
+    ///
+    /// We only record the *explicit* byte order here, rather than resolving
+    /// `None` to the target's native byte order. This keeps the pass
+    /// independent of the target, but does mean we never share a key between an
+    /// access that spells out the native byte order and one that leaves it
+    /// implicit. That scenario leads to missed optimizations, never
+    /// miscompiles, and is exceedingly rare, so we deem the trade off worth it
+    /// for simplicity.
+    endianness: Option<Endianness>,
 }
 
 /// What is known to be in memory at an associated `MemoryLoc`.
@@ -636,8 +654,7 @@ pub struct AliasAnalysis<'a> {
     block_input: FxHashMap<Block, LastStores>,
 
     /// Known memory-value equivalences. This is the result of the
-    /// analysis. This is a mapping from (last store, address
-    /// expression, offset, type) to SSA `Value`.
+    /// analysis. This is a mapping from a memory location to its known value.
     mem_values: FxHashMap<MemoryLoc, KnownValue>,
 }
 
@@ -807,12 +824,19 @@ impl<'a> AliasAnalysis<'a> {
                         // layout, so drop its entry from `mem_values`. This
                         // maintains the invariant that `mem_values` only ever
                         // references instructions that are still in the layout.
+                        //
+                        // NB: the entry we are looking for was keyed on the
+                        // *dead* store's byte order, which `fully_overwrites`
+                        // does not require to match this store's byte order.
+                        // Everything else in the key does have to match, so we
+                        // can take it from this store.
                         let dead_loc = MemoryLoc {
                             last_store: last_store.into(),
                             address,
                             offset,
                             ty,
                             extending_opcode: get_ext_opcode(opcode),
+                            endianness: get_endianness(func, last_store),
                         };
                         let dead_entry = self.mem_values.remove(&dead_loc);
 
@@ -858,6 +882,7 @@ impl<'a> AliasAnalysis<'a> {
                     offset,
                     ty,
                     extending_opcode: get_ext_opcode(opcode),
+                    endianness: get_endianness(func, inst),
                 };
                 if let Some(KnownValue {
                     def_inst,
@@ -899,6 +924,7 @@ impl<'a> AliasAnalysis<'a> {
                     offset,
                     ty,
                     extending_opcode: get_ext_opcode(opcode),
+                    endianness: get_endianness(func, inst),
                 };
                 trace!("  --> updating known values in memory: {mem_loc:?} = {store_data}");
                 self.mem_values.insert(
@@ -924,6 +950,7 @@ impl<'a> AliasAnalysis<'a> {
                     offset,
                     ty,
                     extending_opcode: get_ext_opcode(opcode),
+                    endianness: get_endianness(func, inst),
                 };
                 trace!("  load with last_store at loc {mem_loc:?}");
 
@@ -1040,6 +1067,14 @@ impl<'a> AliasAnalysis<'a> {
     }
 }
 
+/// Get the explicitly-specified byte order of the given memory access,
+/// if any.
+fn get_endianness(func: &Function, inst: Inst) -> Option<Endianness> {
+    func.dfg.insts[inst]
+        .memflags_data(&func.dfg)
+        .and_then(|flags| flags.explicit_endianness())
+}
+
 fn get_ext_opcode(op: Opcode) -> Option<Opcode> {
     debug_assert!(op.can_load() || op.can_store());
     match op {
@@ -1103,6 +1138,12 @@ fn fully_overwrites(
     {
         return false;
     }
+
+    // NB: unlike store-to-load forwarding and redundant-load
+    // elimination, our two stores' byte orders do *not* have to match
+    // Both write the same range of bytes, just in a different order
+    // within that range, and the overwriting store's bytes are the
+    // ones that survive either way.
 
     // Both must write the same address, offset, and type.
     match inst_addr_offset_type(func, maybe_dead) {

--- a/cranelift/filetests/filetests/alias/endianness.clif
+++ b/cranelift/filetests/filetests/alias/endianness.clif
@@ -1,0 +1,197 @@
+test optimize precise-output
+set opt_level=speed
+target x86_64
+
+;; Byte order is part of a memory location's identity: two accesses to the same
+;; address with the same type but opposite byte order are *not* interchangeable,
+;; because forwarding a value from one to the other would drop a byte swap.
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Redundant-load elimination
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; The big-endian load must not be replaced with the little-endian load's
+;; result.
+function %rle_mismatched_endianness(i64) -> i16, i16 {
+    region0 = 0 "heap"
+block0(v0: i64):
+    v1 = load.i16 region0 little v0
+    v2 = load.i16 region0 big v0
+    return v1, v2
+}
+
+; function %rle_mismatched_endianness(i64) -> i16, i16 fast {
+;     region0 = 0 "heap"
+;
+; block0(v0: i64):
+;     v1 = load.i16 little region0 v0
+;     v2 = load.i16 big region0 v0
+;     return v1, v2
+; }
+
+;; Same byte order: the second load is redundant and is removed.
+function %rle_matching_endianness(i64) -> i16, i16 {
+    region0 = 0 "heap"
+block0(v0: i64):
+    v1 = load.i16 region0 big v0
+    v2 = load.i16 region0 big v0
+    return v1, v2
+}
+
+; function %rle_matching_endianness(i64) -> i16, i16 fast {
+;     region0 = 0 "heap"
+;
+; block0(v0: i64):
+;     v1 = load.i16 big region0 v0
+;     return v1, v1
+; }
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Store-to-load forwarding
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; The big-endian load must not be replaced with the little-endian store's data.
+function %stl_mismatched_endianness(i64, i16) -> i16 {
+    region0 = 0 "heap"
+block0(v0: i64, v1: i16):
+    store.i16 region0 little v1, v0
+    v2 = load.i16 region0 big v0
+    return v2
+}
+
+; function %stl_mismatched_endianness(i64, i16) -> i16 fast {
+;     region0 = 0 "heap"
+;
+; block0(v0: i64, v1: i16):
+;     store little region0 v1, v0
+;     v2 = load.i16 big region0 v0
+;     return v2
+; }
+
+;; Same byte order: the load is forwarded from the store.
+function %stl_matching_endianness(i64, i16) -> i16 {
+    region0 = 0 "heap"
+block0(v0: i64, v1: i16):
+    store.i16 region0 big v1, v0
+    v2 = load.i16 region0 big v0
+    return v2
+}
+
+; function %stl_matching_endianness(i64, i16) -> i16 fast {
+;     region0 = 0 "heap"
+;
+; block0(v0: i64, v1: i16):
+;     store big region0 v1, v0
+;     return v1
+; }
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Idempotent-store elimination
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; Storing a big-endian load's result back with little-endian byte order writes
+;; the byte-swapped value to memory, so the store is not idempotent and must be
+;; kept.
+function %idempotent_store_mismatched_endianness(i64) {
+    region0 = 0 "heap"
+block0(v0: i64):
+    v1 = load.i16 region0 big v0
+    store.i16 region0 little v1, v0
+    return
+}
+
+; function %idempotent_store_mismatched_endianness(i64) fast {
+;     region0 = 0 "heap"
+;
+; block0(v0: i64):
+;     v1 = load.i16 big region0 v0
+;     store little region0 v1, v0
+;     return
+; }
+
+;; Same byte order: the store really is idempotent and is removed.
+function %idempotent_store_matching_endianness(i64) {
+    region0 = 0 "heap"
+block0(v0: i64):
+    v1 = load.i16 region0 big v0
+    store.i16 region0 big v1, v0
+    return
+}
+
+; function %idempotent_store_matching_endianness(i64) fast {
+;     region0 = 0 "heap"
+;
+; block0(v0: i64):
+;     v1 = load.i16 big region0 v0
+;     return
+; }
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Implicit (native) versus explicit byte order
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; We do not resolve an unspecified byte order to the target's native byte
+;; order, so an access that leaves the byte order implicit never forwards into
+;; one that spells it out, even when they agree on this target. This is
+;; conservative: it costs an optimization, but is never wrong.
+function %rle_implicit_versus_explicit_endianness(i64) -> i16, i16 {
+    region0 = 0 "heap"
+block0(v0: i64):
+    v1 = load.i16 region0 v0
+    v2 = load.i16 region0 little v0
+    return v1, v2
+}
+
+; function %rle_implicit_versus_explicit_endianness(i64) -> i16, i16 fast {
+;     region0 = 0 "heap"
+;
+; block0(v0: i64):
+;     v1 = load.i16 region0 v0
+;     v2 = load.i16 little region0 v0
+;     return v1, v2
+; }
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Dead-store elimination
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; Dead-store elimination does not care about byte order: both stores write
+;; exactly the same range of bytes, and the second one's bytes are the ones
+;; that survive regardless of the order within that range. So the first store
+;; is dead even though the two disagree about byte order.
+function %dead_store_mismatched_endianness(i64, i16, i16) {
+    region0 = 0 "heap"
+block0(v0: i64, v1: i16, v2: i16):
+    store.i16 region0 big v1, v0
+    store.i16 region0 little v2, v0
+    return
+}
+
+; function %dead_store_mismatched_endianness(i64, i16, i16) fast {
+;     region0 = 0 "heap"
+;
+; block0(v0: i64, v1: i16, v2: i16):
+;     store little region0 v2, v0
+;     return
+; }
+
+;; Removing a dead store whose byte order differs from its overwriter's must
+;; still roll the last-store state back to the version before the dead store,
+;; so that the overwriter is recognized as idempotent on reprocessing. Both
+;; stores should be gone here.
+function %dead_store_then_idempotent_store_mismatched_endianness(i64, i16) {
+    region0 = 0 "heap"
+block0(v0: i64, v1: i16):
+    v2 = load.i16 notrap region0 big v0
+    store.i16 region0 little v1, v0
+    store.i16 region0 big v2, v0
+    return
+}
+
+; function %dead_store_then_idempotent_store_mismatched_endianness(i64, i16) fast {
+;     region0 = 0 "heap"
+;
+; block0(v0: i64, v1: i16):
+;     v2 = load.i16 notrap big region0 v0
+;     return
+; }

--- a/cranelift/filetests/filetests/runtests/alias-analysis-endianness.clif
+++ b/cranelift/filetests/filetests/runtests/alias-analysis-endianness.clif
@@ -1,0 +1,51 @@
+test interpret
+test run
+set opt_level=speed
+
+;; XXX: only the s390x and Pulley backends implement non-native byte order for
+;; memory accesses at the time of writing, and these tests need a mismatched
+;; pair to exercise the alias-analysis behavior at all.
+target s390x
+target pulley64
+
+;; Redundant-load elimination between a little-endian and a big-endian load:
+;; the big-endian load must not be replaced with the little-endian one's
+;; result. Correct result: 0x1234 ^ 0x3412 == 0x2626.
+function %rle_across_endianness(i16) -> i16 {
+    ss0 = explicit_slot 8
+block0(v1: i16):
+    v0 = stack_addr.i64 ss0
+    store little v1, v0
+    v2 = load.i16 little v0
+    v3 = load.i16 big v0
+    v4 = bxor v2, v3
+    return v4
+}
+; run: %rle_across_endianness(0x1234) == 0x2626
+
+;; Store-to-load forwarding between a little-endian store and a big-endian
+;; load: the load must not be replaced with the store's data.
+function %stl_across_endianness(i16) -> i16 {
+    ss0 = explicit_slot 8
+block0(v1: i16):
+    v0 = stack_addr.i64 ss0
+    store little v1, v0
+    v2 = load.i16 big v0
+    return v2
+}
+; run: %stl_across_endianness(0x1234) == 0x3412
+
+;; Idempotent-store elimination between a big-endian load and a little-endian
+;; store: the store writes the byte-swapped value, so it is not idempotent and
+;; must not be deleted.
+function %idempotent_store_across_endianness(i16) -> i16 {
+    ss0 = explicit_slot 8
+block0(v1: i16):
+    v0 = stack_addr.i64 ss0
+    store little v1, v0
+    v2 = load.i16 big v0
+    store little v2, v0
+    v3 = load.i16 little v0
+    return v3
+}
+; run: %idempotent_store_across_endianness(0x1234) == 0x3412


### PR DESCRIPTION
Do not forward the value from a store at memory location `L` to a load of `L` when the store was big endian and the load is little endian, or vice versa. Similar for redundant-load elimination.

Note that dead-store elimination overwrites the same range of bytes in memory regardless of byte order, so it can still happen when the dead store is big and the overwriter is little or vice versa, so long as we update the memory state to correctly record the overwriter's byte order.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please review the Bytecode Alliance's AI tool usage policy at
https://github.com/bytecodealliance/governance/blob/main/AI_TOOL_POLICY.md

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
