### PR TITLE
Cranelift: add mid-end optimization rules

### DIFF
--- a/cranelift/codegen/src/opts/arithmetic.isle
+++ b/cranelift/codegen/src/opts/arithmetic.isle
@@ -585,3 +585,10 @@
 ;; -(X * C) = X * (-C)
 (rule (simplify (ineg (fits_in_64 ty) (imul ty x (iconst ty c))))
       (imul ty x (iconst ty (imm64_neg ty c))))
+
+(rule (simplify (isub ty x (ishl ty (ineg ty y) z))) (iadd ty x (ishl ty y z)))
+
+(rule (simplify (bxor ty (ishl ty x y) (ishl ty z y))) (ishl ty (bxor ty x z) y))
+(rule (simplify (bxor ty (sshr ty x y) (sshr ty z y))) (sshr ty (bxor ty x z) y))
+(rule (simplify (bxor ty (ushr ty x y) (ushr ty z y))) (ushr ty (bxor ty x z) y))
+

--- a/cranelift/codegen/src/opts/arithmetic.isle
+++ b/cranelift/codegen/src/opts/arithmetic.isle
@@ -586,8 +586,10 @@
 (rule (simplify (ineg (fits_in_64 ty) (imul ty x (iconst ty c))))
       (imul ty x (iconst ty (imm64_neg ty c))))
 
+;; x - (-y << z) = x + (y << z)
 (rule (simplify (isub ty x (ishl ty (ineg ty y) z))) (iadd ty x (ishl ty y z)))
 
+;; (x << y) | (z << y) = (x | z) << y, and variants
 (rule (simplify (bxor ty (ishl ty x y) (ishl ty z y))) (ishl ty (bxor ty x z) y))
 (rule (simplify (bxor ty (sshr ty x y) (sshr ty z y))) (sshr ty (bxor ty x z) y))
 (rule (simplify (bxor ty (ushr ty x y) (ushr ty z y))) (ushr ty (bxor ty x z) y))

--- a/cranelift/codegen/src/opts/bitops.isle
+++ b/cranelift/codegen/src/opts/bitops.isle
@@ -741,3 +741,10 @@
 (rule (simplify (ult rty (bor ty y x) x)) (subsume (all_zero rty)))
 (rule (simplify (ugt rty x (bor ty x y))) (subsume (all_zero rty)))
 (rule (simplify (ugt rty x (bor ty y x))) (subsume (all_zero rty)))
+
+;; (x & y) & (x & z) --> (x & y) & z
+(rule (simplify (band ty (band ty x y) (band ty x z))) (band ty (band ty x y) z))
+(rule (simplify (band ty (band ty x y) (band ty y z))) (band ty (band ty y x) z))
+(rule (simplify (band ty (band ty x y) (band ty z x))) (band ty (band ty x y) z))
+(rule (simplify (band ty (band ty x y) (band ty z y))) (band ty (band ty y x) z))
+

--- a/cranelift/codegen/src/opts/shifts.isle
+++ b/cranelift/codegen/src/opts/shifts.isle
@@ -315,6 +315,7 @@
 (rule (simplify (iadd ty (ishl ty x z) (ishl ty y z))) (ishl ty (iadd ty x y) z))
 
 (rule (simplify (ushr ty (band ty (ishl ty x y) z) y)) (band ty x (ushr ty z y)))
+(rule (simplify (ushr ty (band ty x (ishl ty y z)) z)) (band ty y (ushr ty x z)))
 
 ;; Zero remains zero for any shift or rotate amount.
 (rule (simplify (ishl ty (iconst_u ty 0) x)) (subsume (iconst_u ty 0)))

--- a/cranelift/filetests/filetests/egraph/arithmetic.clif
+++ b/cranelift/filetests/filetests/egraph/arithmetic.clif
@@ -505,3 +505,51 @@ block0(v0: i32):
     ; check: v5 = imul v0, v4
     ; check: return v5
 }
+
+;; x - ((-y) << z) --> x + (y << z)
+function %isub_ishl_ineg(i32, i32, i32) -> i32 {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = ineg v1
+    v4 = ishl v3, v2
+    v5 = isub v0, v4
+    return v5
+    ; check: v6 = ishl v1, v2
+    ; check: v7 = iadd v0, v6
+    ; check: return v7
+}
+
+;; (x << z) ^ (y << z) --> (x ^ y) << z
+function %bxor_ishl(i32, i32, i32) -> i32 {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = ishl v0, v2
+    v4 = ishl v1, v2
+    v5 = bxor v3, v4
+    return v5
+    ; check: v6 = bxor v0, v1
+    ; check: v7 = ishl v6, v2
+    ; check: return v7
+}
+
+;; (x >>s z) ^ (y >>s z) --> (x ^ y) >>s z
+function %bxor_sshr(i32, i32, i32) -> i32 {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = sshr v0, v2
+    v4 = sshr v1, v2
+    v5 = bxor v3, v4
+    return v5
+    ; check: v6 = bxor v0, v1
+    ; check: v7 = sshr v6, v2
+    ; check: return v7
+}
+
+;; (x >>u z) ^ (y >>u z) --> (x ^ y) >>u z
+function %bxor_ushr(i32, i32, i32) -> i32 {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = ushr v0, v2
+    v4 = ushr v1, v2
+    v5 = bxor v3, v4
+    return v5
+    ; check: v6 = bxor v0, v1
+    ; check: v7 = ushr v6, v2
+    ; check: return v7
+}

--- a/cranelift/filetests/filetests/egraph/cprop.clif
+++ b/cranelift/filetests/filetests/egraph/cprop.clif
@@ -349,10 +349,10 @@ block0(v0: i32, v1: i32):
     return v7
 }
 
