### PR TITLE
Add `wasmtime::Heap{Top,Bottom}Type` types

### DIFF
--- a/crates/wasmtime/src/runtime/coredump.rs
+++ b/crates/wasmtime/src/runtime/coredump.rs
@@ -1,7 +1,7 @@
 use crate::hash_map::HashMap;
 use crate::prelude::*;
 use crate::{
-    AsContextMut, FrameInfo, Global, HeapType, Instance, Memory, Module, StoreContextMut, Val,
+    AsContextMut, FrameInfo, Global, HeapTopType, Instance, Memory, Module, StoreContextMut, Val,
     ValType, WasmBacktrace, store::StoreOpaque,
 };
 use std::fmt;
@@ -185,13 +185,21 @@ impl WasmCoreDump {
                     // what a concrete type reference's index is in the local
                     // core dump index space.
                     ValType::Ref(r) => match r.heap_type().top() {
-                        HeapType::Extern => wasm_encoder::ValType::EXTERNREF,
-
-                        HeapType::Func => wasm_encoder::ValType::FUNCREF,
-
-                        HeapType::Any => wasm_encoder::ValType::Ref(wasm_encoder::RefType::ANYREF),
-
-                        ty => unreachable!("not a top type: {ty:?}"),
+                        HeapTopType::Extern => wasm_encoder::ValType::EXTERNREF,
+                        HeapTopType::Func => wasm_encoder::ValType::FUNCREF,
+                        HeapTopType::Any => {
+                            wasm_encoder::ValType::Ref(wasm_encoder::RefType::ANYREF)
+                        }
+                        HeapTopType::Exn => {
+                            wasm_encoder::ValType::Ref(wasm_encoder::RefType::EXNREF)
+                        }
+                        HeapTopType::Cont => {
+                            wasm_encoder::ValType::Ref(wasm_encoder::RefType::new_abstract(
+                                wasm_encoder::AbstractHeapType::Cont,
+                                true,
+                                false,
+                            ))
+                        }
                     },
                 };
                 let init = match g.get(&mut store) {

--- a/crates/wasmtime/src/runtime/externals/table.rs
+++ b/crates/wasmtime/src/runtime/externals/table.rs
@@ -3,7 +3,7 @@ use crate::runtime::vm::{self, GcStore, TableElementType, VMFuncRef, VMGcRef, VM
 use crate::store::{AutoAssertNoGc, StoreInstanceId, StoreOpaque, StoreResourceLimiter};
 use crate::trampoline::generate_table_export;
 use crate::{
-    AnyRef, AsContext, AsContextMut, ExnRef, ExternRef, Func, HeapType, Ref, RefType,
+    AnyRef, AsContext, AsContextMut, ExnRef, ExternRef, Func, HeapTopType, Ref, RefType,
     StoreContextMut, TableType, Trap,
 };
 use core::iter;
@@ -219,16 +219,16 @@ impl Table {
                     .map(|r| r.unchecked_copy())
                     .map(|r| store.clone_gc_ref(&r));
                 Some(match self.ty_(&store).element().heap_type().top() {
-                    HeapType::Extern => {
+                    HeapTopType::Extern => {
                         Ref::Extern(gc_ref.map(|r| ExternRef::from_cloned_gc_ref(&mut store, r)))
                     }
-                    HeapType::Any => {
+                    HeapTopType::Any => {
                         Ref::Any(gc_ref.map(|r| AnyRef::from_cloned_gc_ref(&mut store, r)))
                     }
-                    HeapType::Exn => {
+                    HeapTopType::Exn => {
                         Ref::Exn(gc_ref.map(|r| ExnRef::from_cloned_gc_ref(&mut store, r)))
                     }
-                    _ => unreachable!(),
+                    HeapTopType::Func | HeapTopType::Cont => unreachable!("not GC refs"),
                 })
             }
             // TODO(#10248) Required to support stack switching in the embedder
@@ -563,10 +563,9 @@ impl Table {
 
 fn element_type(ty: &TableType) -> TableElementType {
     match ty.element().heap_type().top() {
-        HeapType::Func => TableElementType::Func,
-        HeapType::Exn | HeapType::Extern | HeapType::Any => TableElementType::GcRef,
-        HeapType::Cont => TableElementType::Cont,
-        _ => unreachable!(),
+        HeapTopType::Func => TableElementType::Func,
+        HeapTopType::Exn | HeapTopType::Extern | HeapTopType::Any => TableElementType::GcRef,
+        HeapTopType::Cont => TableElementType::Cont,
     }
 }
 
@@ -580,11 +579,11 @@ impl Ref {
             .context("type mismatch: value does not match table element type")?;
 
         match (self, ty.heap_type().top()) {
-            (Ref::Func(None), HeapType::Func) => {
+            (Ref::Func(None), HeapTopType::Func) => {
                 assert!(ty.is_nullable());
                 Ok(None)
             }
-            (Ref::Func(Some(f)), HeapType::Func) => {
+            (Ref::Func(Some(f)), HeapTopType::Func) => {
                 debug_assert!(
                     f.comes_from_same_store(store),
                     "checked in `ensure_matches_ty`"
@@ -605,7 +604,7 @@ impl Ref {
             .context("type mismatch: value does not match table element type")?;
 
         match (self, ty.heap_type().top()) {
-            (Ref::Extern(e), HeapType::Extern) => match e {
+            (Ref::Extern(e), HeapTopType::Extern) => match e {
                 None => {
                     assert!(ty.is_nullable());
                     Ok(None)
@@ -613,7 +612,7 @@ impl Ref {
                 Some(e) => Ok(Some(e.try_gc_ref(store)?)),
             },
 
-            (Ref::Any(a), HeapType::Any) => match a {
+            (Ref::Any(a), HeapTopType::Any) => match a {
                 None => {
                     assert!(ty.is_nullable());
                     Ok(None)
@@ -621,7 +620,7 @@ impl Ref {
                 Some(a) => Ok(Some(a.try_gc_ref(store)?)),
             },
 
-            (Ref::Exn(e), HeapType::Exn) => match e {
+            (Ref::Exn(e), HeapTopType::Exn) => match e {
                 None => {
                     assert!(ty.is_nullable());
                     Ok(None)

--- a/crates/wasmtime/src/runtime/func/typed.rs
+++ b/crates/wasmtime/src/runtime/func/typed.rs
@@ -294,10 +294,9 @@ pub unsafe trait WasmTy: Send {
                 // parameters, and fall back to dynamic type checks on the
                 // arguments passed to each invocation, as necessary.
                 (Some(expected_ref), Some(actual_ref)) if actual_ref.heap_type().is_concrete() => {
-                    expected_ref
-                        .heap_type()
-                        .top()
-                        .ensure_matches(engine, &actual_ref.heap_type().top())
+                    let expected_top = HeapType::from(expected_ref.heap_type().top());
+                    let actual_top = HeapType::from(actual_ref.heap_type().top());
+                    expected_top.ensure_matches(engine, &actual_top)
                 }
                 _ => expected.ensure_matches(engine, &actual),
             },

--- a/crates/wasmtime/src/runtime/types.rs
+++ b/crates/wasmtime/src/runtime/types.rs
@@ -838,6 +838,60 @@ pub enum HeapType {
     NoExn,
 }
 
+/// A top heap type.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
+pub enum HeapTopType {
+    /// The common supertype of all external references.
+    Extern,
+    /// The common supertype of all internal references.
+    Any,
+    /// The common supertype of all function references.
+    Func,
+    /// The common supertype of all exception references.
+    Exn,
+    /// The common supertype of all continuation references.
+    Cont,
+}
+
+/// A bottom heap type.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum HeapBottomType {
+    /// The common subtype of all external references.
+    NoExtern,
+    /// The common subtype of all internal references.
+    None,
+    /// The common subtype of all function references.
+    NoFunc,
+    /// The common subtype of all exception references.
+    NoExn,
+    /// The common subtype of all continuation references.
+    NoCont,
+}
+
+impl From<HeapTopType> for HeapType {
+    fn from(value: HeapTopType) -> Self {
+        match value {
+            HeapTopType::Extern => Self::Extern,
+            HeapTopType::Any => Self::Any,
+            HeapTopType::Func => Self::Func,
+            HeapTopType::Exn => Self::Exn,
+            HeapTopType::Cont => Self::Cont,
+        }
+    }
+}
+
+impl From<HeapBottomType> for HeapType {
+    fn from(value: HeapBottomType) -> Self {
+        match value {
+            HeapBottomType::NoExtern => Self::NoExtern,
+            HeapBottomType::None => Self::None,
+            HeapBottomType::NoFunc => Self::NoFunc,
+            HeapBottomType::NoExn => Self::NoExn,
+            HeapBottomType::NoCont => Self::NoCont,
+        }
+    }
+}
+
 impl Display for HeapType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -1068,14 +1122,14 @@ impl HeapType {
 
     /// Get the top type of this heap type's type hierarchy.
     ///
-    /// The returned heap type is a supertype of all types in this heap type's
-    /// type hierarchy.
+    /// The returned type represents a supertype of all types in this heap
+    /// type's type hierarchy.
     #[inline]
-    pub fn top(&self) -> HeapType {
+    pub fn top(&self) -> HeapTopType {
         match self {
-            HeapType::Func | HeapType::ConcreteFunc(_) | HeapType::NoFunc => HeapType::Func,
+            HeapType::Func | HeapType::ConcreteFunc(_) | HeapType::NoFunc => HeapTopType::Func,
 
-            HeapType::Extern | HeapType::NoExtern => HeapType::Extern,
+            HeapType::Extern | HeapType::NoExtern => HeapTopType::Extern,
 
             HeapType::Any
             | HeapType::Eq
@@ -1084,11 +1138,11 @@ impl HeapType {
             | HeapType::ConcreteArray(_)
             | HeapType::Struct
             | HeapType::ConcreteStruct(_)
-            | HeapType::None => HeapType::Any,
+            | HeapType::None => HeapTopType::Any,
 
-            HeapType::Cont | HeapType::ConcreteCont(_) | HeapType::NoCont => HeapType::Cont,
+            HeapType::Cont | HeapType::ConcreteCont(_) | HeapType::NoCont => HeapTopType::Cont,
 
-            HeapType::Exn | HeapType::ConcreteExn(_) | HeapType::NoExn => HeapType::Exn,
+            HeapType::Exn | HeapType::ConcreteExn(_) | HeapType::NoExn => HeapTopType::Exn,
         }
     }
 
@@ -1105,14 +1159,14 @@ impl HeapType {
 
     /// Get the bottom type of this heap type's type hierarchy.
     ///
-    /// The returned heap type is a subtype of all types in this heap type's
+    /// The returned type represents a subtype of all types in this heap type's
     /// type hierarchy.
     #[inline]
-    pub fn bottom(&self) -> HeapType {
+    pub fn bottom(&self) -> HeapBottomType {
         match self {
-            HeapType::Extern | HeapType::NoExtern => HeapType::NoExtern,
+            HeapType::Extern | HeapType::NoExtern => HeapBottomType::NoExtern,
 
-            HeapType::Func | HeapType::ConcreteFunc(_) | HeapType::NoFunc => HeapType::NoFunc,
+            HeapType::Func | HeapType::ConcreteFunc(_) | HeapType::NoFunc => HeapBottomType::NoFunc,
 
             HeapType::Any
             | HeapType::Eq
@@ -1121,11 +1175,11 @@ impl HeapType {
             | HeapType::ConcreteArray(_)
             | HeapType::Struct
             | HeapType::ConcreteStruct(_)
-            | HeapType::None => HeapType::None,
+            | HeapType::None => HeapBottomType::None,
 
-            HeapType::Cont | HeapType::ConcreteCont(_) | HeapType::NoCont => HeapType::NoCont,
+            HeapType::Cont | HeapType::ConcreteCont(_) | HeapType::NoCont => HeapBottomType::NoCont,
 
-            HeapType::Exn | HeapType::ConcreteExn(_) | HeapType::NoExn => HeapType::NoExn,
+            HeapType::Exn | HeapType::ConcreteExn(_) | HeapType::NoExn => HeapBottomType::NoExn,
         }
     }
 
@@ -1402,10 +1456,8 @@ impl HeapType {
     #[inline]
     pub(crate) fn is_vmgcref_type(&self) -> bool {
         match self.top() {
-            Self::Any | Self::Extern | Self::Exn => true,
-            Self::Func => false,
-            Self::Cont => false,
-            ty => unreachable!("not a top type: {ty:?}"),
+            HeapTopType::Any | HeapTopType::Extern | HeapTopType::Exn => true,
+            HeapTopType::Func | HeapTopType::Cont => false,
         }
     }
 

--- a/crates/wasmtime/src/runtime/values.rs
+++ b/crates/wasmtime/src/runtime/values.rs
@@ -1,7 +1,7 @@
 use crate::store::{AutoAssertNoGc, StoreOpaque};
 use crate::{
-    AnyRef, ArrayRef, AsContext, AsContextMut, ExnRef, ExternRef, Func, HeapType, RefType, Rooted,
-    StructRef, V128, ValType, prelude::*,
+    AnyRef, ArrayRef, AsContext, AsContextMut, ExnRef, ExternRef, Func, HeapTopType, HeapType,
+    RefType, Rooted, StructRef, V128, ValType, prelude::*,
 };
 use core::ptr;
 
@@ -858,11 +858,11 @@ impl Ref {
     #[inline]
     pub fn null(heap_type: &HeapType) -> Self {
         match heap_type.top() {
-            HeapType::Any => Ref::Any(None),
-            HeapType::Extern => Ref::Extern(None),
-            HeapType::Func => Ref::Func(None),
-            HeapType::Exn => Ref::Exn(None),
-            ty => unreachable!("not a heap type: {ty:?}"),
+            HeapTopType::Any => Ref::Any(None),
+            HeapTopType::Extern => Ref::Extern(None),
+            HeapTopType::Func => Ref::Func(None),
+            HeapTopType::Exn => Ref::Exn(None),
+            HeapTopType::Cont => unimplemented!("embedding API for `(ref cont)`"),
         }
     }
 

--- a/crates/wasmtime/src/runtime/vm/gc/gc_ref.rs
+++ b/crates/wasmtime/src/runtime/vm/gc/gc_ref.rs
@@ -1,7 +1,7 @@
 use crate::runtime::vm::{FuncRefTableId, GcHeap, GcStore, I31, SendSyncPtr};
 use crate::store::AutoAssertNoGc;
 use crate::{
-    AnyRef, ExnRef, ExternRef, Func, HeapType, Result, StorageType, Val, ValType, bail_bug,
+    AnyRef, ExnRef, ExternRef, Func, HeapTopType, Result, StorageType, Val, ValType, bail_bug,
 };
 use core::fmt;
 use core::marker;
@@ -440,19 +440,19 @@ impl VMGcRef {
             StorageType::ValType(ValType::F64) => Val::F64(data.read_u64(offset)?),
             StorageType::ValType(ValType::V128) => Val::V128(data.read_v128(offset)?),
             StorageType::ValType(ValType::Ref(r)) => match r.heap_type().top() {
-                HeapType::Extern => {
+                HeapTopType::Extern => {
                     let raw = data.read_u32(offset)?;
                     Val::ExternRef(ExternRef::_from_raw(store, raw))
                 }
-                HeapType::Any => {
+                HeapTopType::Any => {
                     let raw = data.read_u32(offset)?;
                     Val::AnyRef(AnyRef::_from_raw(store, raw))
                 }
-                HeapType::Exn => {
+                HeapTopType::Exn => {
                     let raw = data.read_u32(offset)?;
                     Val::ExnRef(ExnRef::_from_raw(store, raw))
                 }
-                HeapType::Func => {
+                HeapTopType::Func => {
                     let func_ref_id = data.read_u32(offset)?;
                     let func_ref_id = FuncRefTableId::from_raw(func_ref_id);
                     let func_ref = store
@@ -463,7 +463,7 @@ impl VMGcRef {
                         func_ref.map(|p| Func::from_vm_func_ref(store.id(), p.as_non_null()))
                     })
                 }
-                otherwise => bail_bug!("not a top type: {otherwise:?}"),
+                HeapTopType::Cont => bail_bug!("continuation references are unsupported"),
             },
         })
     }

--- a/tests/all/types.rs
+++ b/tests/all/types.rs
@@ -19,6 +19,37 @@ fn valty(heap_ty: HeapType) -> ValType {
 }
 
 #[test]
+fn heap_type_top_and_bottom() {
+    for (heap_type, top, bottom) in [
+        (
+            HeapType::Extern,
+            HeapTopType::Extern,
+            HeapBottomType::NoExtern,
+        ),
+        (
+            HeapType::NoExtern,
+            HeapTopType::Extern,
+            HeapBottomType::NoExtern,
+        ),
+        (HeapType::Func, HeapTopType::Func, HeapBottomType::NoFunc),
+        (HeapType::NoFunc, HeapTopType::Func, HeapBottomType::NoFunc),
+        (HeapType::Any, HeapTopType::Any, HeapBottomType::None),
+        (HeapType::Eq, HeapTopType::Any, HeapBottomType::None),
+        (HeapType::I31, HeapTopType::Any, HeapBottomType::None),
+        (HeapType::Array, HeapTopType::Any, HeapBottomType::None),
+        (HeapType::Struct, HeapTopType::Any, HeapBottomType::None),
+        (HeapType::None, HeapTopType::Any, HeapBottomType::None),
+        (HeapType::Cont, HeapTopType::Cont, HeapBottomType::NoCont),
+        (HeapType::NoCont, HeapTopType::Cont, HeapBottomType::NoCont),
+        (HeapType::Exn, HeapTopType::Exn, HeapBottomType::NoExn),
+        (HeapType::NoExn, HeapTopType::Exn, HeapBottomType::NoExn),
+    ] {
+        assert_eq!(heap_type.top(), top);
+        assert_eq!(heap_type.bottom(), bottom);
+    }
+}
+
+#[test]
 fn basic_array_types() -> Result<()> {
     let engine = Engine::default();
     for mutability in [Mutability::Const, Mutability::Var] {


### PR DESCRIPTION
This allows us to exhaustively match on top and bottom types, instead of matching on heap types with wildcards for non-top/non-bottom heap types, which then don't get updated when we add support for new Wasm proposals that introduce new type hierarchies.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please review the Bytecode Alliance's AI tool usage policy at
https://github.com/bytecodealliance/governance/blob/main/AI_TOOL_POLICY.md

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
