### PR TITLE
cranelift: fix cubic compile time for modules with many allocating globals

### DIFF
--- a/cranelift/codegen/src/alias_analysis.rs
+++ b/cranelift/codegen/src/alias_analysis.rs
@@ -86,7 +86,8 @@ use crate::{
     post_dominator_tree::PostDominatorTree,
     trace,
 };
-use core::cmp::Ordering;
+use alloc::collections::BinaryHeap;
+use core::cmp::{Ordering, Reverse};
 use cranelift_entity::{EntityRef, SecondaryMap, packed_option::PackedOption};
 
 /// Determine whether this opcode behaves as a memory fence, i.e.,
@@ -708,13 +709,21 @@ impl<'a> AliasAnalysis<'a> {
     }
 
     fn compute_block_input_states(&mut self, func: &Function) {
-        let mut queue = vec![];
+        // Drain the worklist in reverse postorder: a LIFO worklist redoes the
+        // whole tail of the function each time it comes back to the other side
+        // of a branch, which is quadratic for a long chain of diamonds.
+        let mut rpo_index = SecondaryMap::with_default(usize::MAX);
+        for (i, block) in self.domtree.cfg_rpo().enumerate() {
+            rpo_index[*block] = i;
+        }
+
+        let mut queue = BinaryHeap::new();
         let mut queue_set = FxHashSet::default();
         let entry = func.layout.entry_block().unwrap();
-        queue.push(entry);
+        queue.push(Reverse((rpo_index[entry], entry)));
         queue_set.insert(entry);
 
-        while let Some(block) = queue.pop() {
+        while let Some(Reverse((_, block))) = queue.pop() {
             queue_set.remove(&block);
             let mut state = self
                 .block_input
@@ -747,7 +756,7 @@ impl<'a> AliasAnalysis<'a> {
                 };
 
                 if updated && queue_set.insert(succ) {
-                    queue.push(succ);
+                    queue.push(Reverse((rpo_index[succ], succ)));
                 }
             });
         }

--- a/tests/disas/gc/array-copy-with-fuel.wat
+++ b/tests/disas/gc/array-copy-with-fuel.wat
@@ -107,8 +107,6 @@
 ;; @002b                               brif.i32 v6, block6, block9
 ;;
 ;;                                 block6:
-;;                                     v143 = load.i32 notrap aligned region6 v162
-;;                                     v145 = load.i32 notrap aligned region7 v163
 ;; @002b                               v102 = icmp.i64 ult v58, v82
 ;; @002b                               v107 = iadd.i64 v58, v170
 ;; @002b                               v108 = iadd.i64 v82, v170


### PR DESCRIPTION
Fixes #14210.

`AliasAnalysis::compute_block_input_states` drains its worklist LIFO, so on a
branch it runs the entire tail of the function off of one successor before it
looks at the other, and then redoes that tail once the second predecessor
updates the join point. A module whose globals all allocate compiles to one
synthesized initializer that is a long chain of diamonds, where that means each
block is visited O(N) times and each visit walks O(N) alias regions. Ordering
the worklist by reverse postorder converges in a single pass instead.

Compiling a module of N `struct.new` global initializers under the copying
collector; compile times for ordinary modules are unchanged:

| N | before | after |
| ---: | ---: | ---: |
| 250 | 0.17 s | 0.01 s |
| 500 | 1.01 s | 0.03 s |
| 1000 | 8.6 s | 0.08 s |
| 2000 | 67.0 s | 0.22 s |

Note that visit order also affects the precision of the fixpoint, so this
changes generated code: `tests/disas/gc/array-copy-with-fuel.wat` now forwards
two loads it previously reloaded, and its expectation is updated here.

This does not make the pass linear. `LastStores` keeps a dense `SecondaryMap`
over alias regions, so it remains quadratic in the number of regions, which
starts to show again around N=8000.
