### PR TITLE
Release Wasmtime 24.0.13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1110,7 +1110,7 @@ jobs:
       - test_capi
       - test_debug_dwarf
       - test_fuzzing
-      - test_wasi_nn
+      # - test_wasi_nn
       - test_nightly
       - build
       - rustfmt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,7 +216,7 @@ checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "byte-array-literals"
-version = "24.0.12"
+version = "24.0.13"
 
 [[package]]
 name = "byteorder"
@@ -556,7 +556,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.111.12"
+version = "0.111.13"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -569,14 +569,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.111.12"
+version = "0.111.13"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.111.12"
+version = "0.111.13"
 dependencies = [
  "serde",
  "serde_derive",
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.111.12"
+version = "0.111.13"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -615,25 +615,25 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.111.12"
+version = "0.111.13"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.111.12"
+version = "0.111.13"
 
 [[package]]
 name = "cranelift-control"
-version = "0.111.12"
+version = "0.111.13"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.111.12"
+version = "0.111.13"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -671,7 +671,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.111.12"
+version = "0.111.13"
 dependencies = [
  "cranelift-codegen",
  "env_logger",
@@ -696,7 +696,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.111.12"
+version = "0.111.13"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -710,7 +710,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.111.12"
+version = "0.111.13"
 dependencies = [
  "codespan-reporting",
  "log",
@@ -719,7 +719,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.111.12"
+version = "0.111.13"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -740,7 +740,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.111.12"
+version = "0.111.13"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.111.12"
+version = "0.111.13"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -761,7 +761,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.111.12"
+version = "0.111.13"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -776,7 +776,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-reader"
-version = "0.111.12"
+version = "0.111.13"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -786,7 +786,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.111.12"
+version = "0.111.13"
 dependencies = [
  "clap",
  "cranelift-codegen",
@@ -830,7 +830,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.111.12"
+version = "0.111.13"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1045,7 +1045,7 @@ checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
 
 [[package]]
 name = "embedding"
-version = "24.0.12"
+version = "24.0.13"
 dependencies = [
  "anyhow",
  "dlmalloc",
@@ -1846,7 +1846,7 @@ dependencies = [
 
 [[package]]
 name = "min-platform-host"
-version = "24.0.12"
+version = "24.0.13"
 dependencies = [
  "anyhow",
  "libloading",
@@ -3088,7 +3088,7 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "verify-component-adapter"
-version = "24.0.12"
+version = "24.0.13"
 dependencies = [
  "anyhow",
  "wasmparser",
@@ -3138,7 +3138,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi-common"
-version = "24.0.12"
+version = "24.0.13"
 dependencies = [
  "anyhow",
  "bitflags 2.4.1",
@@ -3178,7 +3178,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter"
-version = "24.0.12"
+version = "24.0.13"
 dependencies = [
  "bitflags 2.4.1",
  "byte-array-literals",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "24.0.12"
+version = "24.0.13"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -3432,14 +3432,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "24.0.12"
+version = "24.0.13"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-bench-api"
-version = "24.0.12"
+version = "24.0.13"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3455,14 +3455,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api"
-version = "24.0.12"
+version = "24.0.13"
 dependencies = [
  "wasmtime-c-api-impl",
 ]
 
 [[package]]
 name = "wasmtime-c-api-impl"
-version = "24.0.12"
+version = "24.0.13"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3480,7 +3480,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api-macros"
-version = "24.0.12"
+version = "24.0.13"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3488,7 +3488,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cache"
-version = "24.0.12"
+version = "24.0.13"
 dependencies = [
  "anyhow",
  "base64",
@@ -3510,7 +3510,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "24.0.12"
+version = "24.0.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3578,7 +3578,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "24.0.12"
+version = "24.0.13"
 dependencies = [
  "anyhow",
  "clap",
@@ -3591,7 +3591,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "24.0.12"
+version = "24.0.13"
 dependencies = [
  "anyhow",
  "component-macro-test-helpers",
@@ -3611,11 +3611,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "24.0.12"
+version = "24.0.13"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "24.0.12"
+version = "24.0.13"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3637,7 +3637,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "24.0.12"
+version = "24.0.13"
 dependencies = [
  "anyhow",
  "clap",
@@ -3679,7 +3679,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-explorer"
-version = "24.0.12"
+version = "24.0.13"
 dependencies = [
  "anyhow",
  "capstone",
@@ -3694,7 +3694,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "24.0.12"
+version = "24.0.13"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -3766,7 +3766,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "24.0.12"
+version = "24.0.13"
 dependencies = [
  "object",
  "once_cell",
@@ -3776,7 +3776,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "24.0.12"
+version = "24.0.13"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3786,7 +3786,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-slab"
-version = "24.0.12"
+version = "24.0.13"
 
 [[package]]
 name = "wasmtime-test-macros"
@@ -3800,7 +3800,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "24.0.12"
+version = "24.0.13"
 dependencies = [
  "anyhow",
  "cranelift-entity",
@@ -3812,7 +3812,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "24.0.12"
+version = "24.0.13"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3821,7 +3821,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "24.0.12"
+version = "24.0.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3854,7 +3854,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "24.0.12"
+version = "24.0.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3880,7 +3880,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-keyvalue"
-version = "24.0.12"
+version = "24.0.13"
 dependencies = [
  "anyhow",
  "test-programs-artifacts",
@@ -3891,7 +3891,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "24.0.12"
+version = "24.0.13"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3911,7 +3911,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-runtime-config"
-version = "24.0.12"
+version = "24.0.13"
 dependencies = [
  "anyhow",
  "test-programs-artifacts",
@@ -3922,7 +3922,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-threads"
-version = "24.0.12"
+version = "24.0.13"
 dependencies = [
  "anyhow",
  "log",
@@ -3933,7 +3933,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "24.0.12"
+version = "24.0.13"
 dependencies = [
  "anyhow",
  "log",
@@ -3943,7 +3943,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-winch"
-version = "24.0.12"
+version = "24.0.13"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -3958,7 +3958,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "24.0.12"
+version = "24.0.13"
 dependencies = [
  "anyhow",
  "heck 0.4.0",
@@ -3968,7 +3968,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wmemcheck"
-version = "24.0.12"
+version = "24.0.13"
 
 [[package]]
 name = "wast"
@@ -4035,7 +4035,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "24.0.12"
+version = "24.0.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4052,7 +4052,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "24.0.12"
+version = "24.0.13"
 dependencies = [
  "anyhow",
  "heck 0.4.0",
@@ -4065,7 +4065,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "24.0.12"
+version = "24.0.13"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4120,7 +4120,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "0.22.12"
+version = "0.22.13"
 dependencies = [
  "anyhow",
  "cranelift-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,7 +156,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "24.0.12"
+version = "24.0.13"
 authors = ["The Wasmtime Project Developers"]
 edition = "2021"
 # Wasmtime's current policy is that this number can be no larger than the
@@ -183,60 +183,60 @@ manual_strip = 'warn'
 
 [workspace.dependencies]
 arbitrary = { version = "1.3.1" }
-wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=24.0.12" }
-wasmtime = { path = "crates/wasmtime", version = "24.0.12", default-features = false }
-wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=24.0.12" }
-wasmtime-cache = { path = "crates/cache", version = "=24.0.12" }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=24.0.12" }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=24.0.12" }
-wasmtime-winch = { path = "crates/winch", version = "=24.0.12" }
-wasmtime-environ = { path = "crates/environ", version = "=24.0.12" }
-wasmtime-explorer = { path = "crates/explorer", version = "=24.0.12" }
-wasmtime-fiber = { path = "crates/fiber", version = "=24.0.12" }
-wasmtime-types = { path = "crates/types", version = "24.0.12" }
-wasmtime-jit-debug = { path = "crates/jit-debug", version = "=24.0.12" }
-wasmtime-wast = { path = "crates/wast", version = "=24.0.12" }
-wasmtime-wasi = { path = "crates/wasi", version = "24.0.12", default-features = false }
-wasmtime-wasi-http = { path = "crates/wasi-http", version = "=24.0.12", default-features = false }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "24.0.12" }
-wasmtime-wasi-runtime-config = { path = "crates/wasi-runtime-config", version = "24.0.12" }
-wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "24.0.12" }
-wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "24.0.12" }
-wasmtime-component-util = { path = "crates/component-util", version = "=24.0.12" }
-wasmtime-component-macro = { path = "crates/component-macro", version = "=24.0.12" }
-wasmtime-asm-macros = { path = "crates/asm-macros", version = "=24.0.12" }
-wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=24.0.12" }
-wasmtime-slab = { path = "crates/slab", version = "=24.0.12" }
+wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=24.0.13" }
+wasmtime = { path = "crates/wasmtime", version = "24.0.13", default-features = false }
+wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=24.0.13" }
+wasmtime-cache = { path = "crates/cache", version = "=24.0.13" }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=24.0.13" }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=24.0.13" }
+wasmtime-winch = { path = "crates/winch", version = "=24.0.13" }
+wasmtime-environ = { path = "crates/environ", version = "=24.0.13" }
+wasmtime-explorer = { path = "crates/explorer", version = "=24.0.13" }
+wasmtime-fiber = { path = "crates/fiber", version = "=24.0.13" }
+wasmtime-types = { path = "crates/types", version = "24.0.13" }
+wasmtime-jit-debug = { path = "crates/jit-debug", version = "=24.0.13" }
+wasmtime-wast = { path = "crates/wast", version = "=24.0.13" }
+wasmtime-wasi = { path = "crates/wasi", version = "24.0.13", default-features = false }
+wasmtime-wasi-http = { path = "crates/wasi-http", version = "=24.0.13", default-features = false }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "24.0.13" }
+wasmtime-wasi-runtime-config = { path = "crates/wasi-runtime-config", version = "24.0.13" }
+wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "24.0.13" }
+wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "24.0.13" }
+wasmtime-component-util = { path = "crates/component-util", version = "=24.0.13" }
+wasmtime-component-macro = { path = "crates/component-macro", version = "=24.0.13" }
+wasmtime-asm-macros = { path = "crates/asm-macros", version = "=24.0.13" }
+wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=24.0.13" }
+wasmtime-slab = { path = "crates/slab", version = "=24.0.13" }
 component-test-util = { path = "crates/misc/component-test-util" }
 component-fuzz-util = { path = "crates/misc/component-fuzz-util" }
-wiggle = { path = "crates/wiggle", version = "=24.0.12", default-features = false }
-wiggle-macro = { path = "crates/wiggle/macro", version = "=24.0.12" }
-wiggle-generate = { path = "crates/wiggle/generate", version = "=24.0.12" }
-wasi-common = { path = "crates/wasi-common", version = "=24.0.12", default-features = false }
+wiggle = { path = "crates/wiggle", version = "=24.0.13", default-features = false }
+wiggle-macro = { path = "crates/wiggle/macro", version = "=24.0.13" }
+wiggle-generate = { path = "crates/wiggle/generate", version = "=24.0.13" }
+wasi-common = { path = "crates/wasi-common", version = "=24.0.13", default-features = false }
 wasmtime-fuzzing = { path = "crates/fuzzing" }
-wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=24.0.12" }
-wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=24.0.12" }
+wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=24.0.13" }
+wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=24.0.13" }
 test-programs-artifacts = { path = 'crates/test-programs/artifacts' }
 pulley-interpreter-fuzz = { path = 'pulley/fuzz' }
 
-cranelift-wasm = { path = "cranelift/wasm", version = "0.111.12" }
-cranelift-codegen = { path = "cranelift/codegen", version = "0.111.12", default-features = false, features = ["std", "unwind", "trace-log"] }
-cranelift-frontend = { path = "cranelift/frontend", version = "0.111.12" }
-cranelift-entity = { path = "cranelift/entity", version = "0.111.12" }
-cranelift-native = { path = "cranelift/native", version = "0.111.12" }
-cranelift-module = { path = "cranelift/module", version = "0.111.12" }
-cranelift-interpreter = { path = "cranelift/interpreter", version = "0.111.12" }
-cranelift-reader = { path = "cranelift/reader", version = "0.111.12" }
+cranelift-wasm = { path = "cranelift/wasm", version = "0.111.13" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.111.13", default-features = false, features = ["std", "unwind", "trace-log"] }
+cranelift-frontend = { path = "cranelift/frontend", version = "0.111.13" }
+cranelift-entity = { path = "cranelift/entity", version = "0.111.13" }
+cranelift-native = { path = "cranelift/native", version = "0.111.13" }
+cranelift-module = { path = "cranelift/module", version = "0.111.13" }
+cranelift-interpreter = { path = "cranelift/interpreter", version = "0.111.13" }
+cranelift-reader = { path = "cranelift/reader", version = "0.111.13" }
 cranelift-filetests = { path = "cranelift/filetests" }
-cranelift-object = { path = "cranelift/object", version = "0.111.12" }
-cranelift-jit = { path = "cranelift/jit", version = "0.111.12" }
+cranelift-object = { path = "cranelift/object", version = "0.111.13" }
+cranelift-jit = { path = "cranelift/jit", version = "0.111.13" }
 cranelift-fuzzgen = { path = "cranelift/fuzzgen" }
-cranelift-bforest = { path = "cranelift/bforest", version = "0.111.12" }
-cranelift-bitset = { path = "cranelift/bitset", version = "0.111.12" }
-cranelift-control = { path = "cranelift/control", version = "0.111.12" }
-cranelift = { path = "cranelift/umbrella", version = "0.111.12" }
+cranelift-bforest = { path = "cranelift/bforest", version = "0.111.13" }
+cranelift-bitset = { path = "cranelift/bitset", version = "0.111.13" }
+cranelift-control = { path = "cranelift/control", version = "0.111.13" }
+cranelift = { path = "cranelift/umbrella", version = "0.111.13" }
 
-winch-codegen = { path = "winch/codegen", version = "=0.22.12" }
+winch-codegen = { path = "winch/codegen", version = "=0.22.13" }
 
 wasi-preview1-component-adapter = { path = "crates/wasi-preview1-component-adapter" }
 byte-array-literals = { path = "crates/wasi-preview1-component-adapter/byte-array-literals" }

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,14 @@
+## 24.0.13
+
+Released 2026-08-20
+
+### Fixed
+
+* Filesystem sandbox escape when paths or symlinks contain trailing slashes.
+  [GHSA-vqjp-4c8c-hfgg](https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-vqjp-4c8c-hfgg)
+
+--------------------------------------------------------------------------------
+
 ## 24.0.12
 
 Released 2026-07-31.

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.111.12"
+version = "0.111.13"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"

--- a/cranelift/bitset/Cargo.toml
+++ b/cranelift/bitset/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bitset"
-version = "0.111.12"
+version = "0.111.13"
 description = "Various bitset stuff for use inside Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bitset"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.111.12"
+version = "0.111.13"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -19,7 +19,7 @@ workspace = true
 anyhow = { workspace = true, optional = true, features = ['std'] }
 bumpalo = "3"
 capstone = { workspace = true, optional = true }
-cranelift-codegen-shared = { path = "./shared", version = "0.111.12" }
+cranelift-codegen-shared = { path = "./shared", version = "0.111.13" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
 cranelift-bitset = { workspace = true }
@@ -47,8 +47,8 @@ similar = "2.1.0"
 env_logger = { workspace = true }
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.111.12" }
-cranelift-isle = { path = "../isle/isle", version = "=0.111.12" }
+cranelift-codegen-meta = { path = "meta", version = "0.111.13" }
+cranelift-isle = { path = "../isle/isle", version = "=0.111.13" }
 
 [features]
 default = ["std", "unwind", "host-arch", "timing"]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.111.12"
+version = "0.111.13"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -15,4 +15,4 @@ workspace = true
 rustdoc-args = [ "--document-private-items" ]
 
 [dependencies]
-cranelift-codegen-shared = { path = "../shared", version = "0.111.12" }
+cranelift-codegen-shared = { path = "../shared", version = "0.111.13" }

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.111.12"
+version = "0.111.13"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/control/Cargo.toml
+++ b/cranelift/control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-control"
-version = "0.111.12"
+version = "0.111.13"
 description = "White-box fuzz testing framework"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.111.12"
+version = "0.111.13"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.111.12"
+version = "0.111.13"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.111.12"
+version = "0.111.13"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
-version = "0.111.12"
+version = "0.111.13"
 
 [lints]
 workspace = true

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.111.12"
+version = "0.111.13"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.111.12"
+version = "0.111.13"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.111.12"
+version = "0.111.13"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.111.12"
+version = "0.111.13"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.111.12"
+version = "0.111.13"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.111.12"
+version = "0.111.13"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.111.12"
+version = "0.111.13"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-wasm"
-version = "0.111.12"
+version = "0.111.13"
 authors = ["The Cranelift Project Developers"]
 description = "Translator from WebAssembly to Cranelift IR"
 documentation = "https://docs.rs/cranelift-wasm"

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -206,7 +206,7 @@
 /**
  * \brief Wasmtime version string.
  */
-#define WASMTIME_VERSION "24.0.12"
+#define WASMTIME_VERSION "24.0.13"
 /**
  * \brief Wasmtime major version number.
  */
@@ -218,7 +218,7 @@
 /**
  * \brief Wasmtime patch version number.
  */
-#define WASMTIME_VERSION_PATCH 12
+#define WASMTIME_VERSION_PATCH 13
 
 #ifdef __cplusplus
 extern "C" {

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -53,6 +53,10 @@ audited_as = "0.111.10"
 version = "0.111.12"
 audited_as = "0.111.11"
 
+[[unpublished.cranelift]]
+version = "0.111.13"
+audited_as = "0.111.12"
+
 [[unpublished.cranelift-bforest]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -104,6 +108,10 @@ audited_as = "0.111.10"
 [[unpublished.cranelift-bforest]]
 version = "0.111.12"
 audited_as = "0.111.11"
+
+[[unpublished.cranelift-bforest]]
+version = "0.111.13"
+audited_as = "0.111.12"
 
 [[unpublished.cranelift-bitset]]
 version = "0.111.0"
@@ -157,6 +165,10 @@ audited_as = "0.111.10"
 version = "0.111.12"
 audited_as = "0.111.11"
 
+[[unpublished.cranelift-bitset]]
+version = "0.111.13"
+audited_as = "0.111.12"
+
 [[unpublished.cranelift-codegen]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -208,6 +220,10 @@ audited_as = "0.111.10"
 [[unpublished.cranelift-codegen]]
 version = "0.111.12"
 audited_as = "0.111.11"
+
+[[unpublished.cranelift-codegen]]
+version = "0.111.13"
+audited_as = "0.111.12"
 
 [[unpublished.cranelift-codegen-meta]]
 version = "0.111.0"
@@ -261,6 +277,10 @@ audited_as = "0.111.10"
 version = "0.111.12"
 audited_as = "0.111.11"
 
+[[unpublished.cranelift-codegen-meta]]
+version = "0.111.13"
+audited_as = "0.111.12"
+
 [[unpublished.cranelift-codegen-shared]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -312,6 +332,10 @@ audited_as = "0.111.10"
 [[unpublished.cranelift-codegen-shared]]
 version = "0.111.12"
 audited_as = "0.111.11"
+
+[[unpublished.cranelift-codegen-shared]]
+version = "0.111.13"
+audited_as = "0.111.12"
 
 [[unpublished.cranelift-control]]
 version = "0.111.0"
@@ -365,6 +389,10 @@ audited_as = "0.111.10"
 version = "0.111.12"
 audited_as = "0.111.11"
 
+[[unpublished.cranelift-control]]
+version = "0.111.13"
+audited_as = "0.111.12"
+
 [[unpublished.cranelift-entity]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -417,6 +445,10 @@ audited_as = "0.111.10"
 version = "0.111.12"
 audited_as = "0.111.11"
 
+[[unpublished.cranelift-entity]]
+version = "0.111.13"
+audited_as = "0.111.12"
+
 [[unpublished.cranelift-frontend]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -469,6 +501,10 @@ audited_as = "0.111.10"
 version = "0.111.12"
 audited_as = "0.111.11"
 
+[[unpublished.cranelift-frontend]]
+version = "0.111.13"
+audited_as = "0.111.12"
+
 [[unpublished.cranelift-interpreter]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -521,6 +557,10 @@ audited_as = "0.111.10"
 version = "0.111.12"
 audited_as = "0.111.11"
 
+[[unpublished.cranelift-interpreter]]
+version = "0.111.13"
+audited_as = "0.111.12"
+
 [[unpublished.cranelift-isle]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -573,6 +613,10 @@ audited_as = "0.111.10"
 version = "0.111.12"
 audited_as = "0.111.11"
 
+[[unpublished.cranelift-isle]]
+version = "0.111.13"
+audited_as = "0.111.12"
+
 [[unpublished.cranelift-jit]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -625,6 +669,10 @@ audited_as = "0.111.10"
 version = "0.111.12"
 audited_as = "0.111.11"
 
+[[unpublished.cranelift-jit]]
+version = "0.111.13"
+audited_as = "0.111.12"
+
 [[unpublished.cranelift-module]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -677,6 +725,10 @@ audited_as = "0.111.10"
 version = "0.111.12"
 audited_as = "0.111.11"
 
+[[unpublished.cranelift-module]]
+version = "0.111.13"
+audited_as = "0.111.12"
+
 [[unpublished.cranelift-native]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -729,6 +781,10 @@ audited_as = "0.111.10"
 version = "0.111.12"
 audited_as = "0.111.11"
 
+[[unpublished.cranelift-native]]
+version = "0.111.13"
+audited_as = "0.111.12"
+
 [[unpublished.cranelift-object]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -781,6 +837,10 @@ audited_as = "0.111.10"
 version = "0.111.12"
 audited_as = "0.111.11"
 
+[[unpublished.cranelift-object]]
+version = "0.111.13"
+audited_as = "0.111.12"
+
 [[unpublished.cranelift-reader]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -833,6 +893,10 @@ audited_as = "0.111.10"
 version = "0.111.12"
 audited_as = "0.111.11"
 
+[[unpublished.cranelift-reader]]
+version = "0.111.13"
+audited_as = "0.111.12"
+
 [[unpublished.cranelift-serde]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -885,6 +949,10 @@ audited_as = "0.111.10"
 version = "0.111.12"
 audited_as = "0.111.11"
 
+[[unpublished.cranelift-serde]]
+version = "0.111.13"
+audited_as = "0.111.12"
+
 [[unpublished.cranelift-wasm]]
 version = "0.111.0"
 audited_as = "0.110.1"
@@ -937,6 +1005,10 @@ audited_as = "0.111.10"
 version = "0.111.12"
 audited_as = "0.111.11"
 
+[[unpublished.cranelift-wasm]]
+version = "0.111.13"
+audited_as = "0.111.12"
+
 [[unpublished.wasi-common]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -988,6 +1060,10 @@ audited_as = "24.0.10"
 [[unpublished.wasi-common]]
 version = "24.0.12"
 audited_as = "24.0.11"
+
+[[unpublished.wasi-common]]
+version = "24.0.13"
+audited_as = "24.0.12"
 
 [[unpublished.wasmtime]]
 version = "24.0.0"
@@ -1041,6 +1117,10 @@ audited_as = "24.0.10"
 version = "24.0.12"
 audited_as = "24.0.11"
 
+[[unpublished.wasmtime]]
+version = "24.0.13"
+audited_as = "24.0.12"
+
 [[unpublished.wasmtime-asm-macros]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -1092,6 +1172,10 @@ audited_as = "24.0.10"
 [[unpublished.wasmtime-asm-macros]]
 version = "24.0.12"
 audited_as = "24.0.11"
+
+[[unpublished.wasmtime-asm-macros]]
+version = "24.0.13"
+audited_as = "24.0.12"
 
 [[unpublished.wasmtime-cache]]
 version = "24.0.0"
@@ -1145,6 +1229,10 @@ audited_as = "24.0.10"
 version = "24.0.12"
 audited_as = "24.0.11"
 
+[[unpublished.wasmtime-cache]]
+version = "24.0.13"
+audited_as = "24.0.12"
+
 [[unpublished.wasmtime-cli]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -1196,6 +1284,10 @@ audited_as = "24.0.10"
 [[unpublished.wasmtime-cli]]
 version = "24.0.12"
 audited_as = "24.0.11"
+
+[[unpublished.wasmtime-cli]]
+version = "24.0.13"
+audited_as = "24.0.12"
 
 [[unpublished.wasmtime-cli-flags]]
 version = "24.0.0"
@@ -1249,6 +1341,10 @@ audited_as = "24.0.10"
 version = "24.0.12"
 audited_as = "24.0.11"
 
+[[unpublished.wasmtime-cli-flags]]
+version = "24.0.13"
+audited_as = "24.0.12"
+
 [[unpublished.wasmtime-component-macro]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -1301,6 +1397,10 @@ audited_as = "24.0.10"
 version = "24.0.12"
 audited_as = "24.0.11"
 
+[[unpublished.wasmtime-component-macro]]
+version = "24.0.13"
+audited_as = "24.0.12"
+
 [[unpublished.wasmtime-component-util]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -1353,6 +1453,10 @@ audited_as = "24.0.10"
 version = "24.0.12"
 audited_as = "24.0.11"
 
+[[unpublished.wasmtime-component-util]]
+version = "24.0.13"
+audited_as = "24.0.12"
+
 [[unpublished.wasmtime-cranelift]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -1405,6 +1509,10 @@ audited_as = "24.0.10"
 version = "24.0.12"
 audited_as = "24.0.11"
 
+[[unpublished.wasmtime-cranelift]]
+version = "24.0.13"
+audited_as = "24.0.12"
+
 [[unpublished.wasmtime-environ]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -1457,6 +1565,10 @@ audited_as = "24.0.10"
 version = "24.0.12"
 audited_as = "24.0.11"
 
+[[unpublished.wasmtime-environ]]
+version = "24.0.13"
+audited_as = "24.0.12"
+
 [[unpublished.wasmtime-explorer]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -1509,6 +1621,10 @@ audited_as = "24.0.10"
 version = "24.0.12"
 audited_as = "24.0.11"
 
+[[unpublished.wasmtime-explorer]]
+version = "24.0.13"
+audited_as = "24.0.12"
+
 [[unpublished.wasmtime-fiber]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -1561,6 +1677,10 @@ audited_as = "24.0.10"
 version = "24.0.12"
 audited_as = "24.0.11"
 
+[[unpublished.wasmtime-fiber]]
+version = "24.0.13"
+audited_as = "24.0.12"
+
 [[unpublished.wasmtime-jit-debug]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -1613,6 +1733,10 @@ audited_as = "24.0.10"
 version = "24.0.12"
 audited_as = "24.0.11"
 
+[[unpublished.wasmtime-jit-debug]]
+version = "24.0.13"
+audited_as = "24.0.12"
+
 [[unpublished.wasmtime-jit-icache-coherence]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -1665,6 +1789,10 @@ audited_as = "24.0.10"
 version = "24.0.12"
 audited_as = "24.0.11"
 
+[[unpublished.wasmtime-jit-icache-coherence]]
+version = "24.0.13"
+audited_as = "24.0.12"
+
 [[unpublished.wasmtime-slab]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -1717,6 +1845,10 @@ audited_as = "24.0.10"
 version = "24.0.12"
 audited_as = "24.0.11"
 
+[[unpublished.wasmtime-slab]]
+version = "24.0.13"
+audited_as = "24.0.12"
+
 [[unpublished.wasmtime-types]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -1769,6 +1901,10 @@ audited_as = "24.0.10"
 version = "24.0.12"
 audited_as = "24.0.11"
 
+[[unpublished.wasmtime-types]]
+version = "24.0.13"
+audited_as = "24.0.12"
+
 [[unpublished.wasmtime-wasi]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -1821,6 +1957,10 @@ audited_as = "24.0.10"
 version = "24.0.12"
 audited_as = "24.0.11"
 
+[[unpublished.wasmtime-wasi]]
+version = "24.0.13"
+audited_as = "24.0.12"
+
 [[unpublished.wasmtime-wasi-http]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -1872,6 +2012,10 @@ audited_as = "24.0.10"
 [[unpublished.wasmtime-wasi-http]]
 version = "24.0.12"
 audited_as = "24.0.11"
+
+[[unpublished.wasmtime-wasi-http]]
+version = "24.0.13"
+audited_as = "24.0.12"
 
 [[unpublished.wasmtime-wasi-keyvalue]]
 version = "24.0.1"
@@ -1921,6 +2065,10 @@ audited_as = "24.0.10"
 version = "24.0.12"
 audited_as = "24.0.11"
 
+[[unpublished.wasmtime-wasi-keyvalue]]
+version = "24.0.13"
+audited_as = "24.0.12"
+
 [[unpublished.wasmtime-wasi-nn]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -1973,6 +2121,10 @@ audited_as = "24.0.10"
 version = "24.0.12"
 audited_as = "24.0.11"
 
+[[unpublished.wasmtime-wasi-nn]]
+version = "24.0.13"
+audited_as = "24.0.12"
+
 [[unpublished.wasmtime-wasi-runtime-config]]
 version = "24.0.1"
 audited_as = "24.0.0"
@@ -2020,6 +2172,10 @@ audited_as = "24.0.10"
 [[unpublished.wasmtime-wasi-runtime-config]]
 version = "24.0.12"
 audited_as = "24.0.11"
+
+[[unpublished.wasmtime-wasi-runtime-config]]
+version = "24.0.13"
+audited_as = "24.0.12"
 
 [[unpublished.wasmtime-wasi-threads]]
 version = "24.0.0"
@@ -2073,6 +2229,10 @@ audited_as = "24.0.10"
 version = "24.0.12"
 audited_as = "24.0.11"
 
+[[unpublished.wasmtime-wasi-threads]]
+version = "24.0.13"
+audited_as = "24.0.12"
+
 [[unpublished.wasmtime-wast]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -2125,6 +2285,10 @@ audited_as = "24.0.10"
 version = "24.0.12"
 audited_as = "24.0.11"
 
+[[unpublished.wasmtime-wast]]
+version = "24.0.13"
+audited_as = "24.0.12"
+
 [[unpublished.wasmtime-winch]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -2177,6 +2341,10 @@ audited_as = "24.0.10"
 version = "24.0.12"
 audited_as = "24.0.11"
 
+[[unpublished.wasmtime-winch]]
+version = "24.0.13"
+audited_as = "24.0.12"
+
 [[unpublished.wasmtime-wit-bindgen]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -2229,6 +2397,10 @@ audited_as = "24.0.10"
 version = "24.0.12"
 audited_as = "24.0.11"
 
+[[unpublished.wasmtime-wit-bindgen]]
+version = "24.0.13"
+audited_as = "24.0.12"
+
 [[unpublished.wasmtime-wmemcheck]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -2281,6 +2453,10 @@ audited_as = "24.0.10"
 version = "24.0.12"
 audited_as = "24.0.11"
 
+[[unpublished.wasmtime-wmemcheck]]
+version = "24.0.13"
+audited_as = "24.0.12"
+
 [[unpublished.wiggle]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -2333,6 +2509,10 @@ audited_as = "24.0.10"
 version = "24.0.12"
 audited_as = "24.0.11"
 
+[[unpublished.wiggle]]
+version = "24.0.13"
+audited_as = "24.0.12"
+
 [[unpublished.wiggle-generate]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -2385,6 +2565,10 @@ audited_as = "24.0.10"
 version = "24.0.12"
 audited_as = "24.0.11"
 
+[[unpublished.wiggle-generate]]
+version = "24.0.13"
+audited_as = "24.0.12"
+
 [[unpublished.wiggle-macro]]
 version = "24.0.0"
 audited_as = "23.0.1"
@@ -2436,6 +2620,10 @@ audited_as = "24.0.10"
 [[unpublished.wiggle-macro]]
 version = "24.0.12"
 audited_as = "24.0.11"
+
+[[unpublished.wiggle-macro]]
+version = "24.0.13"
+audited_as = "24.0.12"
 
 [[unpublished.wiggle-test]]
 version = "0.0.0"
@@ -2492,6 +2680,10 @@ audited_as = "0.22.10"
 [[unpublished.winch-codegen]]
 version = "0.22.12"
 audited_as = "0.22.11"
+
+[[unpublished.winch-codegen]]
+version = "0.22.13"
+audited_as = "0.22.12"
 
 [[publisher.aho-corasick]]
 version = "1.0.2"

--- a/winch/codegen/Cargo.toml
+++ b/winch/codegen/Cargo.toml
@@ -4,7 +4,7 @@ name = "winch-codegen"
 description = "Winch code generation library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
-version = "0.22.12"
+version = "0.22.13"
 edition.workspace = true
 
 [lints]


### PR DESCRIPTION
This is an [automated pull request][process] from CI to create a patch release for Wasmtime 24.0.13, requested by @alexcrichton.

It's recommended that maintainers double-check that [RELEASES.md] is up-to-date and that there are no known issues before merging this PR. When this PR is merged a release tag will automatically be created, crates will be published, and CI artifacts will be produced.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/release-24.0.13/RELEASES.md
[process]: https://docs.wasmtime.dev/contributing-release-process.html
