### PR TITLE
Bump MSRV to 1.96.0

### DIFF
--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -32,7 +32,7 @@ runs:
         elif [ "${{ inputs.toolchain }}" = "msrv" ]; then
           echo "version=1.$msrv.0" >> "$GITHUB_OUTPUT"
         elif [ "${{ inputs.toolchain }}" = "wasmtime-ci-pinned-nightly" ]; then
-          echo "version=nightly-2026-08-12" >> "$GITHUB_OUTPUT"
+          echo "version=nightly-2026-08-20" >> "$GITHUB_OUTPUT"
         elif [ "${{ inputs.toolchain }}" = "wasmtime-ci-oss-fuzz-pin" ]; then
           # Do not change this number unless OSS-Fuzz has updated. If you update
           # this version and do not update OSS-Fuzz then you will break our

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -225,7 +225,7 @@ authors = ["The Wasmtime Project Developers"]
 edition = "2024"
 # Wasmtime's current policy is that this number can be no larger than the
 # current stable release of Rust minus 2.
-rust-version = "1.95.0"
+rust-version = "1.96.0"
 
 [workspace.lints.rust]
 # Turn on some lints which are otherwise allow-by-default in rustc.

--- a/crates/fiber/src/windows.rs
+++ b/crates/fiber/src/windows.rs
@@ -178,7 +178,19 @@ impl Fiber {
 impl Drop for Fiber {
     fn drop(&mut self) {
         unsafe {
+            let is_fiber = IsThreadAFiber() != 0;
+            if !is_fiber {
+                // DeleteFiber runs FLS destructors. Make those destructors
+                // observe a fiber so Rust does not run thread-local cleanup
+                // for the live thread.
+                let fiber = ConvertThreadToFiber(ptr::null_mut());
+                assert!(!fiber.is_null(), "failed to make current thread a fiber");
+            }
             DeleteFiber(self.fiber);
+            if !is_fiber {
+                let res = ConvertFiberToThread();
+                assert!(res != 0, "failed to convert main thread back");
+            }
         }
     }
 }


### PR DESCRIPTION
Coupled with today's release of Rust 1.98.0



<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please review the Bytecode Alliance's AI tool usage policy at
https://github.com/bytecodealliance/governance/blob/main/AI_TOOL_POLICY.md

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
