### PR TITLE
fix(wizer): enable `wasmtime/anyhow`

### DIFF
--- a/crates/wizer/Cargo.toml
+++ b/crates/wizer/Cargo.toml
@@ -68,7 +68,7 @@ wasmtime = [
 ]
 
 # Enable support for wizening components.
-component-model = ['wasmtime/component-model']
+component-model = ['wasmtime/component-model', 'wasmtime/anyhow']
 
 [[test]]
 name = "all"


### PR DESCRIPTION
Enabling both `wasmtime` and `component-model` features fails with regular `cargo build`.

Note, that this issue is not reproducible using `cargo test`, because `wasmtime/anyhow` is unconditionally enabled in `dev-dependencies`

```
$ cargo build --features wasmtime,component-model
...
error[E0599]: no associated function or constant named `from_anyhow` found for struct `wasmtime::Error` in the current scope
  --> crates/wizer/src/component/wasmtime.rs:54:43
   |
54 |                 .map_err(wasmtime::Error::from_anyhow)
   |                                           ^^^^^^^^^^^ associated function or constant not found in `wasmtime::Error`

error[E0599]: no associated function or constant named `from_anyhow` found for struct `wasmtime::Error` in the current scope
  --> crates/wizer/src/component/wasmtime.rs:61:47
   |
61 |                     .map_err(wasmtime::Error::from_anyhow)
   |                                               ^^^^^^^^^^^ associated function or constant not found in `wasmtime::Error`
...
```