-; check: v16 = iconst.i32 333
-; check: v19 = iadd v1, v16
-; check: v20 = icmp eq v0, v19
-; nextln: return v20
+; check: v9 = iconst.i32 333
+; check: v18 = iadd v1, v9
+; check: v19 = icmp eq v0, v18
+; nextln: return v19
 
 function %icmp_subs_const_addends(i32, i32) -> i8 {
 block0(v0: i32, v1: i32):
@@ -364,10 +364,10 @@ block0(v0: i32, v1: i32):
     return v7
 }
 
-; check: v40 = iconst.i32 333
-; check: v45 = iadd v0, v40
-; check: v46 = icmp eq v1, v45
-; nextln: return v46
+; check: v36 = iconst.i32 333
+; check: v44 = iadd v0, v36
+; check: v45 = icmp eq v1, v44
+; nextln: return v45
 
 function %ireduce_iconst() -> i8 {
 block0:

--- a/cranelift/filetests/filetests/egraph/fold-bitops.clif
+++ b/cranelift/filetests/filetests/egraph/fold-bitops.clif
@@ -662,3 +662,67 @@ block0(v0: i32x4, v1: i32x4):
 ;     v4 = vconst.i32x4 const0
 ;     return v4  ; v4 = const0
 ; }
+
+;; (x & y) & (x & z) --> (x & y) & z
+function %band_band_common_first(i32, i32, i32) -> i32 {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = band v0, v1
+    v4 = band v0, v2
+    v5 = band v3, v4
+    return v5
+}
+
+; function %band_band_common_first(i32, i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32, v2: i32):
+;     v3 = band v0, v1
+;     v6 = band v3, v2
+;     return v6
+; }
+
+;; (x & y) & (y & z) --> (y & x) & z
+function %band_band_common_second(i32, i32, i32) -> i32 {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = band v0, v1
+    v4 = band v1, v2
+    v5 = band v3, v4
+    return v5
+}
+
+; function %band_band_common_second(i32, i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32, v2: i32):
+;     v6 = band v1, v0
+;     v7 = band v6, v2
+;     return v7
+; }
+
+;; (x & y) & (z & x) --> (x & y) & z
+function %band_band_common_third(i32, i32, i32) -> i32 {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = band v0, v1
+    v4 = band v2, v0
+    v5 = band v3, v4
+    return v5
+}
+
+; function %band_band_common_third(i32, i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32, v2: i32):
+;     v3 = band v0, v1
+;     v6 = band v3, v2
+;     return v6
+; }
+
+;; (x & y) & (z & y) --> (y & x) & z
+function %band_band_common_fourth(i32, i32, i32) -> i32 {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = band v0, v1
+    v4 = band v2, v1
+    v5 = band v3, v4
+    return v5
+}
+
+; function %band_band_common_fourth(i32, i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32, v2: i32):
+;     v6 = band v1, v0
+;     v7 = band v6, v2
+;     return v7
+; }

--- a/cranelift/filetests/filetests/egraph/shifts.clif
+++ b/cranelift/filetests/filetests/egraph/shifts.clif
@@ -669,3 +669,15 @@ block0(v0: i64):
     return v2
     ; check: return v1
 }
+
+;; (x & (y << z)) >>u z --> y & (x >>u z)
+function %ushr_band_ishl(i32, i32, i32) -> i32 {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = ishl v1, v2
+    v4 = band v0, v3
+    v5 = ushr v4, v2
+    return v5
+    ; check: v6 = ushr v0, v2
+    ; check: v7 = band v1, v6
+    ; check: return v7
+}

--- a/cranelift/filetests/filetests/runtests/arithmetic.clif
+++ b/cranelift/filetests/filetests/runtests/arithmetic.clif
@@ -1077,3 +1077,17 @@ block0(v0: i32):
 ; run: %fold_isub_minus_one_lhs_to_bnot_i32_rt(1) == -2
 ; run: %fold_isub_minus_one_lhs_to_bnot_i32_rt(-1) == 0
 ; run: %fold_isub_minus_one_lhs_to_bnot_i32_rt(0x7fffffff) == 0x80000000
+
+function %isub_ishl_ineg_rt(i32, i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = ineg v1
+    v4 = ishl v3, v2
+    v5 = isub v0, v4
+    return v5
+}
+
+; run: %isub_ishl_ineg_rt(0, 0, 0) == 0
+; run: %isub_ishl_ineg_rt(5, 3, 1) == 11
+; run: %isub_ishl_ineg_rt(10, -2, 4) == -22
+; run: %isub_ishl_ineg_rt(0x80000000, 1, 31) == 0
+; run: %isub_ishl_ineg_rt(7, 1, 32) == 8

--- a/cranelift/filetests/filetests/runtests/bitops.clif
+++ b/cranelift/filetests/filetests/runtests/bitops.clif
@@ -845,3 +845,47 @@ block0(v0: i32, v1: i32):
 ; run: %test_band_bnot_bor_x_y_x(0, 0) == 0
 ; run: %test_band_bnot_bor_x_y_x(0x12345678, 0x87654321) == 0
 ; run: %test_band_bnot_bor_x_y_x(-1, 0x55555555) == 0
