### PR TITLE
[46.0.x] Backports for security fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,9 +357,9 @@ dependencies = [
 
 [[package]]
 name = "cap-fs-ext"
-version = "3.4.5"
+version = "3.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5528f85b1e134ae811704e41ef80930f56e795923f866813255bc342cc20654"
+checksum = "476f0d0003a760918ed4b1e039a59e11769030416f79c8222551d22785f7f70d"
 dependencies = [
  "cap-primitives",
  "cap-std",
@@ -369,9 +369,9 @@ dependencies = [
 
 [[package]]
 name = "cap-net-ext"
-version = "3.4.5"
+version = "3.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a158160765c6a7d0d8c072a53d772e4cb243f38b04bfcf6b4939cfbe7482e7"
+checksum = "150941cefd3df4de2fea24604ba4949371576f62e527410298333f7d431a1bc6"
 dependencies = [
  "cap-primitives",
  "cap-std",
@@ -381,9 +381,9 @@ dependencies = [
 
 [[package]]
 name = "cap-primitives"
-version = "3.4.5"
+version = "3.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6cf3aea8a5081171859ef57bc1606b1df6999df4f1110f8eef68b30098d1d3a"
+checksum = "8e0bf07d379916947be6c4a07f43684153d710a2896c31f9e97781362895596c"
 dependencies = [
  "ambient-authority",
  "fs-set-times",
@@ -399,9 +399,9 @@ dependencies = [
 
 [[package]]
 name = "cap-std"
-version = "3.4.5"
+version = "3.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6dc3090992a735d23219de5c204927163d922f42f575a0189b005c62d37549a"
+checksum = "a59e59fa26472d29680ece6a9f8ee8b0551a719a33df2f5240bde065ecbddfd7"
 dependencies = [
  "cap-primitives",
  "io-extras",
@@ -411,9 +411,9 @@ dependencies = [
 
 [[package]]
 name = "cap-time-ext"
-version = "3.4.5"
+version = "3.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def102506ce40c11710a9b16e614af0cde8e76ae51b1f48c04b8d79f4b671a80"
+checksum = "b54c289326c70f1c697ebf0a31842a480932e5942b5fac92fcc46e87286b48e2"
 dependencies = [
  "ambient-authority",
  "cap-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -351,11 +351,11 @@ wasip1 = { version = "1.0.0", default-features = false }
 
 # cap-std family:
 target-lexicon = "0.13.3"
-cap-std = "3.4.5"
-cap-fs-ext = "3.4.5"
-cap-net-ext = "3.4.5"
-cap-time-ext = "3.4.5"
-cap-tempfile = "3.4.5"
+cap-std = "3.4.6"
+cap-fs-ext = "3.4.6"
+cap-net-ext = "3.4.6"
+cap-time-ext = "3.4.6"
+cap-tempfile = "3.4.6"
 fs-set-times = "0.20.3"
 system-interface = { version = "0.27.3", features = ["cap_std_impls"] }
 io-lifetimes = { version = "2.0.3", default-features = false }

--- a/crates/test-programs/src/bin/p3_file_write_chunked.rs
+++ b/crates/test-programs/src/bin/p3_file_write_chunked.rs
@@ -1,0 +1,85 @@
+use futures::join;
+use test_programs::p3::wasi::filesystem::types::{
+    Descriptor, DescriptorFlags, OpenFlags, PathFlags,
+};
+use test_programs::p3::{wasi, wit_stream};
+use wit_bindgen::StreamResult;
+
+struct Component;
+
+test_programs::p3::export!(Component);
+
+impl test_programs::p3::exports::wasi::cli::run::Guest for Component {
+    async fn run() -> Result<(), ()> {
+        let preopens = wasi::filesystem::preopens::get_directories();
+        let (dir, _) = &preopens[0];
+        test_chunked_write(dir, "chunked_write.txt").await;
+        Ok(())
+    }
+}
+
+fn bytes(offset: &mut usize, len: usize) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(len);
+    for i in 0..len {
+        buf.push(((*offset + i) % 251) as u8);
+    }
+    *offset += len;
+    buf
+}
+
+async fn test_chunked_write(dir: &Descriptor, filename: &str) {
+    let mut len = 16;
+    let mut pos = 0;
+
+    let file = dir
+        .open_at(
+            PathFlags::empty(),
+            filename.to_string(),
+            OpenFlags::CREATE,
+            DescriptorFlags::READ | DescriptorFlags::WRITE,
+        )
+        .await
+        .expect("creating a file for writing");
+
+    let (mut tx, rx) = wit_stream::new();
+    join! {
+        async {
+            file.write_via_stream(rx, 0).await.unwrap();
+        },
+        async {
+            loop {
+                // Wasmtime shouldn't buffer this much data by default on the
+                // host, something should have done a short write earlier.
+                assert!(len <= 128 << 20);
+                let (result, remaining) = tx.write(bytes(&mut pos, len)).await;
+                std::assert_matches!(result, StreamResult::Complete(_));
+                if remaining.remaining() == 0 {
+                    len = len.checked_mul(2).unwrap();
+                } else {
+                    pos -= remaining.remaining();
+                    break;
+                }
+            }
+            drop(tx);
+        },
+    };
+
+    let expected = bytes(&mut 0, pos);
+    let (rx, result) = file.read_via_stream(0);
+    let read_back = rx.collect().await;
+    result.await.unwrap();
+
+    assert_eq!(
+        read_back.len(),
+        expected.len(),
+        "wrong number of bytes read back"
+    );
+    assert!(
+        read_back == expected,
+        "contents differ after a chunked write"
+    );
+}
+
+fn main() {
+    unreachable!()
+}

--- a/crates/test-programs/src/bin/p3_file_write_chunked.rs
+++ b/crates/test-programs/src/bin/p3_file_write_chunked.rs
@@ -52,7 +52,7 @@ async fn test_chunked_write(dir: &Descriptor, filename: &str) {
                 // host, something should have done a short write earlier.
                 assert!(len <= 128 << 20);
                 let (result, remaining) = tx.write(bytes(&mut pos, len)).await;
-                std::assert_matches!(result, StreamResult::Complete(_));
+                assert!(matches!(result, StreamResult::Complete(_)), "bad result {result:?}");
                 if remaining.remaining() == 0 {
                     len = len.checked_mul(2).unwrap();
                 } else {

--- a/crates/test-programs/src/bin/p3_http_outbound_request_chunk_size.rs
+++ b/crates/test-programs/src/bin/p3_http_outbound_request_chunk_size.rs
@@ -1,0 +1,86 @@
+use futures::join;
+use test_programs::p3::wasi::http::client;
+use test_programs::p3::wasi::http::types::{Headers, Method, Request, Response, Scheme};
+use test_programs::p3::{wit_future, wit_stream};
+use wit_bindgen::StreamResult;
+
+struct Component;
+
+test_programs::p3::export!(Component);
+
+fn bytes(offset: &mut usize, len: usize) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(len);
+    for i in 0..len {
+        buf.push(((*offset + i) % 251) as u8);
+    }
+    *offset += len;
+    buf
+}
+
+fn addr() -> String {
+    test_programs::p3::wasi::cli::environment::get_environment()
+        .into_iter()
+        .find_map(|(k, v)| k.eq("HTTP_SERVER").then_some(v))
+        .unwrap()
+}
+
+impl test_programs::p3::exports::wasi::cli::run::Guest for Component {
+    async fn run() -> Result<(), ()> {
+        test_chunked_write().await;
+        Ok(())
+    }
+}
+
+async fn test_chunked_write() {
+    let headers = Headers::from_list(&[]).unwrap();
+    let (mut contents_tx, contents_rx) = wit_stream::new();
+    let (trailers_tx, trailers_rx) = wit_future::new(|| Ok(None));
+    let (request, transmit) = Request::new(headers, Some(contents_rx), trailers_rx, None);
+    configure(&request);
+
+    let (transmit, written, echoed) = join!(
+        async { transmit.await },
+        async {
+            let mut len = 16;
+            let mut pos = 0;
+            loop {
+                assert!(len <= 128 << 20);
+                let (result, remaining) = contents_tx.write(bytes(&mut pos, len)).await;
+                assert_eq!(result, StreamResult::Complete(len - remaining.remaining()));
+                if remaining.remaining() == 0 {
+                    len = len.checked_mul(2).unwrap();
+                } else {
+                    pos -= remaining.remaining();
+                    break;
+                }
+            }
+            drop(contents_tx);
+            _ = trailers_tx.write(Ok(None)).await;
+            pos
+        },
+        async { send_and_collect(request).await },
+    );
+    transmit.unwrap();
+    assert_eq!(echoed, bytes(&mut 0, written));
+}
+
+fn configure(request: &Request) {
+    request.set_method(&Method::Post).unwrap();
+    request.set_scheme(Some(&Scheme::Http)).unwrap();
+    request.set_authority(Some(&addr())).unwrap();
+    request.set_path_with_query(Some("/")).unwrap();
+}
+
+async fn send_and_collect(request: Request) -> Vec<u8> {
+    let response = client::send(request).await.unwrap();
+    assert_eq!(response.get_status_code(), 200);
+    let (_, result_rx) = wit_future::new(|| Ok(()));
+    let (body_rx, trailers_rx) = Response::consume_body(response, result_rx);
+    let body = body_rx.collect().await;
+    trailers_rx.await.unwrap();
+    body
+}
+
+fn main() {
+    unreachable!()
+}

--- a/crates/wasi-http/src/p3/body.rs
+++ b/crates/wasi-http/src/p3/body.rs
@@ -139,6 +139,7 @@ struct LimitedGuestBodyConsumer {
     limit: u64,
     /// Number of bytes sent
     sent: u64,
+    max_chunk_size: usize,
     // `true` when the other side of `contents_tx` was unexpectedly closed
     closed: bool,
 }
@@ -179,7 +180,8 @@ impl<D> StreamConsumer<D> for LimitedGuestBodyConsumer {
         debug_assert!(!self.closed);
         let mut src = src.as_direct(store);
         let buf = src.remaining();
-        let n = buf.len();
+        let n = buf.len().min(self.max_chunk_size);
+        let buf = &buf[..n];
 
         // Perform `content-length` check early and precompute the next value
         let Ok(sent) = n.try_into() else {
@@ -222,7 +224,10 @@ impl<D> StreamConsumer<D> for LimitedGuestBodyConsumer {
 
 /// [StreamConsumer] implementation for bodies originating in the guest without `Content-Length`
 /// header set.
-struct UnlimitedGuestBodyConsumer(PollSender<Result<Bytes, ErrorCode>>);
+struct UnlimitedGuestBodyConsumer {
+    contents_tx: PollSender<Result<Bytes, ErrorCode>>,
+    max_chunk_size: usize,
+}
 
 impl<D> StreamConsumer<D> for UnlimitedGuestBodyConsumer {
     type Item = u8;
@@ -234,13 +239,13 @@ impl<D> StreamConsumer<D> for UnlimitedGuestBodyConsumer {
         src: Source<Self::Item>,
         finish: bool,
     ) -> Poll<wasmtime::Result<StreamResult>> {
-        match self.0.poll_reserve(cx) {
+        match self.contents_tx.poll_reserve(cx) {
             Poll::Ready(Ok(())) => {
                 let mut src = src.as_direct(store);
                 let buf = src.remaining();
-                let n = buf.len();
-                let buf = Bytes::copy_from_slice(buf);
-                match self.0.send_item(Ok(buf)) {
+                let n = buf.len().min(self.max_chunk_size);
+                let buf = Bytes::copy_from_slice(&buf[..n]);
+                match self.contents_tx.send_item(Ok(buf)) {
                     Ok(()) => {
                         src.mark_read(n);
                         Poll::Ready(Ok(StreamResult::Completed))
@@ -283,6 +288,11 @@ impl GuestBody {
             },
         )?;
 
+        let max_chunk_size = getter(store.as_context_mut().data_mut())
+            .hooks
+            .p3_outgoing_body_chunk_size()
+            .max(1);
+
         let contents_rx = if let Some(rx) = contents_rx {
             let (http_tx, http_rx) = mpsc::channel(1);
             let contents_tx = PollSender::new(http_tx);
@@ -302,12 +312,19 @@ impl GuestBody {
                         make_error,
                         limit,
                         sent: 0,
+                        max_chunk_size,
                         closed: false,
                     },
                 )?;
             } else {
                 _ = result_tx.send(Box::new(result_fut));
-                rx.pipe(store, UnlimitedGuestBodyConsumer(contents_tx))?;
+                rx.pipe(
+                    store,
+                    UnlimitedGuestBodyConsumer {
+                        contents_tx,
+                        max_chunk_size,
+                    },
+                )?;
             };
             Some(http_rx)
         } else {

--- a/crates/wasi-http/src/p3/mod.rs
+++ b/crates/wasi-http/src/p3/mod.rs
@@ -21,9 +21,7 @@ pub use request::default_send_request;
 pub use request::{Request, RequestOptions};
 pub use response::Response;
 
-/// The default value configured for [`WasiHttpHooks::p3_outgoing_body_chunk_size`].
-///
-/// [`WasiHttpHooks::p3_outgoing_body_chunk_size`]: crate::WasiHttpHooks::p3_outgoing_body_chunk_size
+/// The default value configured for `WasiHttpHooks::p3_outgoing_body_chunk_size`.
 pub const DEFAULT_OUTGOING_BODY_CHUNK_SIZE: usize = 1024 * 1024;
 
 use crate::p3::bindings::http::types::ErrorCode;

--- a/crates/wasi-http/src/p3/mod.rs
+++ b/crates/wasi-http/src/p3/mod.rs
@@ -21,6 +21,11 @@ pub use request::default_send_request;
 pub use request::{Request, RequestOptions};
 pub use response::Response;
 
+/// The default value configured for [`WasiHttpHooks::p3_outgoing_body_chunk_size`].
+///
+/// [`WasiHttpHooks::p3_outgoing_body_chunk_size`]: crate::WasiHttpHooks::p3_outgoing_body_chunk_size
+pub const DEFAULT_OUTGOING_BODY_CHUNK_SIZE: usize = 1024 * 1024;
+
 use crate::p3::bindings::http::types::ErrorCode;
 use crate::{DEFAULT_FORBIDDEN_HEADERS, FieldMapError, WasiHttpCtx};
 use bindings::http::{client, types};
@@ -160,6 +165,13 @@ pub trait WasiHttpHooks: Send {
                 )>,
             > + Send,
     >;
+
+    /// Maximum number of bytes the implementation will copy out of the guest in
+    /// a single write to an outgoing body's stream.
+    #[cfg(feature = "p3")]
+    fn p3_outgoing_body_chunk_size(&mut self) -> usize {
+        crate::p3::DEFAULT_OUTGOING_BODY_CHUNK_SIZE
+    }
 }
 
 #[cfg(feature = "default-send-request")]

--- a/crates/wasi-http/tests/all/p3/mod.rs
+++ b/crates/wasi-http/tests/all/p3/mod.rs
@@ -130,6 +130,7 @@ async fn run_cli(path: &str, server: &Server) -> wasmtime::Result<()> {
         Ctx {
             wasi: wasmtime_wasi::WasiCtx::builder()
                 .env("HTTP_SERVER", server.addr())
+                .inherit_stdio()
                 .build(),
             ..Ctx::new(oneshot::channel().0)
         },
@@ -820,4 +821,10 @@ async fn p3_http_empty_frames_interleaved() -> Result<()> {
     let collected_body = collected_body.to_bytes();
     assert_eq!(collected_body, b"hello world".as_slice());
     Ok(())
+}
+
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn p3_http_outbound_request_chunk_size() -> Result<()> {
+    let server = Server::http1(1)?;
+    run_cli(P3_HTTP_OUTBOUND_REQUEST_CHUNK_SIZE_COMPONENT, &server).await
 }

--- a/crates/wasi/src/p3/filesystem/host.rs
+++ b/crates/wasi/src/p3/filesystem/host.rs
@@ -464,7 +464,9 @@ impl<D> StreamConsumer<D> for WriteStreamConsumer {
         let me = &mut *self;
         let task = me.task.get_or_insert_with(|| {
             debug_assert!(me.buffer.is_empty());
-            me.buffer.extend_from_slice(src.remaining());
+            let remaining = src.remaining();
+            let n = remaining.len().min(DEFAULT_BUFFER_CAPACITY);
+            me.buffer.extend_from_slice(&remaining[..n]);
             let buf = mem::take(&mut me.buffer);
             let file = Arc::clone(me.file.as_file());
             let location = me.location;

--- a/crates/wasi/tests/all/p3/mod.rs
+++ b/crates/wasi/tests/all/p3/mod.rs
@@ -186,6 +186,11 @@ async fn p3_file_write_blocking() -> wasmtime::Result<()> {
 }
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn p3_file_write_chunked() -> wasmtime::Result<()> {
+    run(P3_FILE_WRITE_CHUNKED_COMPONENT).await
+}
+
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn p3_file_truncation_readonly() -> wasmtime::Result<()> {
     run_with_readonly_testfile(P3_FILE_TRUNCATION_READONLY_COMPONENT).await
 }

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -6847,7 +6847,7 @@ end = "2025-12-05"
 criteria = "safe-to-deploy"
 user-id = 6825 # Dan Gohman (sunfishcode)
 start = "2020-12-11"
-end = "2024-07-14"
+end = "2027-08-20"
 
 [[trusted.cap-net-ext]]
 criteria = "safe-to-deploy"
@@ -6855,11 +6855,17 @@ user-id = 6825 # Dan Gohman (sunfishcode)
 start = "2020-12-11"
 end = "2024-07-14"
 
+[[trusted.cap-net-ext]]
+criteria = "safe-to-deploy"
+user-id = 6825 # Dan Gohman (sunfishcode)
+start = "2023-04-07"
+end = "2027-08-20"
+
 [[trusted.cap-primitives]]
 criteria = "safe-to-deploy"
 user-id = 6825 # Dan Gohman (sunfishcode)
 start = "2020-08-07"
-end = "2024-07-14"
+end = "2027-08-20"
 
 [[trusted.cap-rand]]
 criteria = "safe-to-deploy"
@@ -6871,7 +6877,7 @@ end = "2024-07-14"
 criteria = "safe-to-deploy"
 user-id = 6825 # Dan Gohman (sunfishcode)
 start = "2020-06-25"
-end = "2024-07-14"
+end = "2027-08-20"
 
 [[trusted.cap-tempfile]]
 criteria = "safe-to-deploy"
@@ -6883,7 +6889,7 @@ end = "2024-07-14"
 criteria = "safe-to-deploy"
 user-id = 6825 # Dan Gohman (sunfishcode)
 start = "2020-09-21"
-end = "2024-07-14"
+end = "2027-08-20"
 
 [[trusted.cc]]
 criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1045,36 +1045,36 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.cap-fs-ext]]
-version = "3.2.0"
-when = "2024-07-08"
+version = "3.4.6"
+when = "2026-08-20"
 user-id = 6825
 user-login = "sunfishcode"
 user-name = "Dan Gohman"
 
 [[publisher.cap-net-ext]]
-version = "3.2.0"
-when = "2024-07-08"
+version = "3.4.6"
+when = "2026-08-20"
 user-id = 6825
 user-login = "sunfishcode"
 user-name = "Dan Gohman"
 
 [[publisher.cap-primitives]]
-version = "3.2.0"
-when = "2024-07-08"
+version = "3.4.6"
+when = "2026-08-20"
 user-id = 6825
 user-login = "sunfishcode"
 user-name = "Dan Gohman"
 
 [[publisher.cap-std]]
-version = "3.2.0"
-when = "2024-07-08"
+version = "3.4.6"
+when = "2026-08-20"
 user-id = 6825
 user-login = "sunfishcode"
 user-name = "Dan Gohman"
 
 [[publisher.cap-time-ext]]
-version = "3.2.0"
-when = "2024-07-08"
+version = "3.4.6"
+when = "2026-08-20"
 user-id = 6825
 user-login = "sunfishcode"
 user-name = "Dan Gohman"


### PR DESCRIPTION
Backporting fixes for these advisories:

* https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-x84v-gj2h-g759
* https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-vqjp-4c8c-hfgg
