### PR TITLE
Re-add gates on wasi-nn jobs in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1467,7 +1467,7 @@ jobs:
       - test_capi
       - test_debug_dwarf
       - test_fuzzing
-      # - test_wasi_nn
+      - test_wasi_nn
       - test_nightly
       - build
       - rustfmt


### PR DESCRIPTION
I haven't seen this job fail since #14073 so seems good to go ahead and gate on the job again.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please review the Bytecode Alliance's AI tool usage policy at
https://github.com/bytecodealliance/governance/blob/main/AI_TOOL_POLICY.md

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