+
+function %band_band_common_first_rt(i32, i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = band v0, v1
+    v4 = band v0, v2
+    v5 = band v3, v4
+    return v5
+}
+
+; run: %band_band_common_first_rt(0, -1, 0xaaaaaaaa) == 0
+; run: %band_band_common_first_rt(0xf0f0f0f0, 0xcccccccc, 0xaaaaaaaa) == 0x80808080
+
+function %band_band_common_second_rt(i32, i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = band v0, v1
+    v4 = band v1, v2
+    v5 = band v3, v4
+    return v5
+}
+
+; run: %band_band_common_second_rt(0, -1, 0xaaaaaaaa) == 0
+; run: %band_band_common_second_rt(0xf0f0f0f0, 0xcccccccc, 0xaaaaaaaa) == 0x80808080
+
+function %band_band_common_third_rt(i32, i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = band v0, v1
+    v4 = band v2, v0
+    v5 = band v3, v4
+    return v5
+}
+
+; run: %band_band_common_third_rt(0, -1, 0xaaaaaaaa) == 0
+; run: %band_band_common_third_rt(0xf0f0f0f0, 0xcccccccc, 0xaaaaaaaa) == 0x80808080
+
+function %band_band_common_fourth_rt(i32, i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = band v0, v1
+    v4 = band v2, v1
+    v5 = band v3, v4
+    return v5
+}
+
+; run: %band_band_common_fourth_rt(0, -1, 0xaaaaaaaa) == 0
+; run: %band_band_common_fourth_rt(0xf0f0f0f0, 0xcccccccc, 0xaaaaaaaa) == 0x80808080

--- a/cranelift/filetests/filetests/runtests/shifts.clif
+++ b/cranelift/filetests/filetests/runtests/shifts.clif
@@ -1121,3 +1121,52 @@ block0(v0: i64):
 ; run: %sshr_zero_left_operand(1) == 0
 ; run: %sshr_zero_left_operand(63) == 0
 ; run: %sshr_zero_left_operand(64) == 0
+
+function %ushr_band_ishl_rt(i32, i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = ishl v1, v2
+    v4 = band v0, v3
+    v5 = ushr v4, v2
+    return v5
+}
+
+; run: %ushr_band_ishl_rt(0, 0, 0) == 0
+; run: %ushr_band_ishl_rt(0xf0, 0xcc, 4) == 12
+; run: %ushr_band_ishl_rt(0x80000000, -1, 31) == 1
+; run: %ushr_band_ishl_rt(0x12345678, 0xaa, 32) == 0x28
+
+function %bxor_ishl_rt(i32, i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = ishl v0, v2
+    v4 = ishl v1, v2
+    v5 = bxor v3, v4
+    return v5
+}
+
+; run: %bxor_ishl_rt(0, 0, 0) == 0
+; run: %bxor_ishl_rt(0x12345678, 0x9abcdef0, 4) == 0x88888880
+; run: %bxor_ishl_rt(0x12345678, 0x9abcdef0, 32) == 0x88888888
+
+function %bxor_sshr_rt(i32, i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = sshr v0, v2
+    v4 = sshr v1, v2
+    v5 = bxor v3, v4
+    return v5
+}
+
+; run: %bxor_sshr_rt(0, 0, 0) == 0
+; run: %bxor_sshr_rt(0x87654321, 0x12345678, 4) == 0xf9551155
+; run: %bxor_sshr_rt(0x87654321, 0x12345678, 32) == 0x95511559
+
+function %bxor_ushr_rt(i32, i32, i32) -> i32 fast {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = ushr v0, v2
+    v4 = ushr v1, v2
+    v5 = bxor v3, v4
+    return v5
+}
+
+; run: %bxor_ushr_rt(0, 0, 0) == 0
+; run: %bxor_ushr_rt(0x12345678, 0x9abcdef0, 4) == 0x08888888
+; run: %bxor_ushr_rt(0x12345678, 0x9abcdef0, 32) == 0x88888888

--- a/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/drc/array-new-fixed-of-gc-refs.wat
@@ -79,89 +79,89 @@
 ;;                                     v206 = iconst.i64 12
 ;; @0025                               v52 = isub v49, v206  ; v206 = 12
 ;; @0025                               store.i32 user2 little region5 v201, v52
-;;                                     v306 = iadd.i64 v22, v23  ; v23 = 24
-;; @0025                               v81 = load.i32 user2 readonly region5 v306
-;;                                     v307 = iconst.i32 1
-;;                                     v308 = icmp ugt v81, v307  ; v307 = 1
-;; @0025                               trapz v308, user17
+;;                                     v305 = iadd.i64 v22, v23  ; v23 = 24
+;; @0025                               v81 = load.i32 user2 readonly region5 v305
+;;                                     v306 = iconst.i32 1
+;;                                     v307 = icmp ugt v81, v306  ; v306 = 1
+;; @0025                               trapz v307, user17
 ;; @0025                               v84 = uextend.i64 v81
 ;;                                     v207 = iconst.i64 2
-;;                                     v253 = ishl v84, v207  ; v207 = 2
+;;                                     v252 = ishl v84, v207  ; v207 = 2
 ;; @0025                               v10 = iconst.i64 32
-;; @0025                               v87 = ushr v253, v10  ; v10 = 32
+;; @0025                               v87 = ushr v252, v10  ; v10 = 32
 ;; @0025                               trapnz v87, user2
 ;;                                     v228 = iconst.i32 2
-;;                                     v258 = ishl v81, v228  ; v228 = 2
+;;                                     v257 = ishl v81, v228  ; v228 = 2
 ;; @0025                               v6 = iconst.i32 28
-;; @0025                               v90 = uadd_overflow_trap v258, v6, user2  ; v6 = 28
+;; @0025                               v90 = uadd_overflow_trap v257, v6, user2  ; v6 = 28
 ;; @0025                               v94 = uadd_overflow_trap.i32 v18, v90, user2
 ;;                                     v191 = load.i32 notrap aligned region8 v203
-;;                                     v309 = band v191, v307  ; v307 = 1
-;;                                     v310 = iconst.i32 0
-;;                                     v311 = icmp eq v191, v310  ; v310 = 0
-;; @0025                               v106 = uextend.i32 v311
-;; @0025                               v107 = bor v309, v106
+;;                                     v308 = band v191, v306  ; v306 = 1
+;;                                     v309 = iconst.i32 0
+;;                                     v310 = icmp eq v191, v309  ; v309 = 0
+;; @0025                               v106 = uextend.i32 v310
+;; @0025                               v107 = bor v308, v106
 ;; @0025                               brif v107, block5, block4
 ;;
 ;;                                 block4:
 ;; @0025                               v108 = uextend.i64 v191
 ;; @0025                               v111 = iadd.i64 v20, v108
