### PR TITLE
Consolidate store configuration on the CLI

### DIFF
--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -389,15 +389,7 @@ impl RunCommand {
 
         let mut store = Store::new(&engine, host);
         self.populate_with_wasi(&mut linker, &mut store)?;
-
-        store.data_mut().limits = self.run.store_limits();
-        store.limiter(|t| &mut t.limits);
-
-        // If fuel has been configured, we want to add the configured
-        // fuel amount to this store.
-        if let Some(fuel) = self.run.common.wasm.fuel {
-            store.set_fuel(fuel)?;
-        }
+        self.run.configure_store(&mut store, |t| &mut t.limits)?;
 
         Ok((store, linker))
     }
@@ -1349,18 +1341,7 @@ impl RunCommand {
             builder.inherit_stderr();
         }
         self.run.configure_wasip2(&mut builder)?;
-        let mut ctx = builder.build_p1();
-        if let Some(max) = self.run.common.wasi.max_resources {
-            ctx.ctx().table.set_max_capacity(max);
-            #[cfg(feature = "component-model-async")]
-            if let Some(table) = store.concurrent_resource_table() {
-                table.set_max_capacity(max);
-            }
-        }
-        if let Some(fuel) = self.run.common.wasi.hostcall_fuel {
-            store.set_hostcall_fuel(fuel);
-        }
-        store.data_mut().wasip1_ctx = Some(ctx);
+        store.data_mut().wasip1_ctx = Some(builder.build_p1());
         Ok(())
     }
 

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -445,20 +445,7 @@ impl ServeCommand {
         }
 
         let mut store = Store::new(engine, host);
-
-        if let Some(fuel) = self.run.common.wasi.hostcall_fuel {
-            store.set_hostcall_fuel(fuel);
-        }
-
-        store.data_mut().limits = self.run.store_limits();
-        store.limiter(|t| &mut t.limits);
-
-        // If fuel has been configured, we want to add the configured
-        // fuel amount to this store.
-        if let Some(fuel) = self.run.common.wasm.fuel {
-            store.set_fuel(fuel)?;
-        }
-
+        self.run.configure_store(&mut store, |t| &mut t.limits)?;
         Ok(store)
     }
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 use std::net::TcpListener;
 use std::{fs::File, path::Path, time::Duration};
 use wasmtime::{
-    Engine, Module, Precompiled, Result, StoreLimits, StoreLimitsBuilder, bail,
+    Engine, Module, Precompiled, Result, Store, StoreLimits, StoreLimitsBuilder, bail,
     error::Context as _, format_err,
 };
 use wasmtime_cli_flags::{CommonOptions, opt::WasmtimeOptionValue};
@@ -478,6 +478,38 @@ impl RunCommon {
                 .context("failed to link `wasi:cli@0.3.x`")?;
         }
 
+        Ok(())
+    }
+
+    pub fn configure_store<T>(
+        &self,
+        store: &mut Store<T>,
+        limits: fn(&mut T) -> &mut StoreLimits,
+    ) -> Result<()>
+    where
+        T: wasmtime_wasi::WasiView,
+    {
+        if let Some(max) = self.common.wasi.max_resources {
+            if self.common.wasi.cli != Some(false) {
+                store.data_mut().ctx().table.set_max_capacity(max);
+            }
+            #[cfg(feature = "component-model-async")]
+            if let Some(table) = store.concurrent_resource_table() {
+                table.set_max_capacity(max);
+            }
+        }
+        if let Some(fuel) = self.common.wasi.hostcall_fuel {
+            store.set_hostcall_fuel(fuel);
+        }
+
+        *limits(store.data_mut()) = self.store_limits();
+        store.limiter(move |t| limits(t));
+
+        // If fuel has been configured, we want to add the configured
+        // fuel amount to this store.
+        if let Some(fuel) = self.common.wasm.fuel {
+            store.set_fuel(fuel)?;
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
Uniformly configure the store across the `run` and `serve` subcommand to ensure they stay in sync. Notably the `serve` command didn't apply `-Smax-resources` to the concurrent resource table like `run` did.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please review the Bytecode Alliance's AI tool usage policy at
https://github.com/bytecodealliance/governance/blob/main/AI_TOOL_POLICY.md

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
