### PR TITLE
winch: catch exception references

### DIFF
--- a/crates/test-macros/src/wasmtime_test.rs
+++ b/crates/test-macros/src/wasmtime_test.rs
@@ -1,8 +1,8 @@
 //! Wasmtime test macro.
 //!
 //! This macro is a helper to define tests that exercise multiple configuration
-//! combinations for Wasmtime. Currently compiler strategies and wasm features
-//! are supported.
+//! combinations for Wasmtime. Currently compiler strategies, garbage
+//! collectors, and wasm features are supported.
 //!
 //! Usage
 //!
@@ -24,7 +24,18 @@
 //! }
 //! ```
 //!
-//! To explicitly indicate that a wasm features is needed
+//! To use specific garbage collectors:
+//!
+//! ```rust
+//! #[wasmtime_test(collectors(Null, DeferredReferenceCounting))]
+//! fn my_test(config: &mut Config) -> Result<()> {
+//!     Ok(())
+//! }
+//! ```
+//!
+//! Use `collectors(All)` to test all concrete garbage collectors.
+//!
+//! To explicitly indicate that a wasm feature is needed:
 //! ```
 //! #[wasmtime_test(wasm_features(gc))]
 //! fn my_wasm_gc_test(config: &mut Config) -> Result<()> {
@@ -45,11 +56,12 @@ use syn::{
     parse::{Parse, ParseStream},
     parse_macro_input, token,
 };
-use wasmtime_test_util::wast::Compiler;
+use wasmtime_test_util::wast::{Collector, Compiler};
 
 /// Test configuration.
 struct TestConfig {
     strategies: Vec<Compiler>,
+    collectors: Vec<Collector>,
     flags: wasmtime_test_util::wast::TestConfig,
 }
 
@@ -111,6 +123,52 @@ impl TestConfig {
 
         Ok(())
     }
+
+    fn collectors_from(&mut self, meta: &ParseNestedMeta) -> Result<()> {
+        let mut collectors = Vec::new();
+        meta.parse_nested_meta(|meta| {
+            if meta.path.is_ident("All") {
+                if !collectors.is_empty() {
+                    return Err(meta.error("`All` cannot be combined with other collectors"));
+                }
+                collectors.extend([
+                    Collector::Null,
+                    Collector::Copying,
+                    Collector::DeferredReferenceCounting,
+                ]);
+                return Ok(());
+            }
+
+            let collector = if meta.path.is_ident("Auto") {
+                Collector::Auto
+            } else if meta.path.is_ident("Null") {
+                Collector::Null
+            } else if meta.path.is_ident("DeferredReferenceCounting") {
+                Collector::DeferredReferenceCounting
+            } else if meta.path.is_ident("Copying") {
+                Collector::Copying
+            } else {
+                return Err(meta.error("Unknown collector"));
+            };
+
+            if collector == Collector::Auto && !collectors.is_empty()
+                || collector != Collector::Auto && collectors.contains(&Collector::Auto)
+            {
+                return Err(meta.error("`Auto` cannot be combined with other collectors"));
+            }
+            if collectors.contains(&collector) {
+                return Err(meta.error("Duplicate collector"));
+            }
+            collectors.push(collector);
+            Ok(())
+        })?;
+
+        if collectors.is_empty() {
+            return Err(meta.error("Expected at least one collector"));
+        }
+        self.collectors = collectors;
+        Ok(())
+    }
 }
 
 impl Default for TestConfig {
@@ -121,6 +179,7 @@ impl Default for TestConfig {
                 Compiler::Winch,
                 Compiler::CraneliftPulley,
             ],
+            collectors: vec![Collector::Auto],
             flags: Default::default(),
         }
     }