-;;                                     v312 = iconst.i64 8
-;; @0025                               v113 = iadd v111, v312  ; v312 = 8
+;;                                     v311 = iconst.i64 8
+;; @0025                               v113 = iadd v111, v311  ; v311 = 8
 ;; @0025                               v114 = load.i64 user2 region5 v113
-;;                                     v313 = iconst.i64 1
-;; @0025                               v116 = iadd v114, v313  ; v313 = 1
+;;                                     v312 = iconst.i64 1
+;; @0025                               v116 = iadd v114, v312  ; v312 = 1
 ;; @0025                               store user2 region5 v116, v113
 ;; @0025                               jump block5
 ;;
 ;;                                 block5:
 ;; @0025                               v95 = uextend.i64 v94
 ;; @0025                               v98 = iadd.i64 v20, v95
-;;                                     v270 = iconst.i32 32
-;; @0025                               v99 = isub.i32 v90, v270  ; v270 = 32
+;;                                     v269 = iconst.i32 32
+;; @0025                               v99 = isub.i32 v90, v269  ; v269 = 32
 ;; @0025                               v100 = uextend.i64 v99
 ;; @0025                               v101 = isub v98, v100
 ;; @0025                               store.i32 user2 little region5 v191, v101
-;;                                     v314 = iadd.i64 v22, v23  ; v23 = 24
-;; @0025                               v130 = load.i32 user2 readonly region5 v314
-;;                                     v315 = iconst.i32 2
-;;                                     v316 = icmp ugt v130, v315  ; v315 = 2
-;; @0025                               trapz v316, user17
+;;                                     v313 = iadd.i64 v22, v23  ; v23 = 24
+;; @0025                               v130 = load.i32 user2 readonly region5 v313
+;;                                     v314 = iconst.i32 2
+;;                                     v315 = icmp ugt v130, v314  ; v314 = 2
+;; @0025                               trapz v315, user17
 ;; @0025                               v133 = uextend.i64 v130
-;;                                     v317 = iconst.i64 2
-;;                                     v318 = ishl v133, v317  ; v317 = 2
-;;                                     v319 = iconst.i64 32
-;;                                     v320 = ushr v318, v319  ; v319 = 32
-;; @0025                               trapnz v320, user2
-;;                                     v321 = ishl v130, v315  ; v315 = 2
-;;                                     v322 = iconst.i32 28
-;; @0025                               v139 = uadd_overflow_trap v321, v322, user2  ; v322 = 28
+;;                                     v316 = iconst.i64 2
+;;                                     v317 = ishl v133, v316  ; v316 = 2
+;;                                     v318 = iconst.i64 32
+;;                                     v319 = ushr v317, v318  ; v318 = 32
+;; @0025                               trapnz v319, user2
+;;                                     v320 = ishl v130, v314  ; v314 = 2
+;;                                     v321 = iconst.i32 28
+;; @0025                               v139 = uadd_overflow_trap v320, v321, user2  ; v321 = 28
 ;; @0025                               v143 = uadd_overflow_trap.i32 v18, v139, user2
 ;;                                     v181 = load.i32 notrap aligned region7 v204
-;;                                     v323 = iconst.i32 1
-;;                                     v324 = band v181, v323  ; v323 = 1
-;;                                     v325 = iconst.i32 0
-;;                                     v326 = icmp eq v181, v325  ; v325 = 0
-;; @0025                               v155 = uextend.i32 v326
-;; @0025                               v156 = bor v324, v155
+;;                                     v322 = iconst.i32 1
+;;                                     v323 = band v181, v322  ; v322 = 1
+;;                                     v324 = iconst.i32 0
+;;                                     v325 = icmp eq v181, v324  ; v324 = 0
+;; @0025                               v155 = uextend.i32 v325
+;; @0025                               v156 = bor v323, v155
 ;; @0025                               brif v156, block7, block6
 ;;
 ;;                                 block6:
 ;; @0025                               v157 = uextend.i64 v181
 ;; @0025                               v160 = iadd.i64 v20, v157
-;;                                     v327 = iconst.i64 8
-;; @0025                               v162 = iadd v160, v327  ; v327 = 8
+;;                                     v326 = iconst.i64 8
+;; @0025                               v162 = iadd v160, v326  ; v326 = 8
 ;; @0025                               v163 = load.i64 user2 region5 v162
-;;                                     v328 = iconst.i64 1
-;; @0025                               v165 = iadd v163, v328  ; v328 = 1
+;;                                     v327 = iconst.i64 1
+;; @0025                               v165 = iadd v163, v327  ; v327 = 1
 ;; @0025                               store user2 region5 v165, v162
 ;; @0025                               jump block7
 ;;
 ;;                                 block7:
 ;; @0025                               v144 = uextend.i64 v143
 ;; @0025                               v147 = iadd.i64 v20, v144
-;;                                     v300 = iconst.i32 36
-;; @0025                               v148 = isub.i32 v139, v300  ; v300 = 36
+;;                                     v299 = iconst.i32 36
+;; @0025                               v148 = isub.i32 v139, v299  ; v299 = 36
 ;; @0025                               v149 = uextend.i64 v148
 ;; @0025                               v150 = isub v147, v149
 ;; @0025                               store.i32 user2 little region5 v181, v150

--- a/tests/disas/gc/drc/array-new-fixed.wat
+++ b/tests/disas/gc/drc/array-new-fixed.wat
@@ -47,40 +47,40 @@
 ;; @0025                               store user2 little region5 v2, v52
 ;; @0025                               v60 = load.i32 user2 readonly region5 v24
 ;; @0025                               v53 = iconst.i32 1
