### PR TITLE
Fuel const expr operator cost

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -11,6 +11,7 @@ Unreleased.
   expressions) and to the synthesized call to a module's `start` function.
   Previously each of those was charged 1 fuel unit regardless of the configured
   cost.
+  [#14215](https://github.com/bytecodealliance/wasmtime/pull/14215)
 
 --------------------------------------------------------------------------------
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,6 +6,12 @@ Unreleased.
 
 ### Changed
 
+* `Config::operator_cost` now applies to operators inside constant expressions
+  (global initializers, element and data segment offsets, element segment
+  expressions) and to the synthesized call to a module's `start` function.
+  Previously each of those was charged 1 fuel unit regardless of the configured
+  cost.
+
 --------------------------------------------------------------------------------
 
 Release notes for previous releases of Wasmtime can be found on the respective

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -6115,7 +6115,9 @@ impl FuncEnvironment<'_> {
         // Manuall manage fuel around the call as the `Call` opcode does for
         // normal wasm to ensure that it's correctly accounted for.
         if self.tunables.consume_fuel {
-            self.fuel_consumed += 1;
+            self.fuel_consumed += self.tunables.operator_cost.cost(&Operator::Call {
+                function_index: func.as_u32(),
+            });
             self.fuel_increment_var(builder);
             self.fuel_save_from_var(builder);
         }

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -6145,7 +6145,7 @@ impl FuncEnvironment<'_> {
         let mut stack = Vec::new();
         for op in expr.ops() {
             if self.tunables.consume_fuel {
-                self.fuel_consumed += 1;
+                self.fuel_consumed += self.tunables.operator_cost.const_op_cost(op);
             }
             match op {
                 ConstOp::I32Const(i) => {

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -6147,7 +6147,7 @@ impl FuncEnvironment<'_> {
         let mut stack = Vec::new();
         for op in expr.ops() {
             if self.tunables.consume_fuel {
-                self.fuel_consumed += self.tunables.operator_cost.const_op_cost(op);
+                self.fuel_consumed += self.tunables.operator_cost.cost(&op.to_operator());
             }
             match op {
                 ConstOp::I32Const(i) => {

--- a/crates/environ/src/tunables.rs
+++ b/crates/environ/src/tunables.rs
@@ -563,6 +563,13 @@ impl OperatorCostStrategy {
 }
 
 const DEFAULT_VARIABLE_OPERATOR_COST: VariableOperatorCost = VariableOperatorCost::new();
+
+/// The default cost table, used to serve [`OperatorCostStrategy::const_op_cost`]
+/// for the [`OperatorCostStrategy::Default`] strategy.
+///
+/// The `default_cost!` costs baked in here must stay in sync with
+/// `default_operator_cost`, which serves the same strategy for
+/// [`OperatorCostStrategy::cost`].
 const DEFAULT_OPERATOR_COST: OperatorCost = OperatorCost::new();
 
 /// Fuel costs for operators whose work is proportional to a runtime operand.

--- a/crates/environ/src/tunables.rs
+++ b/crates/environ/src/tunables.rs
@@ -544,13 +544,10 @@ impl OperatorCostStrategy {
     /// Get the cost of an operator inside a constant expression.
     ///
     /// Constant expressions are stored as [`ConstOp`] rather than
-    /// `wasmparser::Operator`, so they need their own lookup, but the costs
-    /// come from the same table as [`OperatorCostStrategy::cost`].
+    /// `wasmparser::Operator`, so translate back and reuse
+    /// [`OperatorCostStrategy::cost`].
     pub fn const_op_cost(&self, op: &ConstOp) -> i64 {
-        match self {
-            OperatorCostStrategy::Table(cost) => cost.const_op_cost(op),
-            OperatorCostStrategy::Default => DEFAULT_OPERATOR_COST.const_op_cost(op),
-        }
+        self.cost(&const_op_as_operator(op))
     }
 
     /// Get the costs of work whose size is only known at runtime.
@@ -563,14 +560,6 @@ impl OperatorCostStrategy {
 }
 
 const DEFAULT_VARIABLE_OPERATOR_COST: VariableOperatorCost = VariableOperatorCost::new();
-
-/// The default cost table, used to serve [`OperatorCostStrategy::const_op_cost`]
-/// for the [`OperatorCostStrategy::Default`] strategy.
-///
-/// The `default_cost!` costs baked in here must stay in sync with
-/// `default_operator_cost`, which serves the same strategy for
-/// [`OperatorCostStrategy::cost`].
-const DEFAULT_OPERATOR_COST: OperatorCost = OperatorCost::new();
 
 /// Fuel costs for operators whose work is proportional to a runtime operand.
 ///
@@ -749,37 +738,68 @@ macro_rules! define_operator_cost {
 
 wasmparser::for_each_operator!(define_operator_cost);
 
-impl OperatorCost {
-    /// Returns the cost of an operator appearing in a constant expression.
-    ///
-    /// This mirrors [`OperatorCost::cost`] for the [`ConstOp`] representation
-    /// used by global initializers, element and data segment offsets, and
-    /// element segment expressions.
-    pub fn const_op_cost(&self, op: &ConstOp) -> i64 {
-        let cost = match op {
-            ConstOp::I32Const(_) => self.I32Const,
-            ConstOp::I64Const(_) => self.I64Const,
-            ConstOp::F32Const(_) => self.F32Const,
-            ConstOp::F64Const(_) => self.F64Const,
-            ConstOp::V128Const(_) => self.V128Const,
-            ConstOp::GlobalGet(_) => self.GlobalGet,
-            ConstOp::RefI31 => self.RefI31,
-            ConstOp::RefNull(_) => self.RefNull,
-            ConstOp::RefFunc(_) => self.RefFunc,
-            ConstOp::I32Add => self.I32Add,
-            ConstOp::I32Sub => self.I32Sub,
-            ConstOp::I32Mul => self.I32Mul,
-            ConstOp::I64Add => self.I64Add,
-            ConstOp::I64Sub => self.I64Sub,
-            ConstOp::I64Mul => self.I64Mul,
-            ConstOp::StructNew { .. } => self.StructNew,
-            ConstOp::StructNewDefault { .. } => self.StructNewDefault,
-            ConstOp::ArrayNew { .. } => self.ArrayNew,
-            ConstOp::ArrayNewDefault { .. } => self.ArrayNewDefault,
-            ConstOp::ArrayNewFixed { .. } => self.ArrayNewFixed,
-            ConstOp::ExternConvertAny => self.ExternConvertAny,
-            ConstOp::AnyConvertExtern => self.AnyConvertExtern,
-        };
-        i64::from(cost)
+/// Translate a [`ConstOp`] back into the `wasmparser::Operator` it was parsed
+/// from, so that constant expressions can share the operator cost lookup with
+/// function bodies.
+///
+/// Every immediate round-trips exactly except `ConstOp::RefNull`'s, which stores
+/// a `WasmHeapType` lowered on the way in by `TypeConvert::convert_heap_type`
+/// and has no reverse conversion, so a placeholder heap type stands in for it.
+/// That is fine here because the cost lookup matches on the operator alone and
+/// ignores its immediates.
+fn const_op_as_operator(op: &ConstOp) -> Operator<'static> {
+    use wasmparser::{AbstractHeapType, HeapType, Ieee32, Ieee64, V128};
+    match op {
+        ConstOp::I32Const(value) => Operator::I32Const { value: *value },
+        ConstOp::I64Const(value) => Operator::I64Const { value: *value },
+        ConstOp::F32Const(bits) => Operator::F32Const {
+            value: Ieee32::from(f32::from_bits(*bits)),
+        },
+        ConstOp::F64Const(bits) => Operator::F64Const {
+            value: Ieee64::from(f64::from_bits(*bits)),
+        },
+        ConstOp::V128Const(value) => Operator::V128Const {
+            value: V128::from(*value as i128),
+        },
+        ConstOp::GlobalGet(index) => Operator::GlobalGet {
+            global_index: index.as_u32(),
+        },
+        ConstOp::RefI31 => Operator::RefI31,
+        ConstOp::RefNull(_) => Operator::RefNull {
+            hty: HeapType::Abstract {
+                shared: false,
+                ty: AbstractHeapType::Any,
+            },
+        },
+        ConstOp::RefFunc(index) => Operator::RefFunc {
+            function_index: index.as_u32(),
+        },
+        ConstOp::I32Add => Operator::I32Add,
+        ConstOp::I32Sub => Operator::I32Sub,
+        ConstOp::I32Mul => Operator::I32Mul,
+        ConstOp::I64Add => Operator::I64Add,
+        ConstOp::I64Sub => Operator::I64Sub,
+        ConstOp::I64Mul => Operator::I64Mul,
+        ConstOp::StructNew { struct_type_index } => Operator::StructNew {
+            struct_type_index: struct_type_index.as_u32(),
+        },
+        ConstOp::StructNewDefault { struct_type_index } => Operator::StructNewDefault {
+            struct_type_index: struct_type_index.as_u32(),
+        },
+        ConstOp::ArrayNew { array_type_index } => Operator::ArrayNew {
+            array_type_index: array_type_index.as_u32(),
+        },
+        ConstOp::ArrayNewDefault { array_type_index } => Operator::ArrayNewDefault {
+            array_type_index: array_type_index.as_u32(),
+        },
+        ConstOp::ArrayNewFixed {
+            array_type_index,
+            array_size,
+        } => Operator::ArrayNewFixed {
+            array_type_index: array_type_index.as_u32(),
+            array_size: *array_size,
+        },
+        ConstOp::ExternConvertAny => Operator::ExternConvertAny,
+        ConstOp::AnyConvertExtern => Operator::AnyConvertExtern,
     }
 }

--- a/crates/environ/src/tunables.rs
+++ b/crates/environ/src/tunables.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use crate::{ConstOp, IndexType, Limits, Memory, TripleExt};
+use crate::{IndexType, Limits, Memory, TripleExt};
 use core::num::NonZeroU32;
 use core::{fmt, str::FromStr};
 use serde_derive::{Deserialize, Serialize};
@@ -541,15 +541,6 @@ impl OperatorCostStrategy {
         }
     }
 
-    /// Get the cost of an operator inside a constant expression.
-    ///
-    /// Constant expressions are stored as [`ConstOp`] rather than
-    /// `wasmparser::Operator`, so translate back and reuse
-    /// [`OperatorCostStrategy::cost`].
-    pub fn const_op_cost(&self, op: &ConstOp) -> i64 {
-        self.cost(&const_op_as_operator(op))
-    }
-
     /// Get the costs of work whose size is only known at runtime.
     pub fn variable(&self) -> &VariableOperatorCost {
         match self {
@@ -737,69 +728,3 @@ macro_rules! define_operator_cost {
 }
 
 wasmparser::for_each_operator!(define_operator_cost);
-
-/// Translate a [`ConstOp`] back into the `wasmparser::Operator` it was parsed
-/// from, so that constant expressions can share the operator cost lookup with
-/// function bodies.
-///
-/// Every immediate round-trips exactly except `ConstOp::RefNull`'s, which stores
-/// a `WasmHeapType` lowered on the way in by `TypeConvert::convert_heap_type`
-/// and has no reverse conversion, so a placeholder heap type stands in for it.
-/// That is fine here because the cost lookup matches on the operator alone and
-/// ignores its immediates.
-fn const_op_as_operator(op: &ConstOp) -> Operator<'static> {
-    use wasmparser::{AbstractHeapType, HeapType, Ieee32, Ieee64, V128};
-    match op {
-        ConstOp::I32Const(value) => Operator::I32Const { value: *value },
-        ConstOp::I64Const(value) => Operator::I64Const { value: *value },
-        ConstOp::F32Const(bits) => Operator::F32Const {
-            value: Ieee32::from(f32::from_bits(*bits)),
-        },
-        ConstOp::F64Const(bits) => Operator::F64Const {
-            value: Ieee64::from(f64::from_bits(*bits)),
-        },
-        ConstOp::V128Const(value) => Operator::V128Const {
-            value: V128::from(*value as i128),
-        },
-        ConstOp::GlobalGet(index) => Operator::GlobalGet {
-            global_index: index.as_u32(),
-        },
-        ConstOp::RefI31 => Operator::RefI31,
-        ConstOp::RefNull(_) => Operator::RefNull {
-            hty: HeapType::Abstract {
-                shared: false,
-                ty: AbstractHeapType::Any,
-            },
-        },
-        ConstOp::RefFunc(index) => Operator::RefFunc {
-            function_index: index.as_u32(),
-        },
-        ConstOp::I32Add => Operator::I32Add,
-        ConstOp::I32Sub => Operator::I32Sub,
-        ConstOp::I32Mul => Operator::I32Mul,
-        ConstOp::I64Add => Operator::I64Add,
-        ConstOp::I64Sub => Operator::I64Sub,
-        ConstOp::I64Mul => Operator::I64Mul,
-        ConstOp::StructNew { struct_type_index } => Operator::StructNew {
-            struct_type_index: struct_type_index.as_u32(),
-        },
-        ConstOp::StructNewDefault { struct_type_index } => Operator::StructNewDefault {
-            struct_type_index: struct_type_index.as_u32(),
-        },
-        ConstOp::ArrayNew { array_type_index } => Operator::ArrayNew {
-            array_type_index: array_type_index.as_u32(),
-        },
-        ConstOp::ArrayNewDefault { array_type_index } => Operator::ArrayNewDefault {
-            array_type_index: array_type_index.as_u32(),
-        },
-        ConstOp::ArrayNewFixed {
-            array_type_index,
-            array_size,
-        } => Operator::ArrayNewFixed {
-            array_type_index: array_type_index.as_u32(),
-            array_size: *array_size,
-        },
-        ConstOp::ExternConvertAny => Operator::ExternConvertAny,
-        ConstOp::AnyConvertExtern => Operator::AnyConvertExtern,
-    }
-}

--- a/crates/environ/src/tunables.rs
+++ b/crates/environ/src/tunables.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use crate::{IndexType, Limits, Memory, TripleExt};
+use crate::{ConstOp, IndexType, Limits, Memory, TripleExt};
 use core::num::NonZeroU32;
 use core::{fmt, str::FromStr};
 use serde_derive::{Deserialize, Serialize};
@@ -541,6 +541,18 @@ impl OperatorCostStrategy {
         }
     }
 
+    /// Get the cost of an operator inside a constant expression.
+    ///
+    /// Constant expressions are stored as [`ConstOp`] rather than
+    /// `wasmparser::Operator`, so they need their own lookup, but the costs
+    /// come from the same table as [`OperatorCostStrategy::cost`].
+    pub fn const_op_cost(&self, op: &ConstOp) -> i64 {
+        match self {
+            OperatorCostStrategy::Table(cost) => cost.const_op_cost(op),
+            OperatorCostStrategy::Default => DEFAULT_OPERATOR_COST.const_op_cost(op),
+        }
+    }
+
     /// Get the costs of work whose size is only known at runtime.
     pub fn variable(&self) -> &VariableOperatorCost {
         match self {
@@ -551,6 +563,7 @@ impl OperatorCostStrategy {
 }
 
 const DEFAULT_VARIABLE_OPERATOR_COST: VariableOperatorCost = VariableOperatorCost::new();
+const DEFAULT_OPERATOR_COST: OperatorCost = OperatorCost::new();
 
 /// Fuel costs for operators whose work is proportional to a runtime operand.
 ///
@@ -728,3 +741,38 @@ macro_rules! define_operator_cost {
 }
 
 wasmparser::for_each_operator!(define_operator_cost);
+
+impl OperatorCost {
+    /// Returns the cost of an operator appearing in a constant expression.
+    ///
+    /// This mirrors [`OperatorCost::cost`] for the [`ConstOp`] representation
+    /// used by global initializers, element and data segment offsets, and
+    /// element segment expressions.
+    pub fn const_op_cost(&self, op: &ConstOp) -> i64 {
+        let cost = match op {
+            ConstOp::I32Const(_) => self.I32Const,
+            ConstOp::I64Const(_) => self.I64Const,
+            ConstOp::F32Const(_) => self.F32Const,
+            ConstOp::F64Const(_) => self.F64Const,
+            ConstOp::V128Const(_) => self.V128Const,
+            ConstOp::GlobalGet(_) => self.GlobalGet,
+            ConstOp::RefI31 => self.RefI31,
+            ConstOp::RefNull(_) => self.RefNull,
+            ConstOp::RefFunc(_) => self.RefFunc,
+            ConstOp::I32Add => self.I32Add,
+            ConstOp::I32Sub => self.I32Sub,
+            ConstOp::I32Mul => self.I32Mul,
+            ConstOp::I64Add => self.I64Add,
+            ConstOp::I64Sub => self.I64Sub,
+            ConstOp::I64Mul => self.I64Mul,
+            ConstOp::StructNew { .. } => self.StructNew,
+            ConstOp::StructNewDefault { .. } => self.StructNewDefault,
+            ConstOp::ArrayNew { .. } => self.ArrayNew,
+            ConstOp::ArrayNewDefault { .. } => self.ArrayNewDefault,
+            ConstOp::ArrayNewFixed { .. } => self.ArrayNewFixed,
+            ConstOp::ExternConvertAny => self.ExternConvertAny,
+            ConstOp::AnyConvertExtern => self.AnyConvertExtern,
+        };
+        i64::from(cost)
+    }
+}

--- a/crates/environ/src/types.rs
+++ b/crates/environ/src/types.rs
@@ -2145,6 +2145,67 @@ impl ConstOp {
             }
         })
     }
+
+    /// Convert a `ConstOp` back to a `wasmparser::Operator`.
+    ///
+    /// `RefNull`'s heap type does not round-trip, so only use this where the
+    /// immediates do not matter, such as looking up an operator's fuel cost.
+    pub fn to_operator(&self) -> wasmparser::Operator<'static> {
+        use wasmparser::{AbstractHeapType, HeapType, Ieee32, Ieee64, Operator, V128};
+        match self {
+            ConstOp::I32Const(value) => Operator::I32Const { value: *value },
+            ConstOp::I64Const(value) => Operator::I64Const { value: *value },
+            ConstOp::F32Const(bits) => Operator::F32Const {
+                value: Ieee32::from(f32::from_bits(*bits)),
+            },
+            ConstOp::F64Const(bits) => Operator::F64Const {
+                value: Ieee64::from(f64::from_bits(*bits)),
+            },
+            ConstOp::V128Const(value) => Operator::V128Const {
+                value: V128::from(*value as i128),
+            },
+            ConstOp::GlobalGet(index) => Operator::GlobalGet {
+                global_index: index.as_u32(),
+            },
+            ConstOp::RefI31 => Operator::RefI31,
+            ConstOp::RefNull(_) => Operator::RefNull {
+                hty: HeapType::Abstract {
+                    shared: false,
+                    ty: AbstractHeapType::Any,
+                },
+            },
+            ConstOp::RefFunc(index) => Operator::RefFunc {
+                function_index: index.as_u32(),
+            },
+            ConstOp::I32Add => Operator::I32Add,
+            ConstOp::I32Sub => Operator::I32Sub,
+            ConstOp::I32Mul => Operator::I32Mul,
+            ConstOp::I64Add => Operator::I64Add,
+            ConstOp::I64Sub => Operator::I64Sub,
+            ConstOp::I64Mul => Operator::I64Mul,
+            ConstOp::StructNew { struct_type_index } => Operator::StructNew {
+                struct_type_index: struct_type_index.as_u32(),
+            },
+            ConstOp::StructNewDefault { struct_type_index } => Operator::StructNewDefault {
+                struct_type_index: struct_type_index.as_u32(),
+            },
+            ConstOp::ArrayNew { array_type_index } => Operator::ArrayNew {
+                array_type_index: array_type_index.as_u32(),
+            },
+            ConstOp::ArrayNewDefault { array_type_index } => Operator::ArrayNewDefault {
+                array_type_index: array_type_index.as_u32(),
+            },
+            ConstOp::ArrayNewFixed {
+                array_type_index,
+                array_size,
+            } => Operator::ArrayNewFixed {
+                array_type_index: array_type_index.as_u32(),
+                array_size: *array_size,
+            },
+            ConstOp::ExternConvertAny => Operator::ExternConvertAny,
+            ConstOp::AnyConvertExtern => Operator::AnyConvertExtern,
+        }
+    }
 }
 
 /// The type that can be used to index into [Memory] and [Table].

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -651,6 +651,10 @@ impl Config {
     /// configures per-byte, per-element, and per-page costs for operators whose
     /// work depends on a runtime operand.
     ///
+    /// These costs apply both to operators in function bodies and to operators
+    /// in constant expressions evaluated at instantiation time, such as global
+    /// initializers and element or data segment offsets.
+    ///
     /// This is only relevant when [`Config::consume_fuel`] is enabled.
     pub fn operator_cost(&mut self, cost: OperatorCost) -> &mut Self {
         self.tunables.operator_cost = Some(OperatorCostStrategy::table(cost));

--- a/tests/all/fuel.rs
+++ b/tests/all/fuel.rs
@@ -1061,16 +1061,16 @@ fn fuel_around_table_grow() -> Result<()> {
 /// `(start ...)` function is what flushes the buffered charges into the fuel
 /// counter, so it must be present for the charges to be observable.
 ///
-/// Expected accounting with `I32Add = 100` and every other cost left at its
-/// default of 1:
+/// Expected accounting with `I32Const = 7`, `I32Add = 100`, and every other
+/// cost left at its default of 1:
 ///
 /// | module-startup function entry | 1   |
-/// | `i32.const 1`                 | 1   |
-/// | `i32.const 2`                 | 1   |
+/// | `i32.const 1`                 | 7   |
+/// | `i32.const 2`                 | 7   |
 /// | `i32.add`                     | 100 |
 /// | synthesized `call $start`     | 1   |
 /// | `$start` function entry       | 1   |
-/// | total                         | 105 |
+/// | total                         | 117 |
 ///
 /// With the default table every op costs 1, so the same module totals 6.
 #[test]
@@ -1105,11 +1105,12 @@ fn const_expr_honors_operator_cost() -> Result<()> {
 
     assert_eq!(instantiation_fuel(OperatorCost::default())?, 6);
 
-    let expensive_add = OperatorCost {
+    let custom = OperatorCost {
+        I32Const: 7,
         I32Add: 100,
         ..Default::default()
     };
-    assert_eq!(instantiation_fuel(expensive_add)?, 105);
+    assert_eq!(instantiation_fuel(custom)?, 117);
 
     Ok(())
 }
@@ -1126,6 +1127,10 @@ fn const_expr_honors_operator_cost() -> Result<()> {
 /// | synthesized `call $start`     | 50 |
 /// | `$start` function entry       | 1  |
 /// | total                         | 52 |
+///
+/// The two entry rows are the flat per-function entry charge
+/// (`FuncEnvironment::new`'s `fuel_consumed: 1`, flushed by `fuel_check` on
+/// function entry), not derived from any operator's cost.
 #[test]
 #[cfg_attr(miri, ignore)]
 fn module_start_call_honors_operator_cost() -> Result<()> {

--- a/tests/all/fuel.rs
+++ b/tests/all/fuel.rs
@@ -1053,26 +1053,6 @@ fn fuel_around_table_grow() -> Result<()> {
     Ok(())
 }
 
-/// A const-expr operator must be charged its configured cost, not a hardcoded 1.
-///
-/// The module's global initializer is a three-op const-expr. Wasmtime does not
-/// constant-fold `i32.add` at compile time, so the expression is translated into
-/// the synthesized module-startup function and executed at instantiation. The
-/// `(start ...)` function is what flushes the buffered charges into the fuel
-/// counter, so it must be present for the charges to be observable.
-///
-/// Expected accounting with `I32Const = 7`, `I32Add = 100`, and every other
-/// cost left at its default of 1:
-///
-/// | module-startup function entry | 1   |
-/// | `i32.const 1`                 | 7   |
-/// | `i32.const 2`                 | 7   |
-/// | `i32.add`                     | 100 |
-/// | synthesized `call $start`     | 1   |
-/// | `$start` function entry       | 1   |
-/// | total                         | 117 |
-///
-/// With the default table every op costs 1, so the same module totals 6.
 #[test]
 #[cfg_attr(miri, ignore)]
 fn const_expr_honors_operator_cost() -> Result<()> {
@@ -1115,22 +1095,6 @@ fn const_expr_honors_operator_cost() -> Result<()> {
     Ok(())
 }
 
-/// `module_start` synthesizes the call to the wasm `(start ...)` function and
-/// hand-rolls the fuel accounting that `Operator::Call` normally receives from
-/// `fuel_before_op`. That accounting must use the configured `Call` cost rather
-/// than a hardcoded 1.
-///
-/// The module has no globals and no segments, and an empty start function, so
-/// the only charges are:
-///
-/// | module-startup function entry | 1  |
-/// | synthesized `call $start`     | 50 |
-/// | `$start` function entry       | 1  |
-/// | total                         | 52 |
-///
-/// The two entry rows are the flat per-function entry charge
-/// (`FuncEnvironment::new`'s `fuel_consumed: 1`, flushed by `fuel_check` on
-/// function entry), not derived from any operator's cost.
 #[test]
 #[cfg_attr(miri, ignore)]
 fn module_start_call_honors_operator_cost() -> Result<()> {
@@ -1140,18 +1104,26 @@ fn module_start_call_honors_operator_cost() -> Result<()> {
           (start $start))
     "#;
 
-    let mut config = Config::new();
-    config.consume_fuel(true).operator_cost(OperatorCost {
+    fn instantiation_fuel(op_cost: OperatorCost) -> Result<u64> {
+        let mut config = Config::new();
+        config.consume_fuel(true).operator_cost(op_cost);
+        let engine = Engine::new(&config)?;
+        let module = Module::new(&engine, WAT)?;
+
+        let mut store = Store::new(&engine, ());
+        store.set_fuel(10_000)?;
+        Instance::new(&mut store, &module, &[])?;
+
+        Ok(10_000 - store.get_fuel()?)
+    }
+
+    assert_eq!(instantiation_fuel(OperatorCost::default())?, 3);
+
+    let custom = OperatorCost {
         Call: 50,
         ..Default::default()
-    });
-    let engine = Engine::new(&config)?;
-    let module = Module::new(&engine, WAT)?;
+    };
+    assert_eq!(instantiation_fuel(custom)?, 52);
 
-    let mut store = Store::new(&engine, ());
-    store.set_fuel(10_000)?;
-    Instance::new(&mut store, &module, &[])?;
-
-    assert_eq!(10_000 - store.get_fuel()?, 52);
     Ok(())
 }

--- a/tests/all/fuel.rs
+++ b/tests/all/fuel.rs
@@ -1052,3 +1052,64 @@ fn fuel_around_table_grow() -> Result<()> {
     assert_eq!(trap, Trap::TableOutOfBounds);
     Ok(())
 }
+
+/// A const-expr operator must be charged its configured cost, not a hardcoded 1.
+///
+/// The module's global initializer is a three-op const-expr. Wasmtime does not
+/// constant-fold `i32.add` at compile time, so the expression is translated into
+/// the synthesized module-startup function and executed at instantiation. The
+/// `(start ...)` function is what flushes the buffered charges into the fuel
+/// counter, so it must be present for the charges to be observable.
+///
+/// Expected accounting with `I32Add = 100` and every other cost left at its
+/// default of 1:
+///
+/// | module-startup function entry | 1   |
+/// | `i32.const 1`                 | 1   |
+/// | `i32.const 2`                 | 1   |
+/// | `i32.add`                     | 100 |
+/// | synthesized `call $start`     | 1   |
+/// | `$start` function entry       | 1   |
+/// | total                         | 105 |
+///
+/// With the default table every op costs 1, so the same module totals 6.
+#[test]
+#[cfg_attr(miri, ignore)]
+fn const_expr_honors_operator_cost() -> Result<()> {
+    const WAT: &str = r#"
+        (module
+          (global $g i32 (i32.add (i32.const 1) (i32.const 2)))
+          (export "g" (global $g))
+          (func $start)
+          (start $start))
+    "#;
+
+    fn instantiation_fuel(op_cost: OperatorCost) -> Result<u64> {
+        let mut config = Config::new();
+        config.consume_fuel(true).operator_cost(op_cost);
+        let engine = Engine::new(&config)?;
+        let module = Module::new(&engine, WAT)?;
+
+        let mut store = Store::new(&engine, ());
+        store.set_fuel(10_000)?;
+        let instance = Instance::new(&mut store, &module, &[])?;
+
+        let g = instance
+            .get_global(&mut store, "g")
+            .unwrap()
+            .get(&mut store);
+        assert_eq!(g.i32(), Some(3), "global initializer did not run");
+
+        Ok(10_000 - store.get_fuel()?)
+    }
+
+    assert_eq!(instantiation_fuel(OperatorCost::default())?, 6);
+
+    let expensive_add = OperatorCost {
+        I32Add: 100,
+        ..Default::default()
+    };
+    assert_eq!(instantiation_fuel(expensive_add)?, 105);
+
+    Ok(())
+}

--- a/tests/all/fuel.rs
+++ b/tests/all/fuel.rs
@@ -1113,3 +1113,40 @@ fn const_expr_honors_operator_cost() -> Result<()> {
 
     Ok(())
 }
+
+/// `module_start` synthesizes the call to the wasm `(start ...)` function and
+/// hand-rolls the fuel accounting that `Operator::Call` normally receives from
+/// `fuel_before_op`. That accounting must use the configured `Call` cost rather
+/// than a hardcoded 1.
+///
+/// The module has no globals and no segments, and an empty start function, so
+/// the only charges are:
+///
+/// | module-startup function entry | 1  |
+/// | synthesized `call $start`     | 50 |
+/// | `$start` function entry       | 1  |
+/// | total                         | 52 |
+#[test]
+#[cfg_attr(miri, ignore)]
+fn module_start_call_honors_operator_cost() -> Result<()> {
+    const WAT: &str = r#"
+        (module
+          (func $start)
+          (start $start))
+    "#;
+
+    let mut config = Config::new();
+    config.consume_fuel(true).operator_cost(OperatorCost {
+        Call: 50,
+        ..Default::default()
+    });
+    let engine = Engine::new(&config)?;
+    let module = Module::new(&engine, WAT)?;
+
+    let mut store = Store::new(&engine, ());
+    store.set_fuel(10_000)?;
+    Instance::new(&mut store, &module, &[])?;
+
+    assert_eq!(10_000 - store.get_fuel()?, 52);
+    Ok(())
+}

--- a/tests/all/fuel.rs
+++ b/tests/all/fuel.rs
@@ -1053,9 +1053,9 @@ fn fuel_around_table_grow() -> Result<()> {
     Ok(())
 }
 
-#[test]
+#[wasmtime_test(wasm_features(extended_const))]
 #[cfg_attr(miri, ignore)]
-fn const_expr_honors_operator_cost() -> Result<()> {
+fn const_expr_honors_operator_cost(config: &mut Config) -> Result<()> {
     const WAT: &str = r#"
         (module
           (global $g i32 (i32.add (i32.const 1) (i32.const 2)))
@@ -1064,10 +1064,9 @@ fn const_expr_honors_operator_cost() -> Result<()> {
           (start $start))
     "#;
 
-    fn instantiation_fuel(op_cost: OperatorCost) -> Result<u64> {
-        let mut config = Config::new();
+    fn instantiation_fuel(config: &mut Config, op_cost: OperatorCost) -> Result<u64> {
         config.consume_fuel(true).operator_cost(op_cost);
-        let engine = Engine::new(&config)?;
+        let engine = Engine::new(config)?;
         let module = Module::new(&engine, WAT)?;
 
         let mut store = Store::new(&engine, ());
@@ -1083,31 +1082,30 @@ fn const_expr_honors_operator_cost() -> Result<()> {
         Ok(10_000 - store.get_fuel()?)
     }
 
-    assert_eq!(instantiation_fuel(OperatorCost::default())?, 6);
+    assert_eq!(instantiation_fuel(config, OperatorCost::default())?, 6);
 
     let custom = OperatorCost {
         I32Const: 7,
         I32Add: 100,
         ..Default::default()
     };
-    assert_eq!(instantiation_fuel(custom)?, 117);
+    assert_eq!(instantiation_fuel(config, custom)?, 117);
 
     Ok(())
 }
 
-#[test]
+#[wasmtime_test]
 #[cfg_attr(miri, ignore)]
-fn module_start_call_honors_operator_cost() -> Result<()> {
+fn module_start_call_honors_operator_cost(config: &mut Config) -> Result<()> {
     const WAT: &str = r#"
         (module
           (func $start)
           (start $start))
     "#;
 
-    fn instantiation_fuel(op_cost: OperatorCost) -> Result<u64> {
-        let mut config = Config::new();
+    fn instantiation_fuel(config: &mut Config, op_cost: OperatorCost) -> Result<u64> {
         config.consume_fuel(true).operator_cost(op_cost);
-        let engine = Engine::new(&config)?;
+        let engine = Engine::new(config)?;
         let module = Module::new(&engine, WAT)?;
 
         let mut store = Store::new(&engine, ());
@@ -1117,13 +1115,13 @@ fn module_start_call_honors_operator_cost() -> Result<()> {
         Ok(10_000 - store.get_fuel()?)
     }
 
-    assert_eq!(instantiation_fuel(OperatorCost::default())?, 3);
+    assert_eq!(instantiation_fuel(config, OperatorCost::default())?, 3);
 
     let custom = OperatorCost {
         Call: 50,
         ..Default::default()
     };
-    assert_eq!(instantiation_fuel(custom)?, 52);
+    assert_eq!(instantiation_fuel(config, custom)?, 52);
 
     Ok(())
 }


### PR DESCRIPTION
Closes #14204.

Const-expr operators and the synthesized start call now use the configured operator costs instead of a hardcoded fuel charge of 1. Adds regression tests and a release note.

The issue also reports that variable per-element costs are missing from const-exprs, but those costs are already applied by the shared `array.new` translation path used by both const-exprs and function bodies. Existing fuel tests confirm this behavior: `tests/all/fuel.wast:289` . 