@@ -193,6 +252,8 @@ pub fn run(attrs: TokenStream, item: TokenStream) -> TokenStream {
     let config_parser = syn::meta::parser(|meta| {
         if meta.path.is_ident("strategies") {
             test_config.strategies_from(&meta)
+        } else if meta.path.is_ident("collectors") {
+            test_config.collectors_from(&meta)
         } else if meta.path.is_ident("wasm_features") {
             test_config.wasm_features_from(&meta)
         } else {
@@ -211,6 +272,14 @@ pub fn run(attrs: TokenStream, item: TokenStream) -> TokenStream {
 fn expand(test_config: &TestConfig, func: Fn) -> Result<TokenStream> {
     let mut tests = vec![quote! { #func }];
     let attrs = &func.attrs;
+    let func_name = &func.sig.ident;
+
+    match &func.sig.output {
+        ReturnType::Default => {
+            return Err(syn::Error::new(func_name.span(), "Expected `Result<()>`"));
+        }
+        ReturnType::Type(..) => {}
+    };
 
     let test_attr = if func.sig.asyncness.is_some() {
         quote! { #[tokio::test] }
@@ -225,17 +294,6 @@ fn expand(test_config: &TestConfig, func: Fn) -> Result<TokenStream> {
         } else {
             (quote! {}, quote! {})
         };
-        let func_name = &func.sig.ident;
-        match &func.sig.output {
-            ReturnType::Default => {
-                return Err(syn::Error::new(func_name.span(), "Expected `Result<()>`"));
-            }
-            ReturnType::Type(..) => {}
-        };
-        let test_name = Ident::new(
-            &format!("{}_{}", strategy_name.to_lowercase(), func_name),
-            func_name.span(),
-        );
 
         // Ignore non-pulley tests in Miri as that's the only compiler which
         // works in Miri.
@@ -244,46 +302,67 @@ fn expand(test_config: &TestConfig, func: Fn) -> Result<TokenStream> {
             _ => quote!(#[cfg_attr(miri, ignore)]),
         };
 
-        let test_config = format!("wasmtime_test_util::wast::{:?}", test_config.flags)
+        let flags = format!("wasmtime_test_util::wast::{:?}", test_config.flags)
             .parse::<proc_macro2::TokenStream>()
             .unwrap();
         let strategy_ident = quote::format_ident!("{strategy_name}");
 
-        let tok = quote! {
-            #test_attr
-            #(#attrs)*
-            #ignore_miri
-            #asyncness fn #test_name() {
-                // Skip this test completely if the compiler doesn't support
-                // this host.
-                let compiler = wasmtime_test_util::wast::Compiler::#strategy_ident;
-                if !compiler.supports_host() {
-                    return;
-                }
-                let _ = env_logger::try_init();
-                let mut config = Config::new();
-                wasmtime_test_util::wasmtime_wast::apply_test_config(
-                    &mut config,
-                    &#test_config,
-                );
-                wasmtime_test_util::wasmtime_wast::apply_wast_config(
-                    &mut config,
-                    &wasmtime_test_util::wast::WastConfig {
-                        compiler,
-                        pooling: false,
-                        collector: wasmtime_test_util::wast::Collector::Auto,
-                    },
-                );
-                let result = #func_name(&mut config) #await_;
-                if compiler.should_fail(&#test_config) {
-                    assert!(result.is_err());
-                } else {
-                    result.unwrap();
-                }
-            }
-        };
+        for collector in &test_config.collectors {
+            let collector_name = format!("{collector:?}");
+            let collector_ident = quote::format_ident!("{collector_name}");
+            let collector_suffix = match collector {
+                Collector::Auto => None,
+                Collector::Null => Some("null"),
+                Collector::DeferredReferenceCounting => Some("drc"),
+                Collector::Copying => Some("copying"),
+            };
+            let test_name = match collector_suffix {
+                Some(collector) => format!(
+                    "{}_{}_{}",
+                    strategy_name.to_lowercase(),
+                    collector,
+                    func_name
+                ),
+                None => format!("{}_{}", strategy_name.to_lowercase(), func_name),
+            };
+            let test_name = Ident::new(&test_name, func_name.span());
 
-        tests.push(tok);
+            let tok = quote! {
+                #test_attr
+                #(#attrs)*
+                #ignore_miri
+                #asyncness fn #test_name() {
+                    // Skip this test completely if the compiler doesn't support
+                    // this host.
+                    let compiler = wasmtime_test_util::wast::Compiler::#strategy_ident;
+                    if !compiler.supports_host() {
+                        return;
+                    }
+                    let _ = env_logger::try_init();
+                    let mut config = Config::new();
+                    wasmtime_test_util::wasmtime_wast::apply_test_config(
+                        &mut config,
+                        &#flags,
+                    );
+                    wasmtime_test_util::wasmtime_wast::apply_wast_config(
+                        &mut config,
+                        &wasmtime_test_util::wast::WastConfig {
+                            compiler,
+                            pooling: false,
+                            collector: wasmtime_test_util::wast::Collector::#collector_ident,
+                        },
+                    );
+                    let result = #func_name(&mut config) #await_;
+                    if compiler.should_fail(&#flags) {
+                        assert!(result.is_err());
+                    } else {
+                        result.unwrap();
+                    }
+                }
+            };
+
+            tests.push(tok);
+        }
     }
     Ok(quote! {
         #(#tests)*

--- a/crates/test-util/src/wast.rs
+++ b/crates/test-util/src/wast.rs
@@ -197,6 +197,11 @@ fn spec_test_config(test: &Path) -> TestConfig {
             {
                 ret.gc = Some(true);
             }
+            if test_name == "throw_ref.wast" {
+                // This test only uses exception references, which do not
+                // require enabling the GC proposal.
+                ret.gc = Some(false);
+            }
             if test_name.contains("return_") || test_name.contains("try_table") {
                 ret.tail_call = Some(true);
             }

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -2467,8 +2467,6 @@ impl Config {
                 }
             }
             Some(Strategy::Winch) => {
-                // Exception handling in Winch is a work in progress. Throws currently
-                // compile as uncatchable traps.
                 unsupported |= WasmFeatures::GC
                     | WasmFeatures::FUNCTION_REFERENCES
                     | WasmFeatures::RELAXED_SIMD

--- a/docs/stability-tiers.md
+++ b/docs/stability-tiers.md
@@ -232,7 +232,7 @@ here is:
 | [`gc`]                                  | ✅        | ❌     |
 | [`wide-arithmetic`]                     | ✅        | ✅     |
 | [`custom-page-sizes`]                   | ✅        | ✅     |
-| [`exception-handling`]                  | ✅        | ❌     |
+| [`exception-handling`]                  | ✅        | ✅     |
 | [`stack-switching`]                     | 🚧        | ❌     |
 
 ##### aarch64
@@ -257,7 +257,7 @@ here is:
 | [`gc`]                                  | ✅        | ❌        |
 | [`wide-arithmetic`]                     | ✅        | ❌        |
 | [`custom-page-sizes`]                   | ✅        | ✅        |
-| [`exception-handling`]                  | ✅        | ❌        |
+| [`exception-handling`]                  | ✅        | ✅        |
 | [`stack-switching`]                     | ❌        | ❌        |
 
 ##### s390x

--- a/tests/all/exceptions.rs
+++ b/tests/all/exceptions.rs
@@ -793,12 +793,23 @@ fn store_pending_exnref_is_cloned(config: &mut Config) -> wasmtime::Result<()> {
     Ok(())
 }
 
-// Winch does not implement `catch_ref` yet.
-#[wasmtime_test(strategies(not(Winch)), wasm_features(exceptions, reference_types))]
+#[wasmtime_test(wasm_features(exceptions, reference_types))]
 #[cfg_attr(miri, ignore)]
 fn store_pending_exnref_is_exposed(config: &mut Config) -> wasmtime::Result<()> {
-    config.collector(Collector::DeferredReferenceCounting);
-    let engine = Engine::new(&config)?;
+    for collector in [
+        Collector::Null,
+        Collector::Copying,
+        Collector::DeferredReferenceCounting,
+    ] {
+        config.collector(collector);
+        run_store_pending_exnref_is_exposed(config)?;
+    }
+
+    Ok(())
+}
+
+fn run_store_pending_exnref_is_exposed(config: &Config) -> wasmtime::Result<()> {
+    let engine = Engine::new(config)?;
     let mut store = Store::new(&engine, ());
 
     let module = Module::new(
@@ -812,6 +823,17 @@ fn store_pending_exnref_is_exposed(config: &mut Config) -> wasmtime::Result<()> 
           (func (export "run") (result i32 (ref exn))
             (block $h (result i32 (ref exn))
               (try_table (result i32) (catch_ref $t1 $h)
+                call $throw_t1
+                unreachable
+              )
+              unreachable
+            )
+            call $gc
+          )
+
+          (func (export "run_all") (result (ref exn))
+            (block $h (result (ref exn))
+              (try_table (catch_all_ref $h)
                 call $throw_t1
                 unreachable
               )
@@ -861,6 +883,74 @@ fn store_pending_exnref_is_exposed(config: &mut Config) -> wasmtime::Result<()> 
     store.gc(None)?;
 
     assert_eq!(exnref.field(&mut store, 0)?.unwrap_i32(), 0x1111_1111);
+
+    let run_all = instance.get_typed_func::<(), Rooted<ExnRef>>(&mut store, "run_all")?;
+    let exnref = run_all.call(&mut store, ())?;
+
+    store.gc(None)?;
+
+    assert_eq!(exnref.field(&mut store, 0)?.unwrap_i32(), 0x1111_1111);
+    Ok(())
+}
+
+#[wasmtime_test(wasm_features(exceptions, reference_types))]
+#[cfg_attr(miri, ignore)]
+fn catch_ref_preserves_externref_payload(config: &mut Config) -> wasmtime::Result<()> {
+    config.collector(Collector::DeferredReferenceCounting);
+    let engine = Engine::new(config)?;
+    let mut store = Store::new(&engine, ());
+
+    let module = Module::new(
+        &engine,
+        r#"
+        (module
+          (import "" "gc" (func $gc))
+          (tag $e (param externref i32))
+
+          (func $throw (param externref)
+            (throw $e (local.get 0) (i32.const 42)))
+
+          (func (export "catch") (param externref) (result externref i32 (ref exn))
+            (block $handler (result externref i32 (ref exn))
+              (try_table (catch_ref $e $handler)
+                (call $throw (local.get 0)))
+              unreachable)
+            call $gc)
+        )
+        "#,
+    )?;
+
+    let gc = Func::wrap(&mut store, |mut caller: Caller<'_, ()>| -> Result<()> {
+        caller.gc(None)?;
+        Ok(())
+    });
+    let instance = Instance::new(&mut store, &module, &[gc.into()])?;
+    let catch = instance
+        .get_typed_func::<
+            Option<Rooted<ExternRef>>,
+            (Option<Rooted<ExternRef>>, i32, Rooted<ExnRef>),
+        >(
+            &mut store, "catch",
+        )?;
+
+    let payload = ExternRef::new(&mut store, 0xDECAFu32)?;
+    let (caught, value, exnref) = catch.call(&mut store, Some(payload))?;
+    assert_eq!(value, 42);
+    let caught = caught.expect("catch_ref should return the payload");
+    let caught_data = caught
+        .data(&store)?
+        .and_then(|data| data.downcast_ref::<u32>().copied());
+    assert_eq!(caught_data, Some(0xDECAF));
+
+    let field = exnref.field(&mut store, 0)?;
+    let field = field
+        .unwrap_externref()
+        .expect("the exception payload should not be null");
+    let field_data = field
+        .data(&store)?
+        .and_then(|data| data.downcast_ref::<u32>().copied());
+    assert_eq!(field_data, Some(0xDECAF));
+    assert_eq!(exnref.field(&mut store, 1)?.unwrap_i32(), 42);
     Ok(())
 }
 
@@ -914,23 +1004,23 @@ fn store_pending_exnref_has_write_barrier(config: &mut Config) -> wasmtime::Resu
     Ok(())
 }
 
-// Winch does not support exnref values yet. Modules that place an exnref
-// in a value position should fail with a compile error instead of
-// panicking.
-#[wasmtime_test(strategies(only(Winch)), wasm_features(exceptions, reference_types))]
+#[wasmtime_test(wasm_features(exceptions, reference_types))]
 #[cfg_attr(miri, ignore)]
-fn exnref_local_is_unsupported(config: &mut Config) -> Result<()> {
+fn exnref_local_defaults_to_null(config: &mut Config) -> Result<()> {
     let engine = Engine::new(config)?;
-    let wat = r#"
+    let module = Module::new(
+        &engine,
+        r#"
         (module
-          (func (result i32)
+          (func (export "run") (result i32)
             (local exnref)
-            (i32.const 0)))
-    "#;
-    let err = Module::new(&engine, wat).unwrap_err();
-    assert!(
-        format!("{err:?}").contains("Unsupported Wasm type"),
-        "unexpected error: {err:?}"
-    );
+            local.get 0
+            ref.is_null))
+        "#,
+    )?;
+    let mut store = Store::new(&engine, ());
+    let instance = Instance::new(&mut store, &module, &[])?;
+    let run = instance.get_typed_func::<(), i32>(&mut store, "run")?;
+    assert_eq!(run.call(&mut store, ())?, 1);
     Ok(())
 }

--- a/tests/all/exceptions.rs
+++ b/tests/all/exceptions.rs
@@ -383,23 +383,9 @@ fn funcref_exception_payload_escape_to_host(config: &mut Config) -> Result<()> {
     Ok(())
 }
 
-#[wasmtime_test(wasm_features(exceptions, reference_types))]
+#[wasmtime_test(collectors(All), wasm_features(exceptions, reference_types))]
 #[cfg_attr(miri, ignore)]
 fn caught_funcref_payload(config: &mut Config) -> Result<()> {
-    for collector in [
-        Collector::Null,
-        Collector::Copying,
-        Collector::DeferredReferenceCounting,
-    ] {
-        println!("Using GC collector: {collector:?}");
-        config.collector(collector);
-        run_caught_funcref_payload(config)?;
-    }
-
-    Ok(())
-}
-
-fn run_caught_funcref_payload(config: &Config) -> Result<()> {
     let engine = Engine::new(config)?;
     let mut store = Store::new(&engine, ());
 
@@ -435,19 +421,12 @@ fn run_caught_funcref_payload(config: &Config) -> Result<()> {
     Ok(())
 }
 
-#[wasmtime_test(wasm_features(exceptions, reference_types))]
+#[wasmtime_test(
+    collectors(Copying, DeferredReferenceCounting),
+    wasm_features(exceptions, reference_types)
+)]
 #[cfg_attr(miri, ignore)]
 fn thrown_externref_payload_survives_gc(config: &mut Config) -> Result<()> {
-    for collector in [Collector::Copying, Collector::DeferredReferenceCounting] {
-        println!("Using GC collector: {collector:?}");
-        config.collector(collector);
-        run_thrown_externref_payload_survives_gc(config)?;
-    }
-
-    Ok(())
-}
-
-fn run_thrown_externref_payload_survives_gc(config: &Config) -> Result<()> {
     let engine = Engine::new(config)?;
     let mut store = Store::new(&engine, ());
 
@@ -485,23 +464,9 @@ fn run_thrown_externref_payload_survives_gc(config: &Config) -> Result<()> {
     Ok(())
 }
 
-#[wasmtime_test(wasm_features(exceptions, reference_types))]
+#[wasmtime_test(collectors(All), wasm_features(exceptions, reference_types))]
 #[cfg_attr(miri, ignore)]
 fn caught_externref_payload_survives_gc(config: &mut Config) -> Result<()> {
-    for collector in [
-        Collector::Null,
-        Collector::Copying,
-        Collector::DeferredReferenceCounting,
-    ] {
-        println!("Using GC collector: {collector:?}");
-        config.collector(collector);
-        run_caught_externref_payload_survives_gc(config)?;
-    }
-
-    Ok(())
-}
-
-fn run_caught_externref_payload_survives_gc(config: &Config) -> Result<()> {
     let engine = Engine::new(config)?;
     let mut store = Store::new(&engine, ());
 
@@ -545,10 +510,9 @@ fn run_caught_externref_payload_survives_gc(config: &Config) -> Result<()> {
     Ok(())
 }
 
-#[wasmtime_test(wasm_features(exceptions))]
+#[wasmtime_test(collectors(Null), wasm_features(exceptions))]
 #[cfg_attr(miri, ignore)]
 fn throw_with_null_collector(config: &mut Config) -> Result<()> {
-    config.collector(Collector::Null);
     let engine = Engine::new(config)?;
     let mut store = Store::new(&engine, ());
 
@@ -738,10 +702,9 @@ fn wasm_exceptions_have_backtraces(config: &mut Config) -> Result<()> {
     Ok(())
 }
 
-#[wasmtime_test(wasm_features(exceptions))]
+#[wasmtime_test(collectors(DeferredReferenceCounting), wasm_features(exceptions))]
 #[cfg_attr(miri, ignore)]
 fn store_pending_exnref_is_cloned(config: &mut Config) -> wasmtime::Result<()> {
-    config.collector(Collector::DeferredReferenceCounting);
     let engine = Engine::new(&config)?;
     let mut store = Store::new(&engine, ());
 
@@ -793,22 +756,9 @@ fn store_pending_exnref_is_cloned(config: &mut Config) -> wasmtime::Result<()> {
     Ok(())
 }
 
-#[wasmtime_test(wasm_features(exceptions, reference_types))]
+#[wasmtime_test(collectors(All), wasm_features(exceptions, reference_types))]
 #[cfg_attr(miri, ignore)]
 fn store_pending_exnref_is_exposed(config: &mut Config) -> wasmtime::Result<()> {
-    for collector in [
-        Collector::Null,
-        Collector::Copying,
-        Collector::DeferredReferenceCounting,
-    ] {
-        config.collector(collector);
-        run_store_pending_exnref_is_exposed(config)?;
-    }
-
-    Ok(())
-}
-
-fn run_store_pending_exnref_is_exposed(config: &Config) -> wasmtime::Result<()> {
     let engine = Engine::new(config)?;
     let mut store = Store::new(&engine, ());
 
@@ -893,10 +843,12 @@ fn run_store_pending_exnref_is_exposed(config: &Config) -> wasmtime::Result<()> 
     Ok(())
 }
 
-#[wasmtime_test(wasm_features(exceptions, reference_types))]
+#[wasmtime_test(
+    collectors(DeferredReferenceCounting),
+    wasm_features(exceptions, reference_types)
+)]
 #[cfg_attr(miri, ignore)]
 fn catch_ref_preserves_externref_payload(config: &mut Config) -> wasmtime::Result<()> {
-    config.collector(Collector::DeferredReferenceCounting);
     let engine = Engine::new(config)?;
     let mut store = Store::new(&engine, ());
 
@@ -962,9 +914,8 @@ impl Drop for SetFlagOnDrop {
     }
 }
 
-#[wasmtime_test(wasm_features(exceptions))]
+#[wasmtime_test(collectors(DeferredReferenceCounting), wasm_features(exceptions))]
 fn store_pending_exnref_has_write_barrier(config: &mut Config) -> wasmtime::Result<()> {
-    config.collector(Collector::DeferredReferenceCounting);
     let engine = Engine::new(&config)?;
     let mut store = Store::new(&engine, ());
 

--- a/tests/disas/winch/aarch64/exceptions/catch-ref-drc.wat
+++ b/tests/disas/winch/aarch64/exceptions/catch-ref-drc.wat
@@ -1,0 +1,206 @@
+;;! target = "aarch64"
+;;! test = "winch"
+;;! flags = "-W exceptions -C collector=drc"
+
+;; A `catch_ref` landing pad preserves the exception reference while the DRC
+;; read barrier loads an `externref` payload.
+(module
+  (tag $e (param externref))
+  (func
+    (block $h (result externref exnref)
+      (try_table (catch_ref $e $h)
+        (throw $e (ref.null extern)))
+      (unreachable))
+    (drop)
+    (drop)))
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
+;;       mov     x28, sp
+;;       ldur    x16, [x0, #8]
+;;       ldur    x16, [x16, #0x18]
+;;       mov     x17, #0
+;;       movk    x17, #0x20
+;;       add     x16, x16, x17
+;;       cmp     sp, x16
+;;       b.lo    #0x2cc
+;;   2c: mov     x9, x0
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x0, x9
+;;       bl      #0x48c
+;;       ├─╼ exception frame offset: SP = FP - 0x20
+;;       ╰─╼ exception handler: tag=0, context at [SP+0x8], handler=0x158
+;;   48: ldur    x9, [x28, #8]
+;;       ldur    x1, [x9, #0x28]
+;;       ldur    w1, [x1, #0xc]
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
+;;       stur    w0, [x28]
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
+;;       stur    w1, [x28]
+;;       sub     x28, x28, #8
+;;       mov     sp, x28
+;;       mov     x0, x9
+;;       mov     x1, #0x4000000
+;;       ldur    w2, [x28, #8]
+;;       mov     x3, #0x28
+;;       mov     x4, #8
+;;       bl      #0x43c
+;;       ├─╼ exception frame offset: SP = FP - 0x30
+;;       ╰─╼ exception handler: tag=0, context at [SP+0x18], handler=0x158
+;;   8c: add     x28, x28, #8
+;;       mov     sp, x28
+;;       add     x28, x28, #4
+;;       mov     sp, x28
+;;       ldur    x9, [x28, #0xc]
+;;       ldur    x1, [x9, #8]
+;;       ldur    x2, [x1, #0x28]
+;;       ldur    x1, [x1, #0x20]
+;;       mov     x2, x1
+;;       add     x2, x2, x0, uxtx
+;;       ldur    w1, [x28]
+;;       add     x28, x28, #4
+;;       mov     sp, x28
+;;       stur    w1, [x2, #0x18]
+;;       mov     x16, #0
+;;       stur    w16, [x2, #0x1c]
+;;       mov     x1, #0
+;;       tst     w1, w1
+;;       b.eq    #0x120
+;;       b       #0xdc
+;;   dc: mov     w16, w1
+;;       and     w16, w16, #1
+;;       tst     w16, w16
+;;       b.ne    #0x120
+;;       b       #0xf0
+;;   f0: ldur    x3, [x9, #8]
+;;       ldur    x4, [x3, #0x28]
+;;       ldur    x3, [x3, #0x20]
+;;       mov     x16, x1
+;;       add     x16, x16, #0x10
+;;       cmp     x16, x4, uxtx
+;;       b.hi    #0x2d0
+;;  10c: mov     x5, x3
+;;       add     x5, x5, x1, uxtx
+;;       ldur    x6, [x5, #8]
+;;       add     x6, x6, #1
+;;       stur    x6, [x5, #8]
+;;       stur    w1, [x2, #0x20]
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
+;;       stur    w0, [x28]
+;;       sub     x28, x28, #0xc
+;;       mov     sp, x28
+;;       mov     x0, x9
+;;       ldur    w1, [x28, #0xc]
+;;       bl      #0x4bc
+;;       ├─╼ exception frame offset: SP = FP - 0x30
+;;       ╰─╼ exception handler: tag=0, context at [SP+0x18], handler=0x158
+;;  144: add     x28, x28, #0xc
+;;       mov     sp, x28
+;;       add     x28, x28, #4
+;;       mov     sp, x28
+;;       ldur    x9, [x28, #8]
+;;       mov     x28, x29
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
+;;       ldur    x9, [x28, #8]
+;;       ldur    x1, [x9, #8]
+;;       ldur    x2, [x1, #0x28]
+;;       ldur    x1, [x1, #0x20]
+;;       mov     x16, x0
+;;       add     x16, x16, #0x28
+;;       cmp     x16, x2, uxtx
+;;       b.hi    #0x2d4
+;;  18c: mov     x2, x1
+;;       add     x2, x2, x0, uxtx
+;;       ldur    w1, [x2, #0x20]
+;;       sub     x28, x28, #8
+;;       mov     sp, x28
+;;       stur    x2, [x28]
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
+;;       stur    w0, [x28]
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
+;;       stur    w1, [x28]
+;;       ldur    w0, [x28]
+;;       tst     w0, w0
+;;       b.eq    #0x278
+;;       b       #0x1cc
+;;  1cc: mov     w16, w0
+;;       and     w16, w16, #1
+;;       tst     w16, w16
+;;       b.ne    #0x278
+;;       b       #0x1e0
+;;  1e0: ldur    x1, [x9, #8]
+;;       ldur    x2, [x1, #0x28]
+;;       ldur    x1, [x1, #0x20]
+;;       mov     x16, x0
+;;       add     x16, x16, #0x14
+;;       cmp     x16, x2, uxtx
+;;       b.hi    #0x2d8
+;;  1fc: mov     x2, x1
+;;       add     x2, x2, x0, uxtx
+;;       ldur    w16, [x2]
+;;       and     w16, w16, #2
+;;       tst     w16, w16
+;;       b.ne    #0x278
+;;       b       #0x218
+;;  218: ldur    x3, [x9, #0x20]
+;;       ldur    w16, [x3]
+;;       stur    w16, [x2, #0x10]
+;;       ldur    w16, [x2]
+;;       orr     w16, w16, #2
+;;       stur    w16, [x2]
+;;       ldur    x4, [x2, #8]
+;;       add     x4, x4, #1
+;;       stur    x4, [x2, #8]
+;;       stur    w0, [x3]
+;;       ldur    w4, [x3, #4]
+;;       add     w4, w4, #1
+;;       stur    w4, [x3, #4]
+;;       ldur    w16, [x3, #8]
+;;       add     w16, w16, w16, uxtx
+;;       cmp     w4, w16, uxtx
+;;       b.lo    #0x278
+;;       b       #0x260
+;;  260: cmp     w4, #0x400
+;;       b.lo    #0x278
+;;       b       #0x26c
+;;  26c: mov     x0, x9
+;;       bl      #0x510
+;;  274: ldur    x9, [x28, #0x18]
+;;       ╰─╼ stack_map: frame_size=48, frame_offsets=[0, 4]
+;;       ldur    w0, [x28]
+;;       add     x28, x28, #4
+;;       mov     sp, x28
+;;       ldur    w1, [x28]
+;;       add     x28, x28, #4
+;;       mov     sp, x28
+;;       ldur    x2, [x28]
+;;       add     x28, x28, #8
+;;       mov     sp, x28
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
+;;       stur    w0, [x28]
+;;       mov     w0, w1
+;;       add     x28, x28, #4
+;;       mov     sp, x28
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
+;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret
+;;  2cc: udf     #0xc11f
+;;  2d0: udf     #0xc11f
+;;  2d4: udf     #0xc11f
+;;  2d8: udf     #0xc11f

--- a/tests/disas/winch/aarch64/exceptions/catch-ref-null.wat
+++ b/tests/disas/winch/aarch64/exceptions/catch-ref-null.wat
@@ -1,0 +1,209 @@
+;;! target = "aarch64"
+;;! test = "winch"
+;;! flags = "-W exceptions -C collector=null"
+
+;; A `catch_ref` landing pad appends the exception reference after the tag's
+;; payload fields before branching to its target.
+(module
+  (tag $e (param funcref))
+  (func
+    (block $h (result funcref exnref)
+      (try_table (result funcref) (catch_ref $e $h)
+        (throw $e (ref.null func)))
+      (unreachable))
+    (throw_ref)))
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
+;;       mov     x28, sp
+;;       ldur    x16, [x0, #8]
+;;       ldur    x16, [x16, #0x18]
+;;       mov     x17, #0
+;;       movk    x17, #0x30
+;;       add     x16, x16, x17
+;;       cmp     sp, x16
+;;       b.lo    #0x2d0
+;;   2c: mov     x9, x0
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x0, x9
+;;       bl      #0x51c
+;;       ├─╼ exception frame offset: SP = FP - 0x20
+;;       ╰─╼ exception handler: tag=0, context at [SP+0x8], handler=0x1dc
+;;   48: ldur    x9, [x28, #8]
+;;       ldur    x16, [x9, #0x20]
+;;       ldur    w1, [x16]
+;;       adds    w1, w1, #7
+;;       b.hs    #0x2d4
+;;   5c: and     w1, w1, #0xfffffff8
+;;       mov     w2, w1
+;;       adds    w2, w2, #0x18
+;;       b.hs    #0x2d8
+;;   6c: sub     x28, x28, #4
+;;       mov     sp, x28
+;;       stur    w0, [x28]
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
+;;       stur    w1, [x28]
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
+;;       stur    w2, [x28]
+;;       ldur    w0, [x28]
+;;       add     x28, x28, #4
+;;       mov     sp, x28
+;;       ldur    x1, [x9, #8]
+;;       ldur    x2, [x1, #0x28]
+;;       ldur    x1, [x1, #0x20]
+;;       cmp     x0, x2, uxtx
+;;       b.ls    #0xdc
+;;       b       #0xb4
+;;   b4: sub     x0, x0, x2, uxtx
+;;       sub     x28, x28, #8
+;;       mov     sp, x28
+;;       stur    x0, [x28]
+;;       mov     x0, x9
+;;       ldur    x1, [x28]
+;;       bl      #0x440
+;;       ├─╼ exception frame offset: SP = FP - 0x30
+;;       ╰─╼ exception handler: tag=0, context at [SP+0x18], handler=0x1dc
+;;   d0: add     x28, x28, #8
+;;       mov     sp, x28
+;;       ldur    x9, [x28, #0x10]
+;;       ldur    w0, [x28]
+;;       add     x28, x28, #4
+;;       mov     sp, x28
+;;       ldur    x1, [x9, #8]
+;;       ldur    x2, [x1, #0x28]
+;;       ldur    x1, [x1, #0x20]
+;;       mov     x2, x1
+;;       add     x2, x2, x0, uxtx
+;;       mov     w16, #0x18
+;;       movk    w16, #0x400, lsl #16
+;;       stur    w16, [x2]
+;;       ldur    x16, [x9, #0x28]
+;;       ldur    w16, [x16, #0xc]
+;;       stur    w16, [x2, #4]
+;;       ldur    x1, [x9, #0x20]
+;;       mov     w16, w0
+;;       add     w16, w16, #0x18
+;;       stur    w16, [x1]
+;;       ldur    w1, [x28]
+;;       add     x28, x28, #4
+;;       mov     sp, x28
+;;       stur    w1, [x2, #8]
+;;       mov     x16, #0
+;;       stur    w16, [x2, #0xc]
+;;       mov     x1, #0
+;;       sub     x28, x28, #8
+;;       mov     sp, x28
+;;       stur    x2, [x28]
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
+;;       stur    w0, [x28]
+;;       sub     x28, x28, #8
+;;       mov     sp, x28
+;;       stur    x1, [x28]
+;;       sub     x28, x28, #0xc
+;;       mov     sp, x28
+;;       mov     x0, x9
+;;       ldur    x1, [x28, #0xc]
+;;       bl      #0x494
+;;       ├─╼ exception frame offset: SP = FP - 0x40
+;;       ╰─╼ exception handler: tag=0, context at [SP+0x28], handler=0x1dc
+;;  178: add     x28, x28, #0xc
+;;       mov     sp, x28
+;;       add     x28, x28, #8
+;;       mov     sp, x28
+;;       ldur    x9, [x28, #0x14]
+;;       ldur    w1, [x28]
+;;       add     x28, x28, #4
+;;       mov     sp, x28
+;;       ldur    x2, [x28]
+;;       add     x28, x28, #8
+;;       mov     sp, x28
+;;       stur    w0, [x2, #0x10]
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
+;;       stur    w1, [x28]
+;;       sub     x28, x28, #0xc
+;;       mov     sp, x28
+;;       mov     x0, x9
+;;       ldur    w1, [x28, #0xc]
+;;       bl      #0x54c
+;;       ├─╼ exception frame offset: SP = FP - 0x30
+;;       ╰─╼ exception handler: tag=0, context at [SP+0x18], handler=0x1dc
+;;  1c8: add     x28, x28, #0xc
+;;       mov     sp, x28
+;;       add     x28, x28, #4
+;;       mov     sp, x28
+;;       ldur    x9, [x28, #8]
+;;       mov     x28, x29
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
+;;       ldur    x9, [x28, #8]
+;;       ldur    x1, [x9, #8]
+;;       ldur    x2, [x1, #0x28]
+;;       ldur    x1, [x1, #0x20]
+;;       mov     x16, x0
+;;       add     x16, x16, #0x18
+;;       cmp     x16, x2, uxtx
+;;       b.hi    #0x2dc
+;;  210: mov     x2, x1
+;;       add     x2, x2, x0, uxtx
+;;       ldur    w1, [x2, #0x10]
+;;       sub     x28, x28, #8
+;;       mov     sp, x28
+;;       stur    x2, [x28]
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
+;;       stur    w0, [x28]
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
+;;       stur    w1, [x28]
+;;       mov     x0, x9
+;;       ldur    w1, [x28]
+;;       mov     x2, #0xffffffff
+;;       bl      #0x4c4
+;;  250: add     x28, x28, #4
+;;       ╰─╼ stack_map: frame_size=48, frame_offsets=[4]
+;;       mov     sp, x28
+;;       ldur    x9, [x28, #0x14]
+;;       ldur    w1, [x28]
+;;       add     x28, x28, #4
+;;       mov     sp, x28
+;;       ldur    x2, [x28]
+;;       add     x28, x28, #8
+;;       mov     sp, x28
+;;       sub     x28, x28, #8
+;;       mov     sp, x28
+;;       stur    x0, [x28]
+;;       mov     w0, w1
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
+;;       stur    w0, [x28]
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
+;;       mov     x0, x9
+;;       ldur    w1, [x28, #4]
+;;       bl      #0x54c
+;;  2a4: add     x28, x28, #4
+;;       ╰─╼ stack_map: frame_size=48, frame_offsets=[4]
+;;       mov     sp, x28
+;;       add     x28, x28, #4
+;;       mov     sp, x28
+;;       ldur    x9, [x28, #0x10]
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
+;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret
+;;  2d0: udf     #0xc11f
+;;  2d4: udf     #0xc11f
+;;  2d8: udf     #0xc11f
+;;  2dc: udf     #0xc11f

--- a/tests/disas/winch/aarch64/exceptions/catch-ref.wat
+++ b/tests/disas/winch/aarch64/exceptions/catch-ref.wat
@@ -1,0 +1,180 @@
+;;! target = "aarch64"
+;;! test = "winch"
+;;! flags = "-W exceptions -C collector=copying"
+
+;; A `catch_ref` landing pad appends the exception reference after the tag's
+;; payload fields before branching to its target.
+(module
+  (tag $e (param funcref))
+  (func
+    (block $h (result funcref exnref)
+      (try_table (result funcref) (catch_ref $e $h)
+        (throw $e (ref.null func)))
+      (unreachable))
+    (throw_ref)))
+;; wasm[0]::function[0]:
+;;       stp     x29, x30, [sp, #-0x10]!
+;;       mov     x29, sp
+;;       str     x28, [sp, #-0x10]!
+;;       mov     x28, sp
+;;       ldur    x16, [x0, #8]
+;;       ldur    x16, [x16, #0x18]
+;;       mov     x17, #0
+;;       movk    x17, #0x30
+;;       add     x16, x16, x17
+;;       cmp     sp, x16
+;;       b.lo    #0x264
+;;   2c: mov     x9, x0
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
+;;       stur    x0, [x28, #8]
+;;       stur    x1, [x28]
+;;       mov     x0, x9
+;;       bl      #0x4a4
+;;       ├─╼ exception frame offset: SP = FP - 0x20
+;;       ╰─╼ exception handler: tag=0, context at [SP+0x8], handler=0x170
+;;   48: ldur    x9, [x28, #8]
+;;       ldur    x1, [x9, #0x28]
+;;       ldur    w1, [x1, #0xc]
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
+;;       stur    w0, [x28]
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
+;;       stur    w1, [x28]
+;;       sub     x28, x28, #8
+;;       mov     sp, x28
+;;       mov     x0, x9
+;;       mov     w1, #2
+;;       movk    w1, #0x400, lsl #16
+;;       ldur    w2, [x28, #8]
+;;       mov     x3, #0x20
+;;       mov     x4, #0x10
+;;       bl      #0x3cc
+;;       ├─╼ exception frame offset: SP = FP - 0x30
+;;       ╰─╼ exception handler: tag=0, context at [SP+0x18], handler=0x170
+;;   90: add     x28, x28, #8
+;;       mov     sp, x28
+;;       add     x28, x28, #4
+;;       mov     sp, x28
+;;       ldur    x9, [x28, #0xc]
+;;       ldur    x1, [x9, #8]
+;;       ldur    x2, [x1, #0x28]
+;;       ldur    x1, [x1, #0x20]
+;;       mov     x2, x1
+;;       add     x2, x2, x0, uxtx
+;;       ldur    w1, [x28]
+;;       add     x28, x28, #4
+;;       mov     sp, x28
+;;       stur    w1, [x2, #0x10]
+;;       mov     x16, #0
+;;       stur    w16, [x2, #0x14]
+;;       mov     x1, #0
+;;       sub     x28, x28, #8
+;;       mov     sp, x28
+;;       stur    x2, [x28]
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
+;;       stur    w0, [x28]
+;;       sub     x28, x28, #8
+;;       mov     sp, x28
+;;       stur    x1, [x28]
+;;       sub     x28, x28, #0xc
+;;       mov     sp, x28
+;;       mov     x0, x9
+;;       ldur    x1, [x28, #0xc]
+;;       bl      #0x41c
+;;       ├─╼ exception frame offset: SP = FP - 0x40
+;;       ╰─╼ exception handler: tag=0, context at [SP+0x28], handler=0x170
+;;  10c: add     x28, x28, #0xc
+;;       mov     sp, x28
+;;       add     x28, x28, #8
+;;       mov     sp, x28
+;;       ldur    x9, [x28, #0x14]
+;;       ldur    w1, [x28]
+;;       add     x28, x28, #4
+;;       mov     sp, x28
+;;       ldur    x2, [x28]
+;;       add     x28, x28, #8
+;;       mov     sp, x28
+;;       stur    w0, [x2, #0x18]
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
+;;       stur    w1, [x28]
+;;       sub     x28, x28, #0xc
+;;       mov     sp, x28
+;;       mov     x0, x9
+;;       ldur    w1, [x28, #0xc]
+;;       bl      #0x4d4
+;;       ├─╼ exception frame offset: SP = FP - 0x30
+;;       ╰─╼ exception handler: tag=0, context at [SP+0x18], handler=0x170
+;;  15c: add     x28, x28, #0xc
+;;       mov     sp, x28
+;;       add     x28, x28, #4
+;;       mov     sp, x28
+;;       ldur    x9, [x28, #8]
+;;       mov     x28, x29
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
+;;       sub     x28, x28, #0x10
+;;       mov     sp, x28
+;;       ldur    x9, [x28, #8]
+;;       ldur    x1, [x9, #8]
+;;       ldur    x2, [x1, #0x28]
+;;       ldur    x1, [x1, #0x20]
+;;       mov     x16, x0
+;;       add     x16, x16, #0x20
+;;       cmp     x16, x2, uxtx
+;;       b.hi    #0x268
+;;  1a4: mov     x2, x1
+;;       add     x2, x2, x0, uxtx
+;;       ldur    w1, [x2, #0x18]
+;;       sub     x28, x28, #8
+;;       mov     sp, x28
+;;       stur    x2, [x28]
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
+;;       stur    w0, [x28]
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
+;;       stur    w1, [x28]
+;;       mov     x0, x9
+;;       ldur    w1, [x28]
+;;       mov     x2, #0xffffffff
+;;       bl      #0x44c
+;;  1e4: add     x28, x28, #4
+;;       ╰─╼ stack_map: frame_size=48, frame_offsets=[4]
+;;       mov     sp, x28
+;;       ldur    x9, [x28, #0x14]
+;;       ldur    w1, [x28]
+;;       add     x28, x28, #4
+;;       mov     sp, x28
+;;       ldur    x2, [x28]
+;;       add     x28, x28, #8
+;;       mov     sp, x28
+;;       sub     x28, x28, #8
+;;       mov     sp, x28
+;;       stur    x0, [x28]
+;;       mov     w0, w1
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
+;;       stur    w0, [x28]
+;;       sub     x28, x28, #4
+;;       mov     sp, x28
+;;       mov     x0, x9
+;;       ldur    w1, [x28, #4]
+;;       bl      #0x4d4
+;;  238: add     x28, x28, #4
+;;       ╰─╼ stack_map: frame_size=48, frame_offsets=[4]
+;;       mov     sp, x28
+;;       add     x28, x28, #4
+;;       mov     sp, x28
+;;       ldur    x9, [x28, #0x10]
+;;       add     x28, x28, #0x10
+;;       mov     sp, x28
+;;       mov     sp, x28
+;;       ldr     x28, [sp], #0x10
+;;       ldp     x29, x30, [sp], #0x10
+;;       ret
+;;  264: udf     #0xc11f
+;;  268: udf     #0xc11f

--- a/tests/disas/winch/x64/exceptions/catch-ref-drc.wat
+++ b/tests/disas/winch/x64/exceptions/catch-ref-drc.wat
@@ -1,0 +1,167 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = "-W exceptions -C collector=drc"
+
+;; A `catch_ref` landing pad preserves the exception reference while the DRC
+;; read barrier loads an `externref` payload.
+(module
+  (tag $e (param externref))
+  (func
+    (block $h (result externref exnref)
+      (try_table (catch_ref $e $h)
+        (throw $e (ref.null extern)))
+      (unreachable))
+    (drop)
+    (drop)))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x18(%r11), %r11
+;;       addq    $0x20, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x26b
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x10, %rsp
+;;       movq    %rdi, 8(%rsp)
+;;       movq    %rsi, (%rsp)
+;;       movq    %r14, %rdi
+;;       callq   0x3d7
+;;       ├─╼ exception frame offset: SP = FP - 0x10
+;;       ╰─╼ exception handler: tag=0, context at [SP+0x8], handler=0x13a
+;;       movq    8(%rsp), %r14
+;;       movq    0x28(%r14), %rcx
+;;       movl    0xc(%rcx), %ecx
+;;       subq    $4, %rsp
+;;       movl    %eax, (%rsp)
+;;       subq    $4, %rsp
+;;       movl    %ecx, (%rsp)
+;;       subq    $8, %rsp
+;;       movq    %r14, %rdi
+;;       movl    $0x4000000, %esi
+;;       movl    8(%rsp), %edx
+;;       movl    $0x28, %ecx
+;;       movl    $8, %r8d
+;;       callq   0x388
+;;       ├─╼ exception frame offset: SP = FP - 0x20
+;;       ╰─╼ exception handler: tag=0, context at [SP+0x18], handler=0x13a
+;;       addq    $8, %rsp
+;;       addq    $4, %rsp
+;;       movq    0xc(%rsp), %r14
+;;       movq    8(%r14), %rcx
+;;       movq    0x28(%rcx), %rdx
+;;       movq    0x20(%rcx), %rcx
+;;       movq    %rcx, %rdx
+;;       addq    %rax, %rdx
+;;       movl    (%rsp), %ecx
+;;       addq    $4, %rsp
+;;       movl    %ecx, 0x18(%rdx)
+;;       movl    $0, 0x1c(%rdx)
+;;       movl    $0, %ecx
+;;       testl   %ecx, %ecx
+;;       je      0x107
+;;   c0: movl    %ecx, %r11d
+;;       andl    $1, %r11d
+;;       testl   %r11d, %r11d
+;;       jne     0x107
+;;   d3: movq    8(%r14), %rbx
+;;       movq    0x28(%rbx), %rsi
+;;       movq    0x20(%rbx), %rbx
+;;       movq    %rcx, %r11
+;;       addq    $0x10, %r11
+;;       cmpq    %rsi, %r11
+;;       ja      0x26d
+;;   f2: movq    %rbx, %rdi
+;;       addq    %rcx, %rdi
+;;       movq    8(%rdi), %r8
+;;       addq    $1, %r8
+;;       movq    %r8, 8(%rdi)
+;;       movl    %ecx, 0x20(%rdx)
+;;       subq    $4, %rsp
+;;       movl    %eax, (%rsp)
+;;       subq    $0xc, %rsp
+;;       movq    %r14, %rdi
+;;       movl    0xc(%rsp), %esi
+;;       callq   0x404
+;;       ├─╼ exception frame offset: SP = FP - 0x20
+;;       ╰─╼ exception handler: tag=0, context at [SP+0x18], handler=0x13a
+;;       addq    $0xc, %rsp
+;;       addq    $4, %rsp
+;;       movq    8(%rsp), %r14
+;;       movq    %rbp, %rsp
+;;       subq    $0x10, %rsp
+;;       movq    8(%rsp), %r14
+;;       movq    8(%r14), %rcx
+;;       movq    0x28(%rcx), %rdx
+;;       movq    0x20(%rcx), %rcx
+;;       movq    %rax, %r11
+;;       addq    $0x28, %r11
+;;       cmpq    %rdx, %r11
+;;       ja      0x26f
+;;  168: movq    %rcx, %rdx
+;;       addq    %rax, %rdx
+;;       movl    0x20(%rdx), %ecx
+;;       pushq   %rdx
+;;       subq    $4, %rsp
+;;       movl    %eax, (%rsp)
+;;       subq    $4, %rsp
+;;       movl    %ecx, (%rsp)
+;;       movl    (%rsp), %eax
+;;       testl   %eax, %eax
+;;       je      0x23a
+;;  191: movl    %eax, %r11d
+;;       andl    $1, %r11d
+;;       testl   %r11d, %r11d
+;;       jne     0x23a
+;;  1a4: movq    8(%r14), %rcx
+;;       movq    0x28(%rcx), %rdx
+;;       movq    0x20(%rcx), %rcx
+;;       movq    %rax, %r11
+;;       addq    $0x14, %r11
+;;       cmpq    %rdx, %r11
+;;       ja      0x271
+;;  1c3: movq    %rcx, %rdx
+;;       addq    %rax, %rdx
+;;       movl    (%rdx), %r11d
+;;       andl    $2, %r11d
+;;       testl   %r11d, %r11d
+;;       jne     0x23a
+;;  1dc: movq    0x20(%r14), %rbx
+;;       movl    (%rbx), %r11d
+;;       movl    %r11d, 0x10(%rdx)
+;;       movl    (%rdx), %r11d
+;;       orl     $2, %r11d
+;;       movl    %r11d, (%rdx)
+;;       movq    8(%rdx), %rsi
+;;       addq    $1, %rsi
+;;       movq    %rsi, 8(%rdx)
+;;       movl    %eax, (%rbx)
+;;       movl    4(%rbx), %esi
+;;       addl    $1, %esi
+;;       movl    %esi, 4(%rbx)
+;;       movl    8(%rbx), %r11d
+;;       addl    %r11d, %r11d
+;;       cmpl    %r11d, %esi
+;;       jb      0x23a
+;;  221: cmpl    $0x400, %esi
+;;       jb      0x23a
+;;  22d: movq    %r14, %rdi
+;;       callq   0x44b
+;;       movq    0x18(%rsp), %r14
+;;       ╰─╼ stack_map: frame_size=32, frame_offsets=[0, 4]
+;;       movl    (%rsp), %eax
+;;       addq    $4, %rsp
+;;       movl    (%rsp), %ecx
+;;       addq    $4, %rsp
+;;       popq    %rdx
+;;       subq    $4, %rsp
+;;       movl    %eax, (%rsp)
+;;       movl    %ecx, %eax
+;;       addq    $4, %rsp
+;;       addq    $0x10, %rsp
+;;       popq    %rbp
+;;       retq
+;;  26b: ud2
+;;  26d: ud2
+;;  26f: ud2
+;;  271: ud2

--- a/tests/disas/winch/x64/exceptions/catch-ref-null.wat
+++ b/tests/disas/winch/x64/exceptions/catch-ref-null.wat
@@ -1,0 +1,156 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = "-W exceptions -C collector=null"
+
+;; A `catch_ref` landing pad appends the exception reference after the tag's
+;; payload fields before branching to its target.
+(module
+  (tag $e (param funcref))
+  (func
+    (block $h (result funcref exnref)
+      (try_table (result funcref) (catch_ref $e $h)
+        (throw $e (ref.null func)))
+      (unreachable))
+    (throw_ref)))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x18(%r11), %r11
+;;       addq    $0x30, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x234
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x10, %rsp
+;;       movq    %rdi, 8(%rsp)
+;;       movq    %rsi, (%rsp)
+;;       movq    %r14, %rdi
+;;       callq   0x413
+;;       ├─╼ exception frame offset: SP = FP - 0x10
+;;       ╰─╼ exception handler: tag=0, context at [SP+0x8], handler=0x185
+;;       movq    8(%rsp), %r14
+;;       movq    0x20(%r14), %r11
+;;       movl    (%r11), %ecx
+;;       addl    $7, %ecx
+;;       jb      0x236
+;;   4f: andl    $0xfffffff8, %ecx
+;;       movl    %ecx, %edx
+;;       addl    $0x18, %edx
+;;       jb      0x238
+;;   63: subq    $4, %rsp
+;;       movl    %eax, (%rsp)
+;;       subq    $4, %rsp
+;;       movl    %ecx, (%rsp)
+;;       subq    $4, %rsp
+;;       movl    %edx, (%rsp)
+;;       movl    (%rsp), %eax
+;;       addq    $4, %rsp
+;;       movq    8(%r14), %rcx
+;;       movq    0x28(%rcx), %rdx
+;;       movq    0x20(%rcx), %rcx
+;;       cmpq    %rdx, %rax
+;;       jbe     0xbc
+;;   a0: subq    %rdx, %rax
+;;       pushq   %rax
+;;       movq    %r14, %rdi
+;;       movq    (%rsp), %rsi
+;;       callq   0x354
+;;       ├─╼ exception frame offset: SP = FP - 0x20
+;;       ╰─╼ exception handler: tag=0, context at [SP+0x18], handler=0x185
+;;       addq    $8, %rsp
+;;       movq    0x10(%rsp), %r14
+;;       movl    (%rsp), %eax
+;;       addq    $4, %rsp
+;;       movq    8(%r14), %rcx
+;;       movq    0x28(%rcx), %rdx
+;;       movq    0x20(%rcx), %rcx
+;;       movq    %rcx, %rdx
+;;       addq    %rax, %rdx
+;;       movl    $0x4000018, (%rdx)
+;;       movq    0x28(%r14), %r11
+;;       movl    0xc(%r11), %r11d
+;;       movl    %r11d, 4(%rdx)
+;;       movq    0x20(%r14), %rcx
+;;       movl    %eax, %r11d
+;;       addl    $0x18, %r11d
+;;       movl    %r11d, (%rcx)
+;;       movl    (%rsp), %ecx
+;;       addq    $4, %rsp
+;;       movl    %ecx, 8(%rdx)
+;;       movl    $0, 0xc(%rdx)
+;;       movl    $0, %ecx
+;;       pushq   %rdx
+;;       subq    $4, %rsp
+;;       movl    %eax, (%rsp)
+;;       pushq   %rcx
+;;       subq    $0xc, %rsp
+;;       movq    %r14, %rdi
+;;       movq    0xc(%rsp), %rsi
+;;       callq   0x39b
+;;       ├─╼ exception frame offset: SP = FP - 0x30
+;;       ╰─╼ exception handler: tag=0, context at [SP+0x28], handler=0x185
+;;       addq    $0xc, %rsp
+;;       addq    $8, %rsp
+;;       movq    0x14(%rsp), %r14
+;;       movl    (%rsp), %ecx
+;;       addq    $4, %rsp
+;;       popq    %rdx
+;;       movl    %eax, 0x10(%rdx)
+;;       subq    $4, %rsp
+;;       movl    %ecx, (%rsp)
+;;       subq    $0xc, %rsp
+;;       movq    %r14, %rdi
+;;       movl    0xc(%rsp), %esi
+;;       callq   0x440
+;;       ├─╼ exception frame offset: SP = FP - 0x20
+;;       ╰─╼ exception handler: tag=0, context at [SP+0x18], handler=0x185
+;;       addq    $0xc, %rsp
+;;       addq    $4, %rsp
+;;       movq    8(%rsp), %r14
+;;       movq    %rbp, %rsp
+;;       subq    $0x10, %rsp
+;;       movq    8(%rsp), %r14
+;;       movq    8(%r14), %rcx
+;;       movq    0x28(%rcx), %rdx
+;;       movq    0x20(%rcx), %rcx
+;;       movq    %rax, %r11
+;;       addq    $0x18, %r11
+;;       cmpq    %rdx, %r11
+;;       ja      0x23a
+;;  1b3: movq    %rcx, %rdx
+;;       addq    %rax, %rdx
+;;       movl    0x10(%rdx), %ecx
+;;       pushq   %rdx
+;;       subq    $4, %rsp
+;;       movl    %eax, (%rsp)
+;;       subq    $4, %rsp
+;;       movl    %ecx, (%rsp)
+;;       movq    %r14, %rdi
+;;       movl    (%rsp), %esi
+;;       movl    $0xffffffff, %edx
+;;       callq   0x3c8
+;;       addq    $4, %rsp
+;;       ╰─╼ stack_map: frame_size=32, frame_offsets=[4]
+;;       movq    0x14(%rsp), %r14
+;;       movl    (%rsp), %ecx
+;;       addq    $4, %rsp
+;;       popq    %rdx
+;;       pushq   %rax
+;;       movl    %ecx, %eax
+;;       subq    $4, %rsp
+;;       movl    %eax, (%rsp)
+;;       subq    $4, %rsp
+;;       movq    %r14, %rdi
+;;       movl    4(%rsp), %esi
+;;       callq   0x440
+;;       addq    $4, %rsp
+;;       ╰─╼ stack_map: frame_size=32, frame_offsets=[4]
+;;       addq    $4, %rsp
+;;       movq    0x10(%rsp), %r14
+;;       addq    $0x10, %rsp
+;;       popq    %rbp
+;;       retq
+;;  234: ud2
+;;  236: ud2
+;;  238: ud2
+;;  23a: ud2

--- a/tests/disas/winch/x64/exceptions/catch-ref.wat
+++ b/tests/disas/winch/x64/exceptions/catch-ref.wat
@@ -1,0 +1,132 @@
+;;! target = "x86_64"
+;;! test = "winch"
+;;! flags = "-W exceptions -C collector=copying"
+
+;; A `catch_ref` landing pad appends the exception reference after the tag's
+;; payload fields before branching to its target.
+(module
+  (tag $e (param funcref))
+  (func
+    (block $h (result funcref exnref)
+      (try_table (result funcref) (catch_ref $e $h)
+        (throw $e (ref.null func)))
+      (unreachable))
+    (throw_ref)))
+;; wasm[0]::function[0]:
+;;       pushq   %rbp
+;;       movq    %rsp, %rbp
+;;       movq    8(%rdi), %r11
+;;       movq    0x18(%r11), %r11
+;;       addq    $0x30, %r11
+;;       cmpq    %rsp, %r11
+;;       ja      0x1d8
+;;   1c: movq    %rdi, %r14
+;;       subq    $0x10, %rsp
+;;       movq    %rdi, 8(%rsp)
+;;       movq    %rsi, (%rsp)
+;;       movq    %r14, %rdi
+;;       callq   0x3bb
+;;       ├─╼ exception frame offset: SP = FP - 0x10
+;;       ╰─╼ exception handler: tag=0, context at [SP+0x8], handler=0x129
+;;       movq    8(%rsp), %r14
+;;       movq    0x28(%r14), %rcx
+;;       movl    0xc(%rcx), %ecx
+;;       subq    $4, %rsp
+;;       movl    %eax, (%rsp)
+;;       subq    $4, %rsp
+;;       movl    %ecx, (%rsp)
+;;       subq    $8, %rsp
+;;       movq    %r14, %rdi
+;;       movl    $0x4000002, %esi
+;;       movl    8(%rsp), %edx
+;;       movl    $0x20, %ecx
+;;       movl    $0x10, %r8d
+;;       callq   0x2f4
+;;       ├─╼ exception frame offset: SP = FP - 0x20
+;;       ╰─╼ exception handler: tag=0, context at [SP+0x18], handler=0x129
+;;       addq    $8, %rsp
+;;       addq    $4, %rsp
+;;       movq    0xc(%rsp), %r14
+;;       movq    8(%r14), %rcx
+;;       movq    0x28(%rcx), %rdx
+;;       movq    0x20(%rcx), %rcx
+;;       movq    %rcx, %rdx
+;;       addq    %rax, %rdx
+;;       movl    (%rsp), %ecx
+;;       addq    $4, %rsp
+;;       movl    %ecx, 0x10(%rdx)
+;;       movl    $0, 0x14(%rdx)
+;;       movl    $0, %ecx
+;;       pushq   %rdx
+;;       subq    $4, %rsp
+;;       movl    %eax, (%rsp)
+;;       pushq   %rcx
+;;       subq    $0xc, %rsp
+;;       movq    %r14, %rdi
+;;       movq    0xc(%rsp), %rsi
+;;       callq   0x343
+;;       ├─╼ exception frame offset: SP = FP - 0x30
+;;       ╰─╼ exception handler: tag=0, context at [SP+0x28], handler=0x129
+;;       addq    $0xc, %rsp
+;;       addq    $8, %rsp
+;;       movq    0x14(%rsp), %r14
+;;       movl    (%rsp), %ecx
+;;       addq    $4, %rsp
+;;       popq    %rdx
+;;       movl    %eax, 0x18(%rdx)
+;;       subq    $4, %rsp
+;;       movl    %ecx, (%rsp)
+;;       subq    $0xc, %rsp
+;;       movq    %r14, %rdi
+;;       movl    0xc(%rsp), %esi
+;;       callq   0x3e8
+;;       ├─╼ exception frame offset: SP = FP - 0x20
+;;       ╰─╼ exception handler: tag=0, context at [SP+0x18], handler=0x129
+;;       addq    $0xc, %rsp
+;;       addq    $4, %rsp
+;;       movq    8(%rsp), %r14
+;;       movq    %rbp, %rsp
+;;       subq    $0x10, %rsp
+;;       movq    8(%rsp), %r14
+;;       movq    8(%r14), %rcx
+;;       movq    0x28(%rcx), %rdx
+;;       movq    0x20(%rcx), %rcx
+;;       movq    %rax, %r11
+;;       addq    $0x20, %r11
+;;       cmpq    %rdx, %r11
+;;       ja      0x1da
+;;  157: movq    %rcx, %rdx
+;;       addq    %rax, %rdx
+;;       movl    0x18(%rdx), %ecx
+;;       pushq   %rdx
+;;       subq    $4, %rsp
+;;       movl    %eax, (%rsp)
+;;       subq    $4, %rsp
+;;       movl    %ecx, (%rsp)
+;;       movq    %r14, %rdi
+;;       movl    (%rsp), %esi
+;;       movl    $0xffffffff, %edx
+;;       callq   0x370
+;;       addq    $4, %rsp
+;;       ╰─╼ stack_map: frame_size=32, frame_offsets=[4]
+;;       movq    0x14(%rsp), %r14
+;;       movl    (%rsp), %ecx
+;;       addq    $4, %rsp
+;;       popq    %rdx
+;;       pushq   %rax
+;;       movl    %ecx, %eax
+;;       subq    $4, %rsp
+;;       movl    %eax, (%rsp)
+;;       subq    $4, %rsp
+;;       movq    %r14, %rdi
+;;       movl    4(%rsp), %esi
+;;       callq   0x3e8
+;;       addq    $4, %rsp
+;;       ╰─╼ stack_map: frame_size=32, frame_offsets=[4]
+;;       addq    $4, %rsp
+;;       movq    0x10(%rsp), %r14
+;;       addq    $0x10, %rsp
+;;       popq    %rbp
+;;       retq
+;;  1d8: ud2
+;;  1da: ud2

--- a/winch/codegen/src/codegen/context.rs
+++ b/winch/codegen/src/codegen/context.rs
@@ -166,9 +166,11 @@ impl<'a> CodeGenContext<'a, Emission> {
             // All of our supported architectures use the float registers for vector operations.
             V128 => self.reg_for_class(RegClass::Float, masm),
             Ref(rt) => match rt.heap_type {
-                WasmHeapType::Func | WasmHeapType::Extern => {
-                    self.reg_for_class(RegClass::Int, masm)
-                }
+                WasmHeapType::Func
+                | WasmHeapType::Extern
+                | WasmHeapType::Exn
+                | WasmHeapType::ConcreteExn(_)
+                | WasmHeapType::NoExn => self.reg_for_class(RegClass::Int, masm),
                 _ => bail!(CodeGenError::unsupported_wasm_type()),
             },
         }

--- a/winch/codegen/src/codegen/env.rs
+++ b/winch/codegen/src/codegen/env.rs
@@ -219,6 +219,11 @@ impl<'a, 'translation, 'data, P: PtrSize> FuncEnv<'a, 'translation, 'data, P> {
         })
     }
 
+    /// Converts a parser heap type into its canonicalized Wasmtime type.
+    pub(crate) fn convert_heap_type(&self, ty: wasmparser::HeapType) -> Result<WasmHeapType> {
+        Ok(TypeConverter::new(self.translation, self.types).convert_heap_type(ty)?)
+    }
+
     /// Resolves `GlobalData` of a global at the given index.
     pub fn resolve_global(&mut self, index: GlobalIndex) -> GlobalData {
         let ty = self.translation.module.globals[index].wasm_ty;

--- a/winch/codegen/src/codegen/exceptions.rs
+++ b/winch/codegen/src/codegen/exceptions.rs
@@ -11,7 +11,8 @@ use cranelift_codegen::{MachExceptionHandler, MachLabel, ir::ExceptionTag};
 use smallvec::SmallVec;
 use wasmtime_environ::{
     Collector, GcStructLayout, GcTypeLayouts, ModuleInternedTypeIndex, PtrSize, TagIndex, VMGcKind,
-    WasmExnType, WasmHeapType, WasmStorageType, WasmValType, packed_option::ReservedValue,
+    WasmExnType, WasmHeapType, WasmRefType, WasmStorageType, WasmValType,
+    packed_option::ReservedValue,
 };
 use wasmtime_environ::{WasmCompositeInnerType, copying::InlineTraceInfo};
 
@@ -27,6 +28,7 @@ pub(crate) struct HandlerStateCheckpoint(usize);
 
 #[derive(Debug)]
 pub(crate) struct CatchInfo {
+    pub(crate) is_ref: bool,
     pub(crate) tag: Option<TagIndex>,
     pub(crate) target_depth: u32,
     pub(crate) landing_pad: MachLabel,
@@ -116,8 +118,24 @@ where
             self.context.truncate_stack_to(stack_state.base_len)?;
             self.context.load_vmctx(self.masm)?;
 
+            let mut exception_reg = None;
             if let Some(tag) = catch.tag {
-                self.emit_load_exception_payload_fields(tag, raw_exception_reg)?;
+                exception_reg =
+                    self.emit_load_exception_payload_fields(tag, raw_exception_reg, catch.is_ref)?;
+            }
+            if catch.is_ref {
+                // The runtime exposes the pending exception to Wasm before
+                // entering the landing pad. Append that reference after any
+                // tagged payload fields, as required by the reference catches.
+                let reg = match exception_reg {
+                    Some(reg) => reg,
+                    None => self.context.reg(raw_exception_reg, self.masm)?,
+                };
+                let ty = WasmValType::Ref(WasmRefType {
+                    nullable: false,
+                    heap_type: WasmHeapType::Exn,
+                });
+                self.context.stack.push(TypedReg::new(ty, reg).into());
             }
             self.emit_catch_branch(catch.target_depth)?;
         }
@@ -146,12 +164,19 @@ where
             })
     }
 
+    /// Loads a tagged exception's payload fields.
+    ///
+    /// When `preserve_exception` is true, the exception reference is kept live
+    /// across any calls made while loading the payload and returned to the
+    /// caller. Otherwise its register is released after computing the object
+    /// address.
     fn emit_load_exception_payload_fields(
         &mut self,
         tag_index: TagIndex,
         raw_exception_reg: Reg,
-    ) -> Result<()> {
-        let exception_reg = self.context.reg(raw_exception_reg, self.masm)?;
+        preserve_exception: bool,
+    ) -> Result<Option<Reg>> {
+        let mut exception_reg = self.context.reg(raw_exception_reg, self.masm)?;
         let interned = self.env.translation.module.tags[tag_index]
             .exception
             .unwrap_module_type_index();
@@ -182,7 +207,9 @@ where
 
         let mut object_addr = self.emit_gc_ref_addr(exception_reg, heap_base)?;
         self.context.free_reg(heap_base);
-        self.context.free_reg(exception_reg);
+        if !preserve_exception {
+            self.context.free_reg(exception_reg);
+        }
         for (field_ty, field_offset) in fields {
             let ty = match field_ty {
                 WasmStorageType::Val(ty @ WasmValType::Ref(r))
@@ -194,9 +221,18 @@ where
                         .load(addr, writable!(func_ref_id), OperandSize::S32)?;
 
                     // The builtin call can clobber allocated registers. Preserve
-                    // the object address beneath the call's arguments so later
-                    // payload fields can still be loaded.
+                    // the object address, and the exception when requested,
+                    // beneath the call's arguments.
                     self.context.stack.push(TypedReg::i64(object_addr).into());
+                    if preserve_exception {
+                        let ty = WasmValType::Ref(WasmRefType {
+                            nullable: false,
+                            heap_type: WasmHeapType::Exn,
+                        });
+                        self.context
+                            .stack
+                            .push(TypedReg::new(ty, exception_reg).into());
+                    }
                     self.context.stack.push(TypedReg::i32(func_ref_id).into());
                     self.context.stack.push(Val::i32(
                         ModuleInternedTypeIndex::reserved_value()
@@ -213,6 +249,9 @@ where
                     )?;
 
                     let func_ref = self.context.pop_to_reg(self.masm, None)?;
+                    if preserve_exception {
+                        exception_reg = self.context.pop_to_reg(self.masm, None)?.reg;
+                    }
                     object_addr = self.context.pop_to_reg(self.masm, None)?.reg;
                     self.context
                         .stack
@@ -225,13 +264,25 @@ where
                     let addr = self.masm.address_at_reg(object_addr, field_offset)?;
                     if gc_codegen_config.collector() == Collector::DeferredReferenceCounting {
                         // The DRC read barrier can make an out-of-line call.
-                        // Preserve the object address across the call so later
-                        // payload fields can still be loaded.
+                        // Preserve the object address, and the exception when
+                        // requested, across the call.
                         let gc_ref = self.context.reg_for_type(ty, self.masm)?;
                         self.masm.load(addr, writable!(gc_ref), ty.try_into()?)?;
                         self.context.stack.push(TypedReg::i64(object_addr).into());
+                        if preserve_exception {
+                            let ty = WasmValType::Ref(WasmRefType {
+                                nullable: false,
+                                heap_type: WasmHeapType::Exn,
+                            });
+                            self.context
+                                .stack
+                                .push(TypedReg::new(ty, exception_reg).into());
+                        }
                         self.emit_drc_read_barrier(ty, gc_ref)?;
                         let payload = self.context.pop_to_reg(self.masm, None)?;
+                        if preserve_exception {
+                            exception_reg = self.context.pop_to_reg(self.masm, None)?.reg;
+                        }
                         object_addr = self.context.pop_to_reg(self.masm, None)?.reg;
                         self.context.stack.push(payload.into());
                     } else {
@@ -259,7 +310,7 @@ where
         }
 
         self.context.free_reg(object_addr);
-        Ok(())
+        Ok(preserve_exception.then_some(exception_reg))
     }
 
     /// Allocates an exception and initializes its tag identity.

--- a/winch/codegen/src/codegen/exceptions.rs
+++ b/winch/codegen/src/codegen/exceptions.rs
@@ -118,25 +118,7 @@ where
             self.context.truncate_stack_to(stack_state.base_len)?;
             self.context.load_vmctx(self.masm)?;
 
-            let mut exception_reg = None;
-            if let Some(tag) = catch.tag {
-                exception_reg =
-                    self.emit_load_exception_payload_fields(tag, raw_exception_reg, catch.is_ref)?;
-            }
-            if catch.is_ref {
-                // The runtime exposes the pending exception to Wasm before
-                // entering the landing pad. Append that reference after any
-                // tagged payload fields, as required by the reference catches.
-                let reg = match exception_reg {
-                    Some(reg) => reg,
-                    None => self.context.reg(raw_exception_reg, self.masm)?,
-                };
-                let ty = WasmValType::Ref(WasmRefType {
-                    nullable: false,
-                    heap_type: WasmHeapType::Exn,
-                });
-                self.context.stack.push(TypedReg::new(ty, reg).into());
-            }
+            self.emit_catch_values(&catch, raw_exception_reg)?;
             self.emit_catch_branch(catch.target_depth)?;
         }
 
@@ -164,18 +146,25 @@ where
             })
     }
 
-    /// Loads a tagged exception's payload fields.
+    /// Emits the values produced by an exception catch.
     ///
-    /// When `preserve_exception` is true, the exception reference is kept live
-    /// across any calls made while loading the payload and returned to the
-    /// caller. Otherwise its register is released after computing the object
-    /// address.
-    fn emit_load_exception_payload_fields(
-        &mut self,
-        tag_index: TagIndex,
-        raw_exception_reg: Reg,
-        preserve_exception: bool,
-    ) -> Result<Option<Reg>> {
+    /// Tagged catches produce the exception's payload fields. Reference
+    /// catches additionally append the exception reference after those fields.
+    fn emit_catch_values(&mut self, catch: &CatchInfo, raw_exception_reg: Reg) -> Result<()> {
+        let exception_ty = catch.is_ref.then_some(WasmValType::Ref(WasmRefType {
+            nullable: false,
+            heap_type: WasmHeapType::Exn,
+        }));
+        let Some(tag_index) = catch.tag else {
+            if let Some(ty) = exception_ty {
+                let exception_reg = self.context.reg(raw_exception_reg, self.masm)?;
+                self.context
+                    .stack
+                    .push(TypedReg::new(ty, exception_reg).into());
+            }
+            return Ok(());
+        };
+
         let mut exception_reg = self.context.reg(raw_exception_reg, self.masm)?;
         let interned = self.env.translation.module.tags[tag_index]
             .exception
@@ -207,7 +196,7 @@ where
 
         let mut object_addr = self.emit_gc_ref_addr(exception_reg, heap_base)?;
         self.context.free_reg(heap_base);
-        if !preserve_exception {
+        if exception_ty.is_none() {
             self.context.free_reg(exception_reg);
         }
         for (field_ty, field_offset) in fields {
@@ -221,14 +210,10 @@ where
                         .load(addr, writable!(func_ref_id), OperandSize::S32)?;
 
                     // The builtin call can clobber allocated registers. Preserve
-                    // the object address, and the exception when requested,
-                    // beneath the call's arguments.
+                    // the object address, and for reference catches the
+                    // exception, beneath the call's arguments.
                     self.context.stack.push(TypedReg::i64(object_addr).into());
-                    if preserve_exception {
-                        let ty = WasmValType::Ref(WasmRefType {
-                            nullable: false,
-                            heap_type: WasmHeapType::Exn,
-                        });
+                    if let Some(ty) = exception_ty {
                         self.context
                             .stack
                             .push(TypedReg::new(ty, exception_reg).into());
@@ -249,7 +234,7 @@ where
                     )?;
 
                     let func_ref = self.context.pop_to_reg(self.masm, None)?;
-                    if preserve_exception {
+                    if exception_ty.is_some() {
                         exception_reg = self.context.pop_to_reg(self.masm, None)?.reg;
                     }
                     object_addr = self.context.pop_to_reg(self.masm, None)?.reg;
@@ -264,23 +249,19 @@ where
                     let addr = self.masm.address_at_reg(object_addr, field_offset)?;
                     if gc_codegen_config.collector() == Collector::DeferredReferenceCounting {
                         // The DRC read barrier can make an out-of-line call.
-                        // Preserve the object address, and the exception when
-                        // requested, across the call.
+                        // Preserve the object address, and for reference catches
+                        // the exception, across the call.
                         let gc_ref = self.context.reg_for_type(ty, self.masm)?;
                         self.masm.load(addr, writable!(gc_ref), ty.try_into()?)?;
                         self.context.stack.push(TypedReg::i64(object_addr).into());
-                        if preserve_exception {
-                            let ty = WasmValType::Ref(WasmRefType {
-                                nullable: false,
-                                heap_type: WasmHeapType::Exn,
-                            });
+                        if let Some(ty) = exception_ty {
                             self.context
                                 .stack
                                 .push(TypedReg::new(ty, exception_reg).into());
                         }
                         self.emit_drc_read_barrier(ty, gc_ref)?;
                         let payload = self.context.pop_to_reg(self.masm, None)?;
-                        if preserve_exception {
+                        if exception_ty.is_some() {
                             exception_reg = self.context.pop_to_reg(self.masm, None)?.reg;
                         }
                         object_addr = self.context.pop_to_reg(self.masm, None)?.reg;
@@ -310,7 +291,12 @@ where
         }
 
         self.context.free_reg(object_addr);
-        Ok(preserve_exception.then_some(exception_reg))
+        if let Some(ty) = exception_ty {
+            self.context
+                .stack
+                .push(TypedReg::new(ty, exception_reg).into());
+        }
+        Ok(())
     }
 
     /// Allocates an exception and initializes its tag identity.

--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -252,7 +252,10 @@ where
                             WasmHeapType::Func => {
                                 self.masm.store_ptr(*reg, addr)?;
                             }
-                            WasmHeapType::Extern => {
+                            WasmHeapType::Extern
+                            | WasmHeapType::Exn
+                            | WasmHeapType::ConcreteExn(_)
+                            | WasmHeapType::NoExn => {
                                 self.masm.store((*reg).into(), addr, (*ty).try_into()?)?;
                             }
                             _ => bail!(CodeGenError::unsupported_wasm_type()),

--- a/winch/codegen/src/isa/aarch64/abi.rs
+++ b/winch/codegen/src/isa/aarch64/abi.rs
@@ -131,7 +131,10 @@ impl ABI for Aarch64ABI {
         Ok(match ty {
             WasmValType::Ref(rt) => match rt.heap_type {
                 WasmHeapType::Func => Self::word_bytes(),
-                WasmHeapType::Extern => Self::word_bytes() / 2,
+                WasmHeapType::Extern
+                | WasmHeapType::Exn
+                | WasmHeapType::ConcreteExn(_)
+                | WasmHeapType::NoExn => Self::word_bytes() / 2,
                 ht => bail!("{}: {ht}", CodeGenError::unsupported_wasm_type()),
             },
             WasmValType::F64 | WasmValType::I64 => Self::word_bytes(),
@@ -222,6 +225,7 @@ mod tests {
             Aarch64ABI::word_bytes()
         );
         assert_eq!(Aarch64ABI::sizeof(&ty(WasmHeapType::Extern))?, 4);
+        assert_eq!(Aarch64ABI::sizeof(&ty(WasmHeapType::Exn))?, 4);
         Ok(())
     }
 

--- a/winch/codegen/src/isa/x64/abi.rs
+++ b/winch/codegen/src/isa/x64/abi.rs
@@ -116,7 +116,10 @@ impl ABI for X64ABI {
         Ok(match ty {
             WasmValType::Ref(rt) => match rt.heap_type {
                 WasmHeapType::Func => Self::word_bytes(),
-                WasmHeapType::Extern => Self::word_bytes() / 2,
+                WasmHeapType::Extern
+                | WasmHeapType::Exn
+                | WasmHeapType::ConcreteExn(_)
+                | WasmHeapType::NoExn => Self::word_bytes() / 2,
                 ht => bail!("{}: {ht}", CodeGenError::unsupported_wasm_type()),
             },
             WasmValType::F64 | WasmValType::I64 => Self::word_bytes(),

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -1498,7 +1498,12 @@ pub(crate) trait MacroAssembler {
             WasmValType::I32
             | WasmValType::I64
             | WasmValType::Ref(WasmRefType {
-                heap_type: WasmHeapType::Func | WasmHeapType::Extern,
+                heap_type:
+                    WasmHeapType::Func
+                    | WasmHeapType::Extern
+                    | WasmHeapType::Exn
+                    | WasmHeapType::ConcreteExn(_)
+                    | WasmHeapType::NoExn,
                 ..
             }) => self.with_scratch::<IntScratch, _>(f),
             WasmValType::F32 | WasmValType::F64 | WasmValType::V128 => {

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -1671,9 +1671,11 @@ where
         match slot.ty {
             I32 | I64 | F32 | F64 | V128 => context.stack.push(Val::local(index, slot.ty)),
             Ref(rt) => match rt.heap_type {
-                WasmHeapType::Func | WasmHeapType::Extern => {
-                    context.stack.push(Val::local(index, slot.ty))
-                }
+                WasmHeapType::Func
+                | WasmHeapType::Extern
+                | WasmHeapType::Exn
+                | WasmHeapType::ConcreteExn(_)
+                | WasmHeapType::NoExn => context.stack.push(Val::local(index, slot.ty)),
                 _ => bail!(CodeGenError::unsupported_wasm_type()),
             },
         }
@@ -1860,12 +1862,15 @@ where
         let mut catches = Vec::with_capacity(try_table.catches.len());
 
         for catch in try_table.catches.iter().rev() {
-            let (tag, target_depth) = match catch {
-                wasmparser::Catch::One { tag, label } => (Some(TagIndex::from_u32(*tag)), *label),
-                wasmparser::Catch::All { label } => (None, *label),
-                wasmparser::Catch::OneRef { .. } | wasmparser::Catch::AllRef { .. } => {
-                    bail!(CodeGenError::unimplemented_wasm_instruction())
+            let (is_ref, tag, target_depth) = match catch {
+                wasmparser::Catch::One { tag, label } => {
+                    (false, Some(TagIndex::from_u32(*tag)), *label)
                 }
+                wasmparser::Catch::OneRef { tag, label } => {
+                    (true, Some(TagIndex::from_u32(*tag)), *label)
+                }
+                wasmparser::Catch::All { label } => (false, None, *label),
+                wasmparser::Catch::AllRef { label } => (true, None, *label),
             };
 
             let landing_pad = self.masm.get_label()?;
@@ -1879,6 +1884,7 @@ where
                 .add_handler(exception_tag, landing_pad);
 
             catches.push(CatchInfo {
+                is_ref,
                 tag,
                 target_depth,
                 landing_pad,
@@ -2224,8 +2230,8 @@ where
     }
 
     fn visit_ref_null(&mut self, hty: HeapType) -> Self::Output {
-        match hty {
-            HeapType::FUNC => {
+        match self.env.convert_heap_type(hty)? {
+            WasmHeapType::Func => {
                 let ptr_type = self.env.ptr_type();
                 match ptr_type {
                     WasmValType::I64 => self.context.stack.push(Val::i64(0)),
@@ -2234,7 +2240,10 @@ where
                 }
                 Ok(())
             }
-            HeapType::EXTERN => {
+            WasmHeapType::Extern
+            | WasmHeapType::Exn
+            | WasmHeapType::ConcreteExn(_)
+            | WasmHeapType::NoExn => {
                 self.context.stack.push(Val::i32(0));
                 Ok(())
             }
@@ -4728,7 +4737,10 @@ impl TryFrom<WasmValType> for OperandSize {
                     // to be updated in such a way that the calculation of the
                     // OperandSize will depend on the target's  pointer size.
                     WasmHeapType::Func => OperandSize::S64,
-                    WasmHeapType::Extern => OperandSize::S32,
+                    WasmHeapType::Extern
+                    | WasmHeapType::Exn
+                    | WasmHeapType::ConcreteExn(_)
+                    | WasmHeapType::NoExn => OperandSize::S32,
                     _ => bail!(CodeGenError::unsupported_wasm_type()),
                 }
             }


### PR DESCRIPTION
Adds Winch support for `catch_ref` and `catch_all_ref`, the remaining unsupported catch forms in the exception-handling proposal. Updates the stability documentation to reflect Winch’s support for exception handling.