-;;                                     v151 = icmp ugt v60, v53  ; v53 = 1
-;; @0025                               trapz v151, user17
+;;                                     v150 = icmp ugt v60, v53  ; v53 = 1
+;; @0025                               trapz v150, user17
 ;; @0025                               v63 = uextend.i64 v60
 ;;                                     v109 = iconst.i64 3
-;;                                     v154 = ishl v63, v109  ; v109 = 3
+;;                                     v153 = ishl v63, v109  ; v109 = 3
 ;; @0025                               v10 = iconst.i64 32
-;; @0025                               v66 = ushr v154, v10  ; v10 = 32
+;; @0025                               v66 = ushr v153, v10  ; v10 = 32
 ;; @0025                               trapnz v66, user2
-;;                                     v159 = ishl v60, v5  ; v5 = 3
+;;                                     v158 = ishl v60, v5  ; v5 = 3
 ;; @0025                               v6 = iconst.i32 32
-;; @0025                               v69 = uadd_overflow_trap v159, v6, user2  ; v6 = 32
+;; @0025                               v69 = uadd_overflow_trap v158, v6, user2  ; v6 = 32
 ;; @0025                               v73 = uadd_overflow_trap v18, v69, user2
 ;; @0025                               v74 = uextend.i64 v73
 ;; @0025                               v77 = iadd v20, v74
-;;                                     v171 = iconst.i32 40
-;; @0025                               v78 = isub v69, v171  ; v171 = 40
+;;                                     v170 = iconst.i32 40
+;; @0025                               v78 = isub v69, v170  ; v170 = 40
 ;; @0025                               v79 = uextend.i64 v78
 ;; @0025                               v80 = isub v77, v79
 ;; @0025                               store user2 little region5 v3, v80
 ;; @0025                               v88 = load.i32 user2 readonly region5 v24
 ;; @0025                               v81 = iconst.i32 2
-;;                                     v177 = icmp ugt v88, v81  ; v81 = 2
-;; @0025                               trapz v177, user17
+;;                                     v176 = icmp ugt v88, v81  ; v81 = 2
+;; @0025                               trapz v176, user17
 ;; @0025                               v91 = uextend.i64 v88
-;;                                     v180 = ishl v91, v109  ; v109 = 3
-;; @0025                               v94 = ushr v180, v10  ; v10 = 32
+;;                                     v179 = ishl v91, v109  ; v109 = 3
+;; @0025                               v94 = ushr v179, v10  ; v10 = 32
 ;; @0025                               trapnz v94, user2
-;;                                     v185 = ishl v88, v5  ; v5 = 3
-;; @0025                               v97 = uadd_overflow_trap v185, v6, user2  ; v6 = 32
+;;                                     v184 = ishl v88, v5  ; v5 = 3
+;; @0025                               v97 = uadd_overflow_trap v184, v6, user2  ; v6 = 32
 ;; @0025                               v101 = uadd_overflow_trap v18, v97, user2
 ;; @0025                               v102 = uextend.i64 v101
 ;; @0025                               v105 = iadd v20, v102
-;;                                     v202 = iconst.i32 48
-;; @0025                               v106 = isub v97, v202  ; v202 = 48
+;;                                     v201 = iconst.i32 48
+;; @0025                               v106 = isub v97, v201  ; v201 = 48
 ;; @0025                               v107 = uextend.i64 v106
 ;; @0025                               v108 = isub v105, v107
 ;; @0025                               store user2 little region5 v4, v108

--- a/tests/disas/gc/drc/externref-globals.wat
+++ b/tests/disas/gc/drc/externref-globals.wat
@@ -138,27 +138,27 @@
 ;; @003b                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v64 = iadd.i64 v0, v3  ; v3 = 48
-;; @003b                               store.i32 notrap aligned region2 v2, v64
-;;                                     v65 = iconst.i32 1
-;;                                     v66 = band.i32 v5, v65  ; v65 = 1
-;;                                     v67 = iconst.i32 0
-;;                                     v68 = icmp.i32 eq v5, v67  ; v67 = 0
-;; @003b                               v31 = uextend.i32 v68
-;; @003b                               v32 = bor v66, v31
+;;                                     v63 = iadd.i64 v0, v3  ; v3 = 48
+;; @003b                               store.i32 notrap aligned region2 v2, v63
+;;                                     v64 = iconst.i32 1
+;;                                     v65 = band.i32 v5, v64  ; v64 = 1
+;;                                     v66 = iconst.i32 0
+;;                                     v67 = icmp.i32 eq v5, v66  ; v66 = 0
+;; @003b                               v31 = uextend.i32 v67
+;; @003b                               v32 = bor v65, v31
 ;; @003b                               brif v32, block7, block4
 ;;
 ;;                                 block4:
-;;                                     v69 = load.i64 notrap aligned readonly can_move region0 v0+8
-;;                                     v70 = load.i64 notrap aligned readonly can_move region3 v69+32
+;;                                     v68 = load.i64 notrap aligned readonly can_move region0 v0+8
+;;                                     v69 = load.i64 notrap aligned readonly can_move region3 v68+32
 ;; @003b                               v33 = uextend.i64 v5
-;; @003b                               v36 = iadd v70, v33
-;;                                     v71 = iconst.i64 8
-;; @003b                               v38 = iadd v36, v71  ; v71 = 8
+;; @003b                               v36 = iadd v69, v33
+;;                                     v70 = iconst.i64 8
+;; @003b                               v38 = iadd v36, v70  ; v70 = 8
 ;; @003b                               v39 = load.i64 user2 region5 v38
-;;                                     v72 = iconst.i64 1
-;;                                     v62 = icmp eq v39, v72  ; v72 = 1
-;; @003b                               brif v62, block5, block6
+;;                                     v71 = iconst.i64 1
+;;                                     v61 = icmp eq v39, v71  ; v71 = 1
+;; @003b                               brif v61, block5, block6
 ;;
 ;;                                 block5 cold:
 ;; @003b                               call fn0(v0, v5)
