### PR TITLE
Release Wasmtime 48.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,7 +287,7 @@ dependencies = [
 
 [[package]]
 name = "byte-array-literals"
-version = "48.0.0"
+version = "48.0.1"
 
 [[package]]
 name = "byteorder"
@@ -673,7 +673,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.135.0"
+version = "0.135.1"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -686,7 +686,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.135.0"
+version = "0.135.1"
 dependencies = [
  "arbitrary",
  "arbtest",
@@ -705,14 +705,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.135.0"
+version = "0.135.1"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.135.0"
+version = "0.135.1"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -720,7 +720,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.135.0"
+version = "0.135.1"
 dependencies = [
  "arbitrary",
  "serde",
@@ -730,7 +730,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.135.0"
+version = "0.135.1"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -767,7 +767,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.135.0"
+version = "0.135.1"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -778,18 +778,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.135.0"
+version = "0.135.1"
 
 [[package]]
 name = "cranelift-control"
-version = "0.135.0"
+version = "0.135.1"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.135.0"
+version = "0.135.1"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.135.0"
+version = "0.135.1"
 dependencies = [
  "cranelift-codegen",
  "env_logger 0.11.5",
@@ -856,7 +856,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.135.0"
+version = "0.135.1"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -870,7 +870,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.135.0"
+version = "0.135.1"
 dependencies = [
  "codespan-reporting",
  "log",
@@ -954,7 +954,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.135.0"
+version = "0.135.1"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -976,7 +976,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.135.0"
+version = "0.135.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -988,7 +988,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.135.0"
+version = "0.135.1"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -997,7 +997,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.135.0"
+version = "0.135.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -1013,7 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-reader"
-version = "0.135.0"
+version = "0.135.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -1023,7 +1023,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.135.0"
+version = "0.135.1"
 dependencies = [
  "clap",
  "cranelift-codegen",
@@ -1033,7 +1033,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.135.0"
+version = "0.135.1"
 
 [[package]]
 name = "cranelift-tools"
@@ -1294,7 +1294,7 @@ checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "embedding"
-version = "48.0.0"
+version = "48.0.1"
 dependencies = [
  "dlmalloc",
  "raw-cpuid",
@@ -2462,7 +2462,7 @@ dependencies = [
 
 [[package]]
 name = "min-platform-host"
-version = "48.0.0"
+version = "48.0.1"
 dependencies = [
  "libloading",
  "object 0.39.0",
@@ -2987,7 +2987,7 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "48.0.0"
+version = "48.0.1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -3011,7 +3011,7 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "48.0.0"
+version = "48.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4274,7 +4274,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "verify-component-adapter"
-version = "48.0.0"
+version = "48.0.1"
 dependencies = [
  "anyhow",
  "wasmparser 0.254.0",
@@ -4348,7 +4348,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter"
-version = "48.0.0"
+version = "48.0.1"
 dependencies = [
  "bitflags 2.11.1",
  "byte-array-literals",
@@ -4580,7 +4580,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "48.0.0"
+version = "48.0.1"
 dependencies = [
  "addr2line 0.26.0",
  "async-trait",
@@ -4641,7 +4641,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-bench-api"
-version = "48.0.0"
+version = "48.0.1"
 dependencies = [
  "clap",
  "shuffling-allocator",
@@ -4655,14 +4655,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api"
-version = "48.0.0"
+version = "48.0.1"
 dependencies = [
  "wasmtime-c-api-impl",
 ]
 
 [[package]]
 name = "wasmtime-c-api-impl"
-version = "48.0.0"
+version = "48.0.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4681,7 +4681,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "48.0.0"
+version = "48.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4758,7 +4758,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "48.0.0"
+version = "48.0.1"
 dependencies = [
  "clap",
  "file-per-thread-logger",
@@ -4772,7 +4772,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "48.0.0"
+version = "48.0.1"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -4889,7 +4889,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-c-api-macros"
-version = "48.0.0"
+version = "48.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4897,7 +4897,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "48.0.0"
+version = "48.0.1"
 dependencies = [
  "base64",
  "directories-next",
@@ -4918,7 +4918,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "48.0.0"
+version = "48.0.1"
 dependencies = [
  "anyhow",
  "component-macro-test-helpers",
@@ -4938,11 +4938,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "48.0.0"
+version = "48.0.1"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "48.0.0"
+version = "48.0.1"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.0",
@@ -4952,7 +4952,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "48.0.0"
+version = "48.0.1"
 dependencies = [
  "cranelift-codegen",
  "cranelift-control",
@@ -4976,7 +4976,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-debugger"
-version = "48.0.0"
+version = "48.0.1"
 dependencies = [
  "async-trait",
  "env_logger 0.11.5",
@@ -4989,7 +4989,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-explorer"
-version = "48.0.0"
+version = "48.0.1"
 dependencies = [
  "capstone",
  "serde",
@@ -5003,7 +5003,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "48.0.0"
+version = "48.0.1"
 dependencies = [
  "backtrace",
  "cc",
@@ -5016,7 +5016,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-gdbstub-component"
-version = "48.0.0"
+version = "48.0.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -5032,11 +5032,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-gdbstub-component-artifact"
-version = "48.0.0"
+version = "48.0.1"
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "48.0.0"
+version = "48.0.1"
 dependencies = [
  "cc",
  "object 0.39.0",
@@ -5046,7 +5046,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "48.0.0"
+version = "48.0.1"
 dependencies = [
  "libc",
  "wasmtime-internal-core",
@@ -5055,7 +5055,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "48.0.0"
+version = "48.0.1"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -5065,7 +5065,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "48.0.0"
+version = "48.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5074,7 +5074,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "48.0.0"
+version = "48.0.1"
 dependencies = [
  "cranelift-codegen",
  "gimli 0.33.0",
@@ -5089,7 +5089,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "48.0.0"
+version = "48.0.1"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
@@ -5101,7 +5101,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wmemcheck"
-version = "48.0.0"
+version = "48.0.1"
 
 [[package]]
 name = "wasmtime-test-macros"
@@ -5116,7 +5116,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-test-util"
-version = "48.0.0"
+version = "48.0.1"
 dependencies = [
  "arbitrary",
  "arbtest",
@@ -5139,7 +5139,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "48.0.0"
+version = "48.0.1"
 dependencies = [
  "async-trait",
  "bitflags 2.11.1",
@@ -5167,7 +5167,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-config"
-version = "48.0.0"
+version = "48.0.1"
 dependencies = [
  "test-programs-artifacts",
  "tokio",
@@ -5177,7 +5177,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "48.0.0"
+version = "48.0.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -5210,7 +5210,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "48.0.0"
+version = "48.0.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5221,7 +5221,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-keyvalue"
-version = "48.0.0"
+version = "48.0.1"
 dependencies = [
  "test-programs-artifacts",
  "tokio",
@@ -5231,7 +5231,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "48.0.0"
+version = "48.0.1"
 dependencies = [
  "libtest-mimic",
  "openvino",
@@ -5250,7 +5250,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-tls"
-version = "48.0.0"
+version = "48.0.1"
 dependencies = [
  "bytes",
  "futures",
@@ -5270,7 +5270,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "48.0.0"
+version = "48.0.1"
 dependencies = [
  "json-from-wast",
  "log",
@@ -5284,7 +5284,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wizer"
-version = "48.0.0"
+version = "48.0.1"
 dependencies = [
  "clap",
  "criterion",
@@ -5365,7 +5365,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "48.0.0"
+version = "48.0.1"
 dependencies = [
  "bitflags 2.11.1",
  "proptest",
@@ -5381,7 +5381,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "48.0.0"
+version = "48.0.1"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -5393,7 +5393,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "48.0.0"
+version = "48.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5448,7 +5448,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "48.0.0"
+version = "48.0.1"
 dependencies = [
  "cranelift-assembler-x64",
  "cranelift-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -219,7 +219,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "48.0.0"
+version = "48.0.1"
 authors = ["The Wasmtime Project Developers"]
 edition = "2024"
 # Wasmtime's current policy is that this number can be no larger than the
@@ -280,17 +280,17 @@ extra_unused_type_parameters = 'warn'
 # tooling but aren't intended to be widely depended on.
 #
 # All of these crates are supported though in the sense that
-wasmtime = { path = "crates/wasmtime", version = "48.0.0", default-features = false }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=48.0.0" }
-wasmtime-environ = { path = "crates/environ", version = "=48.0.0" }
-wasmtime-wasi = { path = "crates/wasi", version = "48.0.0", default-features = false }
-wasmtime-wasi-io = { path = "crates/wasi-io", version = "48.0.0", default-features = false }
-wasmtime-wasi-http = { path = "crates/wasi-http", version = "48.0.0", default-features = false }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "48.0.0" }
-wasmtime-wasi-config = { path = "crates/wasi-config", version = "48.0.0" }
-wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "48.0.0" }
-wasmtime-wasi-tls = { path = "crates/wasi-tls", version = "48.0.0" }
-wasmtime-wast = { path = "crates/wast", version = "=48.0.0" }
+wasmtime = { path = "crates/wasmtime", version = "48.0.1", default-features = false }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=48.0.1" }
+wasmtime-environ = { path = "crates/environ", version = "=48.0.1" }
+wasmtime-wasi = { path = "crates/wasi", version = "48.0.1", default-features = false }
+wasmtime-wasi-io = { path = "crates/wasi-io", version = "48.0.1", default-features = false }
+wasmtime-wasi-http = { path = "crates/wasi-http", version = "48.0.1", default-features = false }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "48.0.1" }
+wasmtime-wasi-config = { path = "crates/wasi-config", version = "48.0.1" }
+wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "48.0.1" }
+wasmtime-wasi-tls = { path = "crates/wasi-tls", version = "48.0.1" }
+wasmtime-wast = { path = "crates/wast", version = "=48.0.1" }
 
 # Internal Wasmtime-specific crates.
 #
@@ -299,54 +299,54 @@ wasmtime-wast = { path = "crates/wast", version = "=48.0.0" }
 # that these are internal unsupported crates for external use. These exist as
 # part of the project organization of other public crates in Wasmtime and are
 # otherwise not supported in terms of CVEs for example.
-wasmtime-core = { path = "crates/core", version = "=48.0.0", package = 'wasmtime-internal-core' }
-wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=48.0.0", package = 'wasmtime-internal-wmemcheck' }
-wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=48.0.0", package = 'wasmtime-internal-c-api-macros' }
-wasmtime-cache = { path = "crates/cache", version = "=48.0.0", package = 'wasmtime-internal-cache' }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=48.0.0", package = 'wasmtime-internal-cranelift' }
-wasmtime-winch = { path = "crates/winch", version = "=48.0.0", package = 'wasmtime-internal-winch'  }
-wasmtime-explorer = { path = "crates/explorer", version = "=48.0.0", package = 'wasmtime-internal-explorer'  }
-wasmtime-fiber = { path = "crates/fiber", version = "=48.0.0", package = 'wasmtime-internal-fiber' }
-wasmtime-jit-debug = { path = "crates/jit-debug", version = "=48.0.0", package = 'wasmtime-internal-jit-debug' }
-wasmtime-component-util = { path = "crates/component-util", version = "=48.0.0", package = 'wasmtime-internal-component-util' }
-wasmtime-component-macro = { path = "crates/component-macro", version = "=48.0.0", package = 'wasmtime-internal-component-macro' }
-wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=48.0.0", package = 'wasmtime-internal-versioned-export-macros' }
-wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=48.0.0", package = 'wasmtime-internal-jit-icache-coherence' }
-wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=48.0.0", package = 'wasmtime-internal-wit-bindgen' }
-wasmtime-unwinder = { path = "crates/unwinder", version = "=48.0.0", package = 'wasmtime-internal-unwinder' }
-wasmtime-debugger = { path = "crates/debugger", version = "=48.0.0", package = "wasmtime-internal-debugger" }
-gdbstub-component-artifact = { path = "crates/gdbstub-component/artifact", version = "=48.0.0", package = "wasmtime-internal-gdbstub-component-artifact" }
-wasmtime-wizer = { path = "crates/wizer", version = "48.0.0" }
+wasmtime-core = { path = "crates/core", version = "=48.0.1", package = 'wasmtime-internal-core' }
+wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=48.0.1", package = 'wasmtime-internal-wmemcheck' }
+wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=48.0.1", package = 'wasmtime-internal-c-api-macros' }
+wasmtime-cache = { path = "crates/cache", version = "=48.0.1", package = 'wasmtime-internal-cache' }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=48.0.1", package = 'wasmtime-internal-cranelift' }
+wasmtime-winch = { path = "crates/winch", version = "=48.0.1", package = 'wasmtime-internal-winch'  }
+wasmtime-explorer = { path = "crates/explorer", version = "=48.0.1", package = 'wasmtime-internal-explorer'  }
+wasmtime-fiber = { path = "crates/fiber", version = "=48.0.1", package = 'wasmtime-internal-fiber' }
+wasmtime-jit-debug = { path = "crates/jit-debug", version = "=48.0.1", package = 'wasmtime-internal-jit-debug' }
+wasmtime-component-util = { path = "crates/component-util", version = "=48.0.1", package = 'wasmtime-internal-component-util' }
+wasmtime-component-macro = { path = "crates/component-macro", version = "=48.0.1", package = 'wasmtime-internal-component-macro' }
+wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=48.0.1", package = 'wasmtime-internal-versioned-export-macros' }
+wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=48.0.1", package = 'wasmtime-internal-jit-icache-coherence' }
+wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=48.0.1", package = 'wasmtime-internal-wit-bindgen' }
+wasmtime-unwinder = { path = "crates/unwinder", version = "=48.0.1", package = 'wasmtime-internal-unwinder' }
+wasmtime-debugger = { path = "crates/debugger", version = "=48.0.1", package = "wasmtime-internal-debugger" }
+gdbstub-component-artifact = { path = "crates/gdbstub-component/artifact", version = "=48.0.1", package = "wasmtime-internal-gdbstub-component-artifact" }
+wasmtime-wizer = { path = "crates/wizer", version = "48.0.1" }
 
 # Miscellaneous crates without a `wasmtime-*` prefix in their name but still
 # used in the `wasmtime-*` family of crates depending on various features/etc.
-wiggle = { path = "crates/wiggle", version = "=48.0.0", default-features = false }
-wiggle-macro = { path = "crates/wiggle/macro", version = "=48.0.0" }
-wiggle-generate = { path = "crates/wiggle/generate", version = "=48.0.0" }
-pulley-interpreter = { path = 'pulley', version = "=48.0.0" }
-pulley-macros = { path = 'pulley/macros', version = "=48.0.0" }
+wiggle = { path = "crates/wiggle", version = "=48.0.1", default-features = false }
+wiggle-macro = { path = "crates/wiggle/macro", version = "=48.0.1" }
+wiggle-generate = { path = "crates/wiggle/generate", version = "=48.0.1" }
+pulley-interpreter = { path = 'pulley', version = "=48.0.1" }
+pulley-macros = { path = 'pulley/macros', version = "=48.0.1" }
 
 # Cranelift crates in this workspace
-cranelift-assembler-x64 = { path = "cranelift/assembler-x64", version = "0.135.0" }
-cranelift-codegen = { path = "cranelift/codegen", version = "0.135.0", default-features = false, features = ["unwind"] }
-cranelift-frontend = { path = "cranelift/frontend", version = "0.135.0" }
-cranelift-entity = { path = "cranelift/entity", version = "0.135.0" }
-cranelift-native = { path = "cranelift/native", version = "0.135.0" }
-cranelift-module = { path = "cranelift/module", version = "0.135.0" }
-cranelift-interpreter = { path = "cranelift/interpreter", version = "0.135.0" }
-cranelift-reader = { path = "cranelift/reader", version = "0.135.0" }
+cranelift-assembler-x64 = { path = "cranelift/assembler-x64", version = "0.135.1" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.135.1", default-features = false, features = ["unwind"] }
+cranelift-frontend = { path = "cranelift/frontend", version = "0.135.1" }
+cranelift-entity = { path = "cranelift/entity", version = "0.135.1" }
+cranelift-native = { path = "cranelift/native", version = "0.135.1" }
+cranelift-module = { path = "cranelift/module", version = "0.135.1" }
+cranelift-interpreter = { path = "cranelift/interpreter", version = "0.135.1" }
+cranelift-reader = { path = "cranelift/reader", version = "0.135.1" }
 cranelift-filetests = { path = "cranelift/filetests" }
-cranelift-object = { path = "cranelift/object", version = "0.135.0" }
-cranelift-jit = { path = "cranelift/jit", version = "0.135.0" }
+cranelift-object = { path = "cranelift/object", version = "0.135.1" }
+cranelift-jit = { path = "cranelift/jit", version = "0.135.1" }
 cranelift-fuzzgen = { path = "cranelift/fuzzgen" }
-cranelift-bforest = { path = "cranelift/bforest", version = "0.135.0" }
-cranelift-bitset = { path = "cranelift/bitset", version = "0.135.0" }
-cranelift-control = { path = "cranelift/control", version = "0.135.0", default-features = false }
-cranelift-srcgen = { path = "cranelift/srcgen", version = "0.135.0" }
-cranelift = { path = "cranelift/umbrella", version = "0.135.0" }
+cranelift-bforest = { path = "cranelift/bforest", version = "0.135.1" }
+cranelift-bitset = { path = "cranelift/bitset", version = "0.135.1" }
+cranelift-control = { path = "cranelift/control", version = "0.135.1", default-features = false }
+cranelift-srcgen = { path = "cranelift/srcgen", version = "0.135.1" }
+cranelift = { path = "cranelift/umbrella", version = "0.135.1" }
 
 # Winch crates in this workspace.
-winch-codegen = { path = "winch/codegen", version = "=48.0.0" }
+winch-codegen = { path = "winch/codegen", version = "=48.0.1" }
 
 # Internal crates not published to crates.io used in testing, builds, etc
 wasi-preview1-component-adapter = { path = "crates/wasi-preview1-component-adapter" }

--- a/cranelift/assembler-x64/Cargo.toml
+++ b/cranelift/assembler-x64/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-assembler-x64"
 description = "A Cranelift-specific x64 assembler"
-version = "0.135.0"
+version = "0.135.1"
 license = "Apache-2.0 WITH LLVM-exception"
 edition.workspace = true
 rust-version.workspace = true
@@ -25,7 +25,7 @@ arbtest = { workspace = true }
 capstone = { workspace = true }
 
 [build-dependencies]
-cranelift-assembler-x64-meta = { path = "meta", version = "0.135.0" }
+cranelift-assembler-x64-meta = { path = "meta", version = "0.135.1" }
 
 [lints]
 workspace = true

--- a/cranelift/assembler-x64/meta/Cargo.toml
+++ b/cranelift/assembler-x64/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-assembler-x64-meta"
 description = "Generate a Cranelift-specific assembler for x64 instructions"
-version = "0.135.0"
+version = "0.135.1"
 license = "Apache-2.0 WITH LLVM-exception"
 edition.workspace = true
 rust-version.workspace = true

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.135.0"
+version = "0.135.1"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"

--- a/cranelift/bitset/Cargo.toml
+++ b/cranelift/bitset/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bitset"
-version = "0.135.0"
+version = "0.135.1"
 description = "Various bitset stuff for use inside Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bitset"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.135.0"
+version = "0.135.1"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -25,7 +25,7 @@ anyhow = { workspace = true, optional = true, features = ['std'] }
 bumpalo = { workspace = true }
 capstone = { workspace = true, optional = true }
 cranelift-assembler-x64 = { workspace = true }
-cranelift-codegen-shared = { path = "./shared", version = "0.135.0" }
+cranelift-codegen-shared = { path = "./shared", version = "0.135.1" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
 cranelift-bitset = { workspace = true }
@@ -58,8 +58,8 @@ proptest = { workspace = true }
 mutatis = { workspace = true }
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.135.0" }
-cranelift-isle = { path = "../isle/isle", version = "=0.135.0" }
+cranelift-codegen-meta = { path = "meta", version = "0.135.1" }
+cranelift-isle = { path = "../isle/isle", version = "=0.135.1" }
 
 [features]
 default = ["std", "unwind", "host-arch", "timing"]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.135.0"
+version = "0.135.1"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -17,8 +17,8 @@ rustdoc-args = ["--document-private-items"]
 
 [dependencies]
 cranelift-srcgen = { workspace = true }
-cranelift-assembler-x64-meta = { path = "../../assembler-x64/meta", version = "0.135.0" }
-cranelift-codegen-shared = { path = "../shared", version = "0.135.0" }
+cranelift-assembler-x64-meta = { path = "../../assembler-x64/meta", version = "0.135.1" }
+cranelift-codegen-shared = { path = "../shared", version = "0.135.1" }
 pulley-interpreter = { workspace = true, optional = true }
 heck = "0.5.0"
 

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.135.0"
+version = "0.135.1"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/control/Cargo.toml
+++ b/cranelift/control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-control"
-version = "0.135.0"
+version = "0.135.1"
 description = "White-box fuzz testing framework"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.135.0"
+version = "0.135.1"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.135.0"
+version = "0.135.1"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.135.0"
+version = "0.135.1"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
-version = "0.135.0"
+version = "0.135.1"
 
 [lints]
 workspace = true

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.135.0"
+version = "0.135.1"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.135.0"
+version = "0.135.1"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.135.0"
+version = "0.135.1"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.135.0"
+version = "0.135.1"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.135.0"
+version = "0.135.1"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.135.0"
+version = "0.135.1"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/srcgen/Cargo.toml
+++ b/cranelift/srcgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-srcgen"
-version = "0.135.0"
+version = "0.135.1"
 authors = ["The Wasmtime Project Developers"]
 description = "Helper functions for generating Rust and ISLE files"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.135.0"
+version = "0.135.1"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -229,7 +229,7 @@
 /**
  * \brief Wasmtime version string.
  */
-#define WASMTIME_VERSION "48.0.0"
+#define WASMTIME_VERSION "48.0.1"
 /**
  * \brief Wasmtime major version number.
  */
@@ -241,6 +241,6 @@
 /**
  * \brief Wasmtime patch version number.
  */
-#define WASMTIME_VERSION_PATCH 0
+#define WASMTIME_VERSION_PATCH 1
 
 #endif // WASMTIME_API_H

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -17,6 +17,10 @@ audited_as = "0.132.0"
 version = "0.135.0"
 audited_as = "0.133.1"
 
+[[unpublished.cranelift]]
+version = "0.135.1"
+audited_as = "0.135.0"
+
 [[unpublished.cranelift-assembler-x64]]
 version = "0.132.0"
 audited_as = "0.130.1"
@@ -32,6 +36,10 @@ audited_as = "0.132.0"
 [[unpublished.cranelift-assembler-x64]]
 version = "0.135.0"
 audited_as = "0.133.1"
+
+[[unpublished.cranelift-assembler-x64]]
+version = "0.135.1"
+audited_as = "0.135.0"
 
 [[unpublished.cranelift-assembler-x64-meta]]
 version = "0.132.0"
@@ -49,6 +57,10 @@ audited_as = "0.132.0"
 version = "0.135.0"
 audited_as = "0.133.1"
 
+[[unpublished.cranelift-assembler-x64-meta]]
+version = "0.135.1"
+audited_as = "0.135.0"
+
 [[unpublished.cranelift-bforest]]
 version = "0.132.0"
 audited_as = "0.130.1"
@@ -64,6 +76,10 @@ audited_as = "0.132.0"
 [[unpublished.cranelift-bforest]]
 version = "0.135.0"
 audited_as = "0.133.1"
+
+[[unpublished.cranelift-bforest]]
+version = "0.135.1"
+audited_as = "0.135.0"
 
 [[unpublished.cranelift-bitset]]
 version = "0.132.0"
@@ -81,6 +97,10 @@ audited_as = "0.132.0"
 version = "0.135.0"
 audited_as = "0.133.1"
 
+[[unpublished.cranelift-bitset]]
+version = "0.135.1"
+audited_as = "0.135.0"
+
 [[unpublished.cranelift-codegen]]
 version = "0.132.0"
 audited_as = "0.130.1"
@@ -96,6 +116,10 @@ audited_as = "0.132.0"
 [[unpublished.cranelift-codegen]]
 version = "0.135.0"
 audited_as = "0.133.1"
+
+[[unpublished.cranelift-codegen]]
+version = "0.135.1"
+audited_as = "0.135.0"
 
 [[unpublished.cranelift-codegen-meta]]
 version = "0.132.0"
@@ -113,6 +137,10 @@ audited_as = "0.132.0"
 version = "0.135.0"
 audited_as = "0.133.1"
 
+[[unpublished.cranelift-codegen-meta]]
+version = "0.135.1"
+audited_as = "0.135.0"
+
 [[unpublished.cranelift-codegen-shared]]
 version = "0.132.0"
 audited_as = "0.130.1"
@@ -128,6 +156,10 @@ audited_as = "0.132.0"
 [[unpublished.cranelift-codegen-shared]]
 version = "0.135.0"
 audited_as = "0.133.1"
+
+[[unpublished.cranelift-codegen-shared]]
+version = "0.135.1"
+audited_as = "0.135.0"
 
 [[unpublished.cranelift-control]]
 version = "0.132.0"
@@ -145,6 +177,10 @@ audited_as = "0.132.0"
 version = "0.135.0"
 audited_as = "0.133.1"
 
+[[unpublished.cranelift-control]]
+version = "0.135.1"
+audited_as = "0.135.0"
+
 [[unpublished.cranelift-entity]]
 version = "0.132.0"
 audited_as = "0.130.1"
@@ -160,6 +196,10 @@ audited_as = "0.132.0"
 [[unpublished.cranelift-entity]]
 version = "0.135.0"
 audited_as = "0.133.1"
+
+[[unpublished.cranelift-entity]]
+version = "0.135.1"
+audited_as = "0.135.0"
 
 [[unpublished.cranelift-frontend]]
 version = "0.132.0"
@@ -177,6 +217,10 @@ audited_as = "0.132.0"
 version = "0.135.0"
 audited_as = "0.133.1"
 
+[[unpublished.cranelift-frontend]]
+version = "0.135.1"
+audited_as = "0.135.0"
+
 [[unpublished.cranelift-interpreter]]
 version = "0.132.0"
 audited_as = "0.130.1"
@@ -192,6 +236,10 @@ audited_as = "0.132.0"
 [[unpublished.cranelift-interpreter]]
 version = "0.135.0"
 audited_as = "0.133.1"
+
+[[unpublished.cranelift-interpreter]]
+version = "0.135.1"
+audited_as = "0.135.0"
 
 [[unpublished.cranelift-isle]]
 version = "0.132.0"
@@ -209,6 +257,10 @@ audited_as = "0.132.0"
 version = "0.135.0"
 audited_as = "0.133.1"
 
+[[unpublished.cranelift-isle]]
+version = "0.135.1"
+audited_as = "0.135.0"
+
 [[unpublished.cranelift-jit]]
 version = "0.132.0"
 audited_as = "0.130.1"
@@ -224,6 +276,10 @@ audited_as = "0.132.0"
 [[unpublished.cranelift-jit]]
 version = "0.135.0"
 audited_as = "0.133.1"
+
+[[unpublished.cranelift-jit]]
+version = "0.135.1"
+audited_as = "0.135.0"
 
 [[unpublished.cranelift-module]]
 version = "0.132.0"
@@ -241,6 +297,10 @@ audited_as = "0.132.0"
 version = "0.135.0"
 audited_as = "0.133.1"
 
+[[unpublished.cranelift-module]]
+version = "0.135.1"
+audited_as = "0.135.0"
+
 [[unpublished.cranelift-native]]
 version = "0.132.0"
 audited_as = "0.130.1"
@@ -256,6 +316,10 @@ audited_as = "0.132.0"
 [[unpublished.cranelift-native]]
 version = "0.135.0"
 audited_as = "0.133.1"
+
+[[unpublished.cranelift-native]]
+version = "0.135.1"
+audited_as = "0.135.0"
 
 [[unpublished.cranelift-object]]
 version = "0.132.0"
@@ -273,6 +337,10 @@ audited_as = "0.132.0"
 version = "0.135.0"
 audited_as = "0.133.1"
 
+[[unpublished.cranelift-object]]
+version = "0.135.1"
+audited_as = "0.135.0"
+
 [[unpublished.cranelift-reader]]
 version = "0.132.0"
 audited_as = "0.130.1"
@@ -289,6 +357,10 @@ audited_as = "0.132.0"
 version = "0.135.0"
 audited_as = "0.133.1"
 
+[[unpublished.cranelift-reader]]
+version = "0.135.1"
+audited_as = "0.135.0"
+
 [[unpublished.cranelift-serde]]
 version = "0.132.0"
 audited_as = "0.130.1"
@@ -305,6 +377,10 @@ audited_as = "0.132.0"
 version = "0.135.0"
 audited_as = "0.133.1"
 
+[[unpublished.cranelift-serde]]
+version = "0.135.1"
+audited_as = "0.135.0"
+
 [[unpublished.cranelift-srcgen]]
 version = "0.132.0"
 audited_as = "0.130.1"
@@ -320,6 +396,10 @@ audited_as = "0.132.0"
 [[unpublished.cranelift-srcgen]]
 version = "0.135.0"
 audited_as = "0.133.1"
+
+[[unpublished.cranelift-srcgen]]
+version = "0.135.1"
+audited_as = "0.135.0"
 
 [[unpublished.pulley-interpreter]]
 version = "45.0.0"
@@ -337,6 +417,10 @@ audited_as = "45.0.0"
 version = "48.0.0"
 audited_as = "46.0.1"
 
+[[unpublished.pulley-interpreter]]
+version = "48.0.1"
+audited_as = "48.0.0"
+
 [[unpublished.pulley-macros]]
 version = "45.0.0"
 audited_as = "43.0.1"
@@ -352,6 +436,10 @@ audited_as = "45.0.0"
 [[unpublished.pulley-macros]]
 version = "48.0.0"
 audited_as = "46.0.1"
+
+[[unpublished.pulley-macros]]
+version = "48.0.1"
+audited_as = "48.0.0"
 
 [[unpublished.wasi-common]]
 version = "45.0.0"
@@ -377,6 +465,10 @@ audited_as = "45.0.0"
 version = "48.0.0"
 audited_as = "46.0.1"
 
+[[unpublished.wasmtime]]
+version = "48.0.1"
+audited_as = "48.0.0"
+
 [[unpublished.wasmtime-cli]]
 version = "45.0.0"
 audited_as = "43.0.1"
@@ -392,6 +484,10 @@ audited_as = "45.0.0"
 [[unpublished.wasmtime-cli]]
 version = "48.0.0"
 audited_as = "46.0.1"
+
+[[unpublished.wasmtime-cli]]
+version = "48.0.1"
+audited_as = "48.0.0"
 
 [[unpublished.wasmtime-cli-flags]]
 version = "45.0.0"
@@ -409,6 +505,10 @@ audited_as = "45.0.0"
 version = "48.0.0"
 audited_as = "46.0.1"
 
+[[unpublished.wasmtime-cli-flags]]
+version = "48.0.1"
+audited_as = "48.0.0"
+
 [[unpublished.wasmtime-environ]]
 version = "45.0.0"
 audited_as = "43.0.1"
@@ -424,6 +524,10 @@ audited_as = "45.0.0"
 [[unpublished.wasmtime-environ]]
 version = "48.0.0"
 audited_as = "46.0.1"
+
+[[unpublished.wasmtime-environ]]
+version = "48.0.1"
+audited_as = "48.0.0"
 
 [[unpublished.wasmtime-internal-c-api-macros]]
 version = "45.0.0"
@@ -441,6 +545,10 @@ audited_as = "45.0.0"
 version = "48.0.0"
 audited_as = "46.0.1"
 
+[[unpublished.wasmtime-internal-c-api-macros]]
+version = "48.0.1"
+audited_as = "48.0.0"
+
 [[unpublished.wasmtime-internal-cache]]
 version = "45.0.0"
 audited_as = "43.0.1"
@@ -456,6 +564,10 @@ audited_as = "45.0.0"
 [[unpublished.wasmtime-internal-cache]]
 version = "48.0.0"
 audited_as = "46.0.1"
+
+[[unpublished.wasmtime-internal-cache]]
+version = "48.0.1"
+audited_as = "48.0.0"
 
 [[unpublished.wasmtime-internal-component-macro]]
 version = "45.0.0"
@@ -473,6 +585,10 @@ audited_as = "45.0.0"
 version = "48.0.0"
 audited_as = "46.0.1"
 
+[[unpublished.wasmtime-internal-component-macro]]
+version = "48.0.1"
+audited_as = "48.0.0"
+
 [[unpublished.wasmtime-internal-component-util]]
 version = "45.0.0"
 audited_as = "43.0.1"
@@ -488,6 +604,10 @@ audited_as = "45.0.0"
 [[unpublished.wasmtime-internal-component-util]]
 version = "48.0.0"
 audited_as = "46.0.1"
+
+[[unpublished.wasmtime-internal-component-util]]
+version = "48.0.1"
+audited_as = "48.0.0"
 
 [[unpublished.wasmtime-internal-core]]
 version = "45.0.0"
@@ -505,6 +625,10 @@ audited_as = "45.0.0"
 version = "48.0.0"
 audited_as = "46.0.1"
 
+[[unpublished.wasmtime-internal-core]]
+version = "48.0.1"
+audited_as = "48.0.0"
+
 [[unpublished.wasmtime-internal-cranelift]]
 version = "45.0.0"
 audited_as = "43.0.1"
@@ -520,6 +644,10 @@ audited_as = "45.0.0"
 [[unpublished.wasmtime-internal-cranelift]]
 version = "48.0.0"
 audited_as = "46.0.1"
+
+[[unpublished.wasmtime-internal-cranelift]]
+version = "48.0.1"
+audited_as = "48.0.0"
 
 [[unpublished.wasmtime-internal-debugger]]
 version = "45.0.0"
@@ -537,6 +665,10 @@ audited_as = "45.0.0"
 version = "48.0.0"
 audited_as = "46.0.1"
 
+[[unpublished.wasmtime-internal-debugger]]
+version = "48.0.1"
+audited_as = "48.0.0"
+
 [[unpublished.wasmtime-internal-explorer]]
 version = "45.0.0"
 audited_as = "43.0.1"
@@ -553,6 +685,10 @@ audited_as = "45.0.0"
 version = "48.0.0"
 audited_as = "46.0.1"
 
+[[unpublished.wasmtime-internal-explorer]]
+version = "48.0.1"
+audited_as = "48.0.0"
+
 [[unpublished.wasmtime-internal-fiber]]
 version = "45.0.0"
 audited_as = "43.0.1"
@@ -568,6 +704,10 @@ audited_as = "45.0.0"
 [[unpublished.wasmtime-internal-fiber]]
 version = "48.0.0"
 audited_as = "46.0.1"
+
+[[unpublished.wasmtime-internal-fiber]]
+version = "48.0.1"
+audited_as = "48.0.0"
 
 [[unpublished.wasmtime-internal-gdbstub-component-artifact]]
 version = "45.0.0"
@@ -585,6 +725,10 @@ audited_as = "45.0.0"
 version = "48.0.0"
 audited_as = "46.0.1"
 
+[[unpublished.wasmtime-internal-gdbstub-component-artifact]]
+version = "48.0.1"
+audited_as = "48.0.0"
+
 [[unpublished.wasmtime-internal-jit-debug]]
 version = "45.0.0"
 audited_as = "43.0.1"
@@ -600,6 +744,10 @@ audited_as = "45.0.0"
 [[unpublished.wasmtime-internal-jit-debug]]
 version = "48.0.0"
 audited_as = "46.0.1"
+
+[[unpublished.wasmtime-internal-jit-debug]]
+version = "48.0.1"
+audited_as = "48.0.0"
 
 [[unpublished.wasmtime-internal-jit-icache-coherence]]
 version = "45.0.0"
@@ -617,6 +765,10 @@ audited_as = "45.0.0"
 version = "48.0.0"
 audited_as = "46.0.1"
 
+[[unpublished.wasmtime-internal-jit-icache-coherence]]
+version = "48.0.1"
+audited_as = "48.0.0"
+
 [[unpublished.wasmtime-internal-unwinder]]
 version = "45.0.0"
 audited_as = "43.0.1"
@@ -632,6 +784,10 @@ audited_as = "45.0.0"
 [[unpublished.wasmtime-internal-unwinder]]
 version = "48.0.0"
 audited_as = "46.0.1"
+
+[[unpublished.wasmtime-internal-unwinder]]
+version = "48.0.1"
+audited_as = "48.0.0"
 
 [[unpublished.wasmtime-internal-versioned-export-macros]]
 version = "45.0.0"
@@ -649,6 +805,10 @@ audited_as = "45.0.0"
 version = "48.0.0"
 audited_as = "46.0.1"
 
+[[unpublished.wasmtime-internal-versioned-export-macros]]
+version = "48.0.1"
+audited_as = "48.0.0"
+
 [[unpublished.wasmtime-internal-winch]]
 version = "45.0.0"
 audited_as = "43.0.1"
@@ -664,6 +824,10 @@ audited_as = "45.0.0"
 [[unpublished.wasmtime-internal-winch]]
 version = "48.0.0"
 audited_as = "46.0.1"
+
+[[unpublished.wasmtime-internal-winch]]
+version = "48.0.1"
+audited_as = "48.0.0"
 
 [[unpublished.wasmtime-internal-wit-bindgen]]
 version = "45.0.0"
@@ -681,6 +845,10 @@ audited_as = "45.0.0"
 version = "48.0.0"
 audited_as = "46.0.1"
 
+[[unpublished.wasmtime-internal-wit-bindgen]]
+version = "48.0.1"
+audited_as = "48.0.0"
+
 [[unpublished.wasmtime-internal-wmemcheck]]
 version = "45.0.0"
 audited_as = "43.0.1"
@@ -696,6 +864,10 @@ audited_as = "45.0.0"
 [[unpublished.wasmtime-internal-wmemcheck]]
 version = "48.0.0"
 audited_as = "46.0.1"
+
+[[unpublished.wasmtime-internal-wmemcheck]]
+version = "48.0.1"
+audited_as = "48.0.0"
 
 [[unpublished.wasmtime-wasi]]
 version = "45.0.0"
@@ -713,6 +885,10 @@ audited_as = "45.0.0"
 version = "48.0.0"
 audited_as = "46.0.1"
 
+[[unpublished.wasmtime-wasi]]
+version = "48.0.1"
+audited_as = "48.0.0"
+
 [[unpublished.wasmtime-wasi-config]]
 version = "45.0.0"
 audited_as = "43.0.1"
@@ -728,6 +904,10 @@ audited_as = "45.0.0"
 [[unpublished.wasmtime-wasi-config]]
 version = "48.0.0"
 audited_as = "46.0.1"
+
+[[unpublished.wasmtime-wasi-config]]
+version = "48.0.1"
+audited_as = "48.0.0"
 
 [[unpublished.wasmtime-wasi-http]]
 version = "45.0.0"
@@ -745,6 +925,10 @@ audited_as = "45.0.0"
 version = "48.0.0"
 audited_as = "46.0.1"
 
+[[unpublished.wasmtime-wasi-http]]
+version = "48.0.1"
+audited_as = "48.0.0"
+
 [[unpublished.wasmtime-wasi-io]]
 version = "45.0.0"
 audited_as = "43.0.1"
@@ -761,6 +945,10 @@ audited_as = "45.0.0"
 version = "48.0.0"
 audited_as = "46.0.1"
 
+[[unpublished.wasmtime-wasi-io]]
+version = "48.0.1"
+audited_as = "48.0.0"
+
 [[unpublished.wasmtime-wasi-keyvalue]]
 version = "45.0.0"
 audited_as = "43.0.1"
@@ -777,6 +965,10 @@ audited_as = "45.0.0"
 version = "48.0.0"
 audited_as = "46.0.1"
 
+[[unpublished.wasmtime-wasi-keyvalue]]
+version = "48.0.1"
+audited_as = "48.0.0"
+
 [[unpublished.wasmtime-wasi-nn]]
 version = "45.0.0"
 audited_as = "43.0.1"
@@ -792,6 +984,10 @@ audited_as = "45.0.0"
 [[unpublished.wasmtime-wasi-nn]]
 version = "48.0.0"
 audited_as = "46.0.1"
+
+[[unpublished.wasmtime-wasi-nn]]
+version = "48.0.1"
+audited_as = "48.0.0"
 
 [[unpublished.wasmtime-wasi-threads]]
 version = "45.0.0"
@@ -817,6 +1013,10 @@ audited_as = "45.0.0"
 version = "48.0.0"
 audited_as = "46.0.1"
 
+[[unpublished.wasmtime-wasi-tls]]
+version = "48.0.1"
+audited_as = "48.0.0"
+
 [[unpublished.wasmtime-wast]]
 version = "45.0.0"
 audited_as = "43.0.1"
@@ -832,6 +1032,10 @@ audited_as = "45.0.0"
 [[unpublished.wasmtime-wast]]
 version = "48.0.0"
 audited_as = "46.0.1"
+
+[[unpublished.wasmtime-wast]]
+version = "48.0.1"
+audited_as = "48.0.0"
 
 [[unpublished.wasmtime-wizer]]
 version = "45.0.0"
@@ -849,6 +1053,10 @@ audited_as = "45.0.0"
 version = "48.0.0"
 audited_as = "46.0.1"
 
+[[unpublished.wasmtime-wizer]]
+version = "48.0.1"
+audited_as = "48.0.0"
+
 [[unpublished.wiggle]]
 version = "45.0.0"
 audited_as = "43.0.1"
@@ -865,6 +1073,10 @@ audited_as = "45.0.0"
 version = "48.0.0"
 audited_as = "46.0.1"
 
+[[unpublished.wiggle]]
+version = "48.0.1"
+audited_as = "48.0.0"
+
 [[unpublished.wiggle-generate]]
 version = "45.0.0"
 audited_as = "43.0.1"
@@ -881,6 +1093,10 @@ audited_as = "45.0.0"
 version = "48.0.0"
 audited_as = "46.0.1"
 
+[[unpublished.wiggle-generate]]
+version = "48.0.1"
+audited_as = "48.0.0"
+
 [[unpublished.wiggle-macro]]
 version = "45.0.0"
 audited_as = "43.0.1"
@@ -896,6 +1112,10 @@ audited_as = "45.0.0"
 [[unpublished.wiggle-macro]]
 version = "48.0.0"
 audited_as = "46.0.1"
+
+[[unpublished.wiggle-macro]]
+version = "48.0.1"
+audited_as = "48.0.0"
 
 [[unpublished.wiggle-test]]
 version = "0.0.0"
@@ -916,6 +1136,10 @@ audited_as = "45.0.0"
 [[unpublished.winch-codegen]]
 version = "48.0.0"
 audited_as = "46.0.1"
+
+[[unpublished.winch-codegen]]
+version = "48.0.1"
+audited_as = "48.0.0"
 
 [[publisher.aho-corasick]]
 version = "1.0.2"
@@ -1113,103 +1337,103 @@ user-login = "jrmuizel"
 user-name = "Jeff Muizelaar"
 
 [[publisher.cranelift]]
-version = "0.133.1"
-when = "2026-06-24"
+version = "0.135.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-assembler-x64]]
-version = "0.133.1"
-when = "2026-06-24"
+version = "0.135.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-assembler-x64-meta]]
-version = "0.133.1"
-when = "2026-06-24"
+version = "0.135.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-bforest]]
-version = "0.133.1"
-when = "2026-06-24"
+version = "0.135.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-bitset]]
-version = "0.133.1"
-when = "2026-06-24"
+version = "0.135.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-codegen]]
-version = "0.133.1"
-when = "2026-06-24"
+version = "0.135.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-codegen-meta]]
-version = "0.133.1"
-when = "2026-06-24"
+version = "0.135.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-codegen-shared]]
-version = "0.133.1"
-when = "2026-06-24"
+version = "0.135.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-control]]
-version = "0.133.1"
-when = "2026-06-24"
+version = "0.135.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-entity]]
-version = "0.133.1"
-when = "2026-06-24"
+version = "0.135.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-frontend]]
-version = "0.133.1"
-when = "2026-06-24"
+version = "0.135.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-interpreter]]
-version = "0.133.1"
-when = "2026-06-24"
+version = "0.135.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-isle]]
-version = "0.133.1"
-when = "2026-06-24"
+version = "0.135.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-jit]]
-version = "0.133.1"
-when = "2026-06-24"
+version = "0.135.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-module]]
-version = "0.133.1"
-when = "2026-06-24"
+version = "0.135.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-native]]
-version = "0.133.1"
-when = "2026-06-24"
+version = "0.135.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-object]]
-version = "0.133.1"
-when = "2026-06-24"
+version = "0.135.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-reader]]
-version = "0.133.1"
-when = "2026-06-24"
+version = "0.135.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-serde]]
-version = "0.133.1"
-when = "2026-06-24"
+version = "0.135.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-srcgen]]
-version = "0.133.1"
-when = "2026-06-24"
+version = "0.135.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.derive_arbitrary]]
@@ -1555,13 +1779,13 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.pulley-interpreter]]
-version = "46.0.1"
-when = "2026-06-24"
+version = "48.0.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.pulley-macros]]
-version = "46.0.1"
-when = "2026-06-24"
+version = "48.0.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.quote]]
@@ -1969,153 +2193,153 @@ when = "2026-07-20"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wasmtime]]
-version = "46.0.1"
-when = "2026-06-24"
+version = "48.0.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-cli]]
-version = "46.0.1"
-when = "2026-06-24"
+version = "48.0.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-cli-flags]]
-version = "46.0.1"
-when = "2026-06-24"
+version = "48.0.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-environ]]
-version = "46.0.1"
-when = "2026-06-24"
+version = "48.0.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-c-api-macros]]
-version = "46.0.1"
-when = "2026-06-24"
+version = "48.0.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-cache]]
-version = "46.0.1"
-when = "2026-06-24"
+version = "48.0.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-component-macro]]
-version = "46.0.1"
-when = "2026-06-24"
+version = "48.0.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-component-util]]
-version = "46.0.1"
-when = "2026-06-24"
+version = "48.0.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-core]]
-version = "46.0.1"
-when = "2026-06-24"
+version = "48.0.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-cranelift]]
-version = "46.0.1"
-when = "2026-06-24"
+version = "48.0.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-debugger]]
-version = "46.0.1"
-when = "2026-06-24"
+version = "48.0.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-explorer]]
-version = "46.0.1"
-when = "2026-06-24"
+version = "48.0.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-fiber]]
-version = "46.0.1"
-when = "2026-06-24"
+version = "48.0.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-gdbstub-component-artifact]]
-version = "46.0.1"
-when = "2026-06-24"
+version = "48.0.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-jit-debug]]
-version = "46.0.1"
-when = "2026-06-24"
+version = "48.0.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-jit-icache-coherence]]
-version = "46.0.1"
-when = "2026-06-24"
+version = "48.0.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-unwinder]]
-version = "46.0.1"
-when = "2026-06-24"
+version = "48.0.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-versioned-export-macros]]
-version = "46.0.1"
-when = "2026-06-24"
+version = "48.0.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-winch]]
-version = "46.0.1"
-when = "2026-06-24"
+version = "48.0.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-wit-bindgen]]
-version = "46.0.1"
-when = "2026-06-24"
+version = "48.0.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-wmemcheck]]
-version = "46.0.1"
-when = "2026-06-24"
+version = "48.0.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi]]
-version = "46.0.1"
-when = "2026-06-24"
+version = "48.0.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-config]]
-version = "46.0.1"
-when = "2026-06-24"
+version = "48.0.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-http]]
-version = "46.0.1"
-when = "2026-06-24"
+version = "48.0.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-io]]
-version = "46.0.1"
-when = "2026-06-24"
+version = "48.0.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-keyvalue]]
-version = "46.0.1"
-when = "2026-06-24"
+version = "48.0.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-nn]]
-version = "46.0.1"
-when = "2026-06-24"
+version = "48.0.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-tls]]
-version = "46.0.1"
-when = "2026-06-24"
+version = "48.0.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wast]]
-version = "46.0.1"
-when = "2026-06-24"
+version = "48.0.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wizer]]
-version = "46.0.1"
-when = "2026-06-24"
+version = "48.0.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wast]]
@@ -2129,18 +2353,18 @@ when = "2026-07-20"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wiggle]]
-version = "46.0.1"
-when = "2026-06-24"
+version = "48.0.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wiggle-generate]]
-version = "46.0.1"
-when = "2026-06-24"
+version = "48.0.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wiggle-macro]]
-version = "46.0.1"
-when = "2026-06-24"
+version = "48.0.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wiggle-test]]
@@ -2158,8 +2382,8 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.winch-codegen]]
-version = "46.0.1"
-when = "2026-06-24"
+version = "48.0.0"
+when = "2026-08-20"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.windows]]


### PR DESCRIPTION
This is an [automated pull request][process] from CI to create a patch release for Wasmtime 48.0.1, requested by @alexcrichton.

It's recommended that maintainers double-check that [RELEASES.md] is up-to-date and that there are no known issues before merging this PR. When this PR is merged a release tag will automatically be created, crates will be published, and CI artifacts will be produced.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/release-48.0.1/RELEASES.md
[process]: https://docs.wasmtime.dev/contributing-release-process.html
