### PR TITLE
Scope futures returned by wasip3 http implementations

### DIFF
--- a/crates/wasi-http/src/p3/request.rs
+++ b/crates/wasi-http/src/p3/request.rs
@@ -89,7 +89,7 @@ impl Request {
         req: http::Request<T>,
     ) -> (
         Self,
-        impl Future<Output = Result<(), Error>> + Send + 'static,
+        impl Future<Output = Result<(), Error>> + Send + 'static + use<T>,
     )
     where
         T: http_body::Body<Data = Bytes> + Send + 'static,

--- a/crates/wasi-http/src/p3/response.rs
+++ b/crates/wasi-http/src/p3/response.rs
@@ -94,7 +94,7 @@ impl Response {
         res: http::Response<T>,
     ) -> (
         Self,
-        impl Future<Output = Result<(), Error>> + Send + 'static,
+        impl Future<Output = Result<(), Error>> + Send + 'static + use<T>,
     )
     where
         T: http_body::Body<Data = Bytes> + Send + 'static,


### PR DESCRIPTION
Flag to rustc that the input `hooks` argument isn't captured in the output `impl Future` argument.

Closes #14218

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please review the Bytecode Alliance's AI tool usage policy at
https://github.com/bytecodealliance/governance/blob/main/AI_TOOL_POLICY.md

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