@@ -167,8 +167,8 @@
 ;;                                 block6:
 ;; @003b                               v40 = iconst.i64 -1
 ;; @003b                               v41 = iadd.i64 v39, v40  ; v40 = -1
-;;                                     v73 = iadd.i64 v36, v71  ; v71 = 8
-;; @003b                               store user2 region5 v41, v73
+;;                                     v72 = iadd.i64 v36, v70  ; v70 = 8
+;; @003b                               store user2 region5 v41, v72
 ;; @003b                               jump block7
 ;;
 ;;                                 block7:

--- a/tests/disas/gc/drc/struct-set.wat
+++ b/tests/disas/gc/drc/struct-set.wat
@@ -113,25 +113,25 @@
 ;; @004a                               jump block3
 ;;
 ;;                                 block3:
-;;                                     v69 = iadd.i64 v7, v8  ; v8 = 32
-;; @004a                               store.i32 user2 little region4 v3, v69
-;;                                     v70 = iconst.i32 1
-;;                                     v71 = band.i32 v10, v70  ; v70 = 1
-;;                                     v72 = iconst.i32 0
-;;                                     v73 = icmp.i32 eq v10, v72  ; v72 = 0
-;; @004a                               v36 = uextend.i32 v73
-;; @004a                               v37 = bor v71, v36
+;;                                     v68 = iadd.i64 v7, v8  ; v8 = 32
+;; @004a                               store.i32 user2 little region4 v3, v68
+;;                                     v69 = iconst.i32 1
+;;                                     v70 = band.i32 v10, v69  ; v69 = 1
+;;                                     v71 = iconst.i32 0
+;;                                     v72 = icmp.i32 eq v10, v71  ; v71 = 0
+;; @004a                               v36 = uextend.i32 v72
+;; @004a                               v37 = bor v70, v36
 ;; @004a                               brif v37, block7, block4
 ;;
 ;;                                 block4:
 ;; @004a                               v38 = uextend.i64 v10
 ;; @004a                               v41 = iadd.i64 v6, v38
-;;                                     v74 = iconst.i64 8
-;; @004a                               v43 = iadd v41, v74  ; v74 = 8
+;;                                     v73 = iconst.i64 8
+;; @004a                               v43 = iadd v41, v73  ; v73 = 8
 ;; @004a                               v44 = load.i64 user2 region4 v43
-;;                                     v75 = iconst.i64 1
-;;                                     v67 = icmp eq v44, v75  ; v75 = 1
-;; @004a                               brif v67, block5, block6
+;;                                     v74 = iconst.i64 1
+;;                                     v66 = icmp eq v44, v74  ; v74 = 1
+;; @004a                               brif v66, block5, block6
 ;;
 ;;                                 block5 cold:
 ;; @004a                               call fn0(v0, v10)
@@ -140,8 +140,8 @@
 ;;                                 block6:
 ;; @004a                               v45 = iconst.i64 -1
 ;; @004a                               v46 = iadd.i64 v44, v45  ; v45 = -1
-;;                                     v76 = iadd.i64 v41, v74  ; v74 = 8
-;; @004a                               store user2 region4 v46, v76
+;;                                     v75 = iadd.i64 v41, v73  ; v73 = 8
+;; @004a                               store user2 region4 v46, v75
 ;; @004a                               jump block7
 ;;
 ;;                                 block7:

--- a/tests/disas/gc/null/array-new-fixed-of-gc-refs.wat
+++ b/tests/disas/gc/null/array-new-fixed-of-gc-refs.wat
@@ -56,9 +56,9 @@
 ;;                                 block2:
 ;;                                     v158 = iconst.i32 -1476394984
 ;; @0025                               v32 = load.i64 notrap aligned readonly can_move region5 v26+32
-;;                                     v253 = band.i32 v21, v157  ; v157 = -8
-;;                                     v254 = uextend.i64 v253
-;; @0025                               v34 = iadd v32, v254
+;;                                     v252 = band.i32 v21, v157  ; v157 = -8
+;;                                     v253 = uextend.i64 v252
+;; @0025                               v34 = iadd v32, v253
 ;; @0025                               store user2 region8 v158, v34  ; v158 = -1476394984
 ;; @0025                               v37 = load.i64 notrap aligned readonly can_move region6 v0+40
 ;; @0025                               v38 = load.i32 notrap aligned readonly can_move region7 v37
@@ -68,9 +68,9 @@
 ;; @0025                               v39 = iconst.i64 8
 ;; @0025                               v40 = iadd v34, v39  ; v39 = 8
 ;; @0025                               store user2 region8 v5, v40  ; v5 = 3
-;; @0025                               trapz v253, user16
-;;                                     v255 = iconst.i32 24
-;; @0025                               v61 = uadd_overflow_trap v253, v255, user2  ; v255 = 24
+;; @0025                               trapz v252, user16
+;;                                     v254 = iconst.i32 24
+;; @0025                               v61 = uadd_overflow_trap v252, v254, user2  ; v254 = 24
 ;;                                     v130 = load.i32 notrap aligned region11 v131
 ;; @0025                               v62 = uextend.i64 v61
 ;; @0025                               v65 = iadd v32, v62
@@ -79,42 +79,42 @@
 ;; @0025                               store user2 little region8 v130, v68
 ;; @0025                               v76 = load.i32 user2 readonly region8 v40
 ;; @0025                               v69 = iconst.i32 1
-;;                                     v197 = icmp ugt v76, v69  ; v69 = 1
-;; @0025                               trapz v197, user17
+;;                                     v196 = icmp ugt v76, v69  ; v69 = 1
+;; @0025                               trapz v196, user17
 ;; @0025                               v79 = uextend.i64 v76
 ;;                                     v136 = iconst.i64 2
