### PR TITLE
Cranelift arithmetic mid-end optimization rules

### DIFF
--- a/cranelift/codegen/src/opts/arithmetic.isle
+++ b/cranelift/codegen/src/opts/arithmetic.isle
@@ -303,6 +303,10 @@
 (rule (simplify (isub ty (bor ty y x) (band ty x y))) (bxor ty x y))
 (rule (simplify (isub ty (bor ty y x) (band ty y x))) (bxor ty x y))
 
+;; (x & y) - (x | y) --> -(x ^ y)
+(rule (simplify (isub ty (band ty x y) (bor ty x y))) (ineg ty (bxor ty x y)))
+(rule (simplify (isub ty (band ty y x) (bor ty x y))) (ineg ty (bxor ty x y)))
+
 ;; (x + y) - (x & y)  ==>  (x | y)
 (rule (simplify (isub ty (iadd ty x y) (band ty x y))) (bor ty x y))
 (rule (simplify (isub ty (iadd ty x y) (band ty y x))) (bor ty x y))
@@ -315,6 +319,16 @@
 (rule (simplify (isub ty (bor ty y x) (bxor ty x y))) (band ty x y))
 (rule (simplify (isub ty (bor ty y x) (bxor ty y x))) (band ty x y))
 
+;; (x ^ y) - (x | y) --> -(x & y)
+(rule (simplify (isub ty (bxor ty x y) (bor ty x y))) (ineg ty (band ty x y)))
+(rule (simplify (isub ty (bxor ty x y) (bor ty y x))) (ineg ty (band ty x y)))
+
+;; (x ^ y) + 2 * (x & y) --> x + y
+(rule (simplify (iadd ty (bxor ty x y) (ishl ty (band ty x y) (iconst_u ty 1)))) (iadd ty x y))
+(rule (simplify (iadd ty (bxor ty x y) (ishl ty (band ty y x) (iconst_u ty 1)))) (iadd ty x y))
+(rule (simplify (iadd ty (ishl ty (band ty x y) (iconst_u ty 1)) (bxor ty x y))) (iadd ty x y))
+(rule (simplify (iadd ty (ishl ty (band ty x y) (iconst_u ty 1)) (bxor ty y x))) (iadd ty x y))
+
 ;; (~x) + x == -1
 (rule (simplify (iadd ty (bnot ty x) x)) (iconst_s ty -1))
 (rule (simplify (iadd ty x (bnot ty x))) (iconst_s ty -1))
@@ -324,6 +338,9 @@
 (rule (simplify (isub ty (iadd ty x y) (iadd ty z x))) (isub ty y z))
 (rule (simplify (isub ty (iadd ty y x) (iadd ty x z))) (isub ty y z))
 (rule (simplify (isub ty (iadd ty y x) (iadd ty z x))) (isub ty y z))
+
+;; (x - y) + (y - x) --> 0
+(rule (simplify (iadd ty (isub ty x y) (isub ty y x))) (subsume (iconst_u ty 0)))
 
 ;; ((x - z) - (y - z)) --> (x - y)
 (rule (simplify (isub ty (isub ty x z) (isub ty y z))) (isub ty x y))
@@ -593,4 +610,3 @@
 (rule (simplify (bxor ty (ishl ty x y) (ishl ty z y))) (ishl ty (bxor ty x z) y))
 (rule (simplify (bxor ty (sshr ty x y) (sshr ty z y))) (sshr ty (bxor ty x z) y))
 (rule (simplify (bxor ty (ushr ty x y) (ushr ty z y))) (ushr ty (bxor ty x z) y))
-

--- a/cranelift/filetests/filetests/egraph/arithmetic.clif
+++ b/cranelift/filetests/filetests/egraph/arithmetic.clif
@@ -553,3 +553,63 @@ block0(v0: i32, v1: i32, v2: i32):
     ; check: v7 = ushr v6, v2
     ; check: return v7
 }
+
+function %band_bor_isub_to_ineg_bxor(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = band.i32 v0, v1
+    v3 = bor.i32 v0, v1
+    v4 = isub.i32 v2, v3
+    return v4
+    ; check: v5 = bxor v0, v1
+    ; check: v6 = ineg v5
+    ; check: return v6
+}
+
+;; (x - y) + (y - x) --> 0
+function %iadd_isub_cancel(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = isub.i32 v0, v1
+    v3 = isub.i32 v1, v0
+    v4 = iadd.i32 v2, v3
+    return v4
+    ; check: v5 = iconst.i32 0
+    ; check: return v5
+}
+
+;; (x ^ y) + 2 * (x & y) --> x + y
+function %iadd_bxor_ishl_band(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = iconst.i32 1
+    v3 = bxor.i32 v0, v1
+    v4 = band.i32 v0, v1
+    v5 = ishl.i32 v4, v2
+    v6 = iadd.i32 v3, v5
+    return v6
+    ; check: v7 = iadd v0, v1
+    ; check: return v7
+}
+
+;; (x ^ y) + 2 * (x & y) --> x + y
+function %iadd_bxor_ishl_band_commute(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = iconst.i32 1
+    v3 = band.i32 v0, v1
+    v4 = ishl.i32 v3, v2
+    v5 = bxor.i32 v0, v1
+    v6 = iadd.i32 v4, v5
+    return v6
+    ; check: v7 = iadd v0, v1
+    ; check: return v7
+}
+
+;; (x ^ y) - (x | y) --> -(x & y)
+function %bxor_bor_isub_to_ineg_band(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = bxor.i32 v0, v1
+    v3 = bor.i32 v0, v1
+    v4 = isub.i32 v2, v3
+    return v4
+    ; check: v5 = band v0, v1
+    ; check: v6 = ineg v5
+    ; check: return v6
+}


### PR DESCRIPTION
This commit adds these arithmetic mid-end optimization rules and their commutative variants. I've also added at least one filetest for each rule that failed to optimize in main.

```
(x & y) - (x | y)     --> -(x ^ y)
(x ^ y) - (x | y)     --> -(x & y)
(x ^ y) + 2 * (x & y) --> x + y
(x - y) + (y - x)     --> 0
```
