### PR TITLE
[47.0.x] Add release notes

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,17 @@
+## 47.0.4
+
+Released 2026-08-20
+
+### Fixed
+
+* Guest controlled-size host heap allocation through WASIp3 streams.
+  [GHSA-x84v-gj2h-g759](https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-x84v-gj2h-g759)
+
+* Filesystem sandbox escape when paths or symlinks contain trailing slashes.
+  [GHSA-vqjp-4c8c-hfgg](https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-vqjp-4c8c-hfgg)
+
+--------------------------------------------------------------------------------
+
 ## 47.0.3
 
 Released 2026-07-31.


### PR DESCRIPTION
Forgot to add this in the previous backport PR so I cancelled the in-flight workflow for publishing the release and this will re-trigger it.