-;;                                     v200 = ishl v79, v136  ; v136 = 2
+;;                                     v199 = ishl v79, v136  ; v136 = 2
 ;; @0025                               v10 = iconst.i64 32
-;; @0025                               v82 = ushr v200, v10  ; v10 = 32
+;; @0025                               v82 = ushr v199, v10  ; v10 = 32
 ;; @0025                               trapnz v82, user2
 ;;                                     v175 = iconst.i32 2
-;;                                     v205 = ishl v76, v175  ; v175 = 2
+;;                                     v204 = ishl v76, v175  ; v175 = 2
 ;; @0025                               v6 = iconst.i32 12
-;; @0025                               v85 = uadd_overflow_trap v205, v6, user2  ; v6 = 12
-;; @0025                               v89 = uadd_overflow_trap v253, v85, user2
+;; @0025                               v85 = uadd_overflow_trap v204, v6, user2  ; v6 = 12
+;; @0025                               v89 = uadd_overflow_trap v252, v85, user2
 ;;                                     v128 = load.i32 notrap aligned region10 v132
 ;; @0025                               v90 = uextend.i64 v89
 ;; @0025                               v93 = iadd v32, v90
-;;                                     v217 = iconst.i32 16
-;; @0025                               v94 = isub v85, v217  ; v217 = 16
+;;                                     v216 = iconst.i32 16
+;; @0025                               v94 = isub v85, v216  ; v216 = 16
 ;; @0025                               v95 = uextend.i64 v94
 ;; @0025                               v96 = isub v93, v95
 ;; @0025                               store user2 little region8 v128, v96
 ;; @0025                               v104 = load.i32 user2 readonly region8 v40
-;;                                     v223 = icmp ugt v104, v175  ; v175 = 2
-;; @0025                               trapz v223, user17
+;;                                     v222 = icmp ugt v104, v175  ; v175 = 2
+;; @0025                               trapz v222, user17
 ;; @0025                               v107 = uextend.i64 v104
-;;                                     v226 = ishl v107, v136  ; v136 = 2
-;; @0025                               v110 = ushr v226, v10  ; v10 = 32
+;;                                     v225 = ishl v107, v136  ; v136 = 2
+;; @0025                               v110 = ushr v225, v10  ; v10 = 32
 ;; @0025                               trapnz v110, user2
-;;                                     v231 = ishl v104, v175  ; v175 = 2
-;; @0025                               v113 = uadd_overflow_trap v231, v6, user2  ; v6 = 12
-;; @0025                               v117 = uadd_overflow_trap v253, v113, user2
+;;                                     v230 = ishl v104, v175  ; v175 = 2
+;; @0025                               v113 = uadd_overflow_trap v230, v6, user2  ; v6 = 12
+;; @0025                               v117 = uadd_overflow_trap v252, v113, user2
 ;;                                     v126 = load.i32 notrap aligned region9 v133
 ;; @0025                               v118 = uextend.i64 v117
 ;; @0025                               v121 = iadd v32, v118
-;;                                     v247 = iconst.i32 20
-;; @0025                               v122 = isub v113, v247  ; v247 = 20
+;;                                     v246 = iconst.i32 20
+;; @0025                               v122 = isub v113, v246  ; v246 = 20
 ;; @0025                               v123 = uextend.i64 v122
 ;; @0025                               v124 = isub v121, v123
 ;; @0025                               store user2 little region8 v126, v124
@@ -126,6 +126,6 @@
 ;; @0025                               jump block2
 ;;
 ;;                                 block1:
-;;                                     v256 = band.i32 v21, v157  ; v157 = -8
-;; @0029                               return v256
+;;                                     v255 = band.i32 v21, v157  ; v157 = -8
+;; @0029                               return v255
 ;; }

--- a/tests/disas/gc/null/array-new-fixed.wat
+++ b/tests/disas/gc/null/array-new-fixed.wat
@@ -44,9 +44,9 @@
 ;;                                 block2:
 ;;                                     v149 = iconst.i32 -1476394968
 ;; @0025                               v32 = load.i64 notrap aligned readonly can_move region5 v26+32
-;;                                     v241 = band.i32 v21, v148  ; v148 = -8
-;;                                     v242 = uextend.i64 v241
-;; @0025                               v34 = iadd v32, v242
+;;                                     v240 = band.i32 v21, v148  ; v148 = -8
+;;                                     v241 = uextend.i64 v240
+;; @0025                               v34 = iadd v32, v241
 ;; @0025                               store user2 region8 v149, v34  ; v149 = -1476394968
 ;; @0025                               v37 = load.i64 notrap aligned readonly can_move region6 v0+40
 ;; @0025                               v38 = load.i32 notrap aligned readonly can_move region7 v37
@@ -56,9 +56,9 @@
 ;; @0025                               v8 = iconst.i64 8
 ;; @0025                               v40 = iadd v34, v8  ; v8 = 8
 ;; @0025                               store user2 region8 v5, v40  ; v5 = 3
-;; @0025                               trapz v241, user16
-;;                                     v243 = iconst.i32 40
-;; @0025                               v61 = uadd_overflow_trap v241, v243, user2  ; v243 = 40
+;; @0025                               trapz v240, user16
+;;                                     v242 = iconst.i32 40
+;; @0025                               v61 = uadd_overflow_trap v240, v242, user2  ; v242 = 40
 ;; @0025                               v62 = uextend.i64 v61
 ;; @0025                               v65 = iadd v32, v62
 ;;                                     v126 = iconst.i64 24
@@ -66,18 +66,18 @@
 ;; @0025                               store.i64 user2 little region8 v2, v68
 ;; @0025                               v76 = load.i32 user2 readonly region8 v40
 ;; @0025                               v69 = iconst.i32 1
