### PR TITLE
Skip stack-switching wast tests when fuzzing with asan

### DIFF
--- a/crates/fuzzing/build.rs
+++ b/crates/fuzzing/build.rs
@@ -41,4 +41,21 @@ fn main() {
 
     code.push_str("];\n");
     std::fs::write(out_dir.join("wasttests.rs"), code).unwrap();
+
+    // NB: duplicating a workaround in the wasmtime-fiber build script.
+    custom_cfg("asan", cfg_is("sanitize", "address"));
+}
+
+fn cfg_is(key: &str, val: &str) -> bool {
+    std::env::var(&format!("CARGO_CFG_{}", key.to_uppercase()))
+        .ok()
+        .as_deref()
+        == Some(val)
+}
+
+fn custom_cfg(key: &str, enabled: bool) {
+    println!("cargo:rustc-check-cfg=cfg({key})");
+    if enabled {
+        println!("cargo:rustc-cfg={key}");
+    }
 }

--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -620,6 +620,12 @@ pub fn wast_test(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<()> {
 
     let test = &test.test;
 
+    // FIXME(#14222) stack-switching and asan aren't integrated yet, so skip
+    // stack-switching tests when asan is enabled.
+    if cfg!(asan) && test.config.stack_switching == Some(true) {
+        return Err(arbitrary::Error::IncorrectFormat);
+    }
+
     if test.config.component_model_async() || u.arbitrary()? {
         fuzz_config.enable_async(u)?;
     }


### PR DESCRIPTION
See more details in #14222

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please review the Bytecode Alliance's AI tool usage policy at
https://github.com/bytecodealliance/governance/blob/main/AI_TOOL_POLICY.md

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