-;;                                     v186 = icmp ugt v76, v69  ; v69 = 1
-;; @0025                               trapz v186, user17
+;;                                     v185 = icmp ugt v76, v69  ; v69 = 1
+;; @0025                               trapz v185, user17
 ;; @0025                               v79 = uextend.i64 v76
 ;;                                     v125 = iconst.i64 3
-;;                                     v189 = ishl v79, v125  ; v125 = 3
+;;                                     v188 = ishl v79, v125  ; v125 = 3
 ;; @0025                               v10 = iconst.i64 32
-;; @0025                               v82 = ushr v189, v10  ; v10 = 32
+;; @0025                               v82 = ushr v188, v10  ; v10 = 32
 ;; @0025                               trapnz v82, user2
-;;                                     v194 = ishl v76, v5  ; v5 = 3
+;;                                     v193 = ishl v76, v5  ; v5 = 3
 ;; @0025                               v6 = iconst.i32 16
-;; @0025                               v85 = uadd_overflow_trap v194, v6, user2  ; v6 = 16
-;; @0025                               v89 = uadd_overflow_trap v241, v85, user2
+;; @0025                               v85 = uadd_overflow_trap v193, v6, user2  ; v6 = 16
+;; @0025                               v89 = uadd_overflow_trap v240, v85, user2
 ;; @0025                               v90 = uextend.i64 v89
 ;; @0025                               v93 = iadd v32, v90
 ;;                                     v134 = iconst.i32 24
@@ -87,19 +87,19 @@
 ;; @0025                               store.i64 user2 little region8 v3, v96
 ;; @0025                               v104 = load.i32 user2 readonly region8 v40
 ;; @0025                               v97 = iconst.i32 2
-;;                                     v211 = icmp ugt v104, v97  ; v97 = 2
-;; @0025                               trapz v211, user17
+;;                                     v210 = icmp ugt v104, v97  ; v97 = 2
+;; @0025                               trapz v210, user17
 ;; @0025                               v107 = uextend.i64 v104
-;;                                     v214 = ishl v107, v125  ; v125 = 3
-;; @0025                               v110 = ushr v214, v10  ; v10 = 32
+;;                                     v213 = ishl v107, v125  ; v125 = 3
+;; @0025                               v110 = ushr v213, v10  ; v10 = 32
 ;; @0025                               trapnz v110, user2
-;;                                     v219 = ishl v104, v5  ; v5 = 3
-;; @0025                               v113 = uadd_overflow_trap v219, v6, user2  ; v6 = 16
-;; @0025                               v117 = uadd_overflow_trap v241, v113, user2
+;;                                     v218 = ishl v104, v5  ; v5 = 3
+;; @0025                               v113 = uadd_overflow_trap v218, v6, user2  ; v6 = 16
+;; @0025                               v117 = uadd_overflow_trap v240, v113, user2
 ;; @0025                               v118 = uextend.i64 v117
 ;; @0025                               v121 = iadd v32, v118
-;;                                     v235 = iconst.i32 32
-;; @0025                               v122 = isub v113, v235  ; v235 = 32
+;;                                     v234 = iconst.i32 32
+;; @0025                               v122 = isub v113, v234  ; v234 = 32
 ;; @0025                               v123 = uextend.i64 v122
 ;; @0025                               v124 = isub v121, v123
 ;; @0025                               store.i64 user2 little region8 v4, v124
@@ -111,6 +111,6 @@
 ;; @0025                               jump block2
 ;;
 ;;                                 block1:
-;;                                     v244 = band.i32 v21, v148  ; v148 = -8
-;; @0029                               return v244
+;;                                     v243 = band.i32 v21, v148  ; v148 = -8
+;; @0029                               return v243
 ;; }

--- a/tests/disas/startup-table-initial-value.wat
+++ b/tests/disas/startup-table-initial-value.wat
@@ -53,19 +53,19 @@
 ;;     trapnz v51, user6
 ;;     v18 = load.i64 notrap aligned region0 v0+48
 ;;     v3 = iconst.i32 1
-;;     v81 = iconst.i64 36
-;;     v84 = iadd v18, v81  ; v81 = 36
+;;     v74 = iconst.i64 36
+;;     v83 = iadd v18, v74  ; v74 = 36
 ;;     v20 = iconst.i64 4
 ;;     jump block1(v18)
 ;;
 ;; block1(v29: i64):
-;;     v87 = iconst.i32 1
-;;     store notrap aligned region2 v87, v29  ; v87 = 1
-;;     v88 = iadd.i64 v18, v81  ; v81 = 36
-;;     v89 = icmp eq v29, v88
-;;     v90 = iconst.i64 4
-;;     v91 = iadd v29, v90  ; v90 = 4
-;;     brif v89, block2, block1(v91)
+;;     v86 = iconst.i32 1
+;;     store notrap aligned region2 v86, v29  ; v86 = 1
+;;     v87 = iadd.i64 v18, v74  ; v74 = 36
+;;     v88 = icmp eq v29, v87
+;;     v89 = iconst.i64 4
+;;     v90 = iadd v29, v89  ; v89 = 4
+;;     brif v88, block2, block1(v90)
 ;;
 ;; block2:
 ;;     return


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please review the Bytecode Alliance's AI tool usage policy at
https://github.com/bytecodealliance/governance/blob/main/AI_TOOL_POLICY.md

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

Hi, I added some missing optimization rules:
* `x - (-y << z) = x + (y << z)`
* `(x << y) | (z << y) = (x | z) << y`
* `(x & y) & (x & z) --> (x & y) & z`
* and one commutative variant of an existing rule

Also added unit test cases for these rules, and blessed minor changes of tests.

Thank you.

---

Besides this PR, I noticed that the new ISLE verifier was integrated.
Do you have any plan to run the verifier for all existing midend/backend rules on a regular basis (like CI)?