### PR TITLE
cranelift: add arithmetic opt rules

### DIFF
--- a/cranelift/codegen/src/opts/arithmetic.isle
+++ b/cranelift/codegen/src/opts/arithmetic.isle
@@ -610,3 +610,13 @@
 (rule (simplify (bxor ty (ishl ty x y) (ishl ty z y))) (ishl ty (bxor ty x z) y))
 (rule (simplify (bxor ty (sshr ty x y) (sshr ty z y))) (sshr ty (bxor ty x z) y))
 (rule (simplify (bxor ty (ushr ty x y) (ushr ty z y))) (ushr ty (bxor ty x z) y))
+
+;; (max (-x) x) * (max (-x) x) = x * x
+(rule (simplify (imul ty (smax ty (ineg ty x) x) (smax ty (ineg ty x) x))) (imul ty x x))
+(rule (simplify (imul ty (smax ty (ineg ty x) x) (smax ty x (ineg ty x)))) (imul ty x x))
+(rule (simplify (imul ty (smax ty x (ineg ty x)) (smax ty (ineg ty x) x))) (imul ty x x))
+(rule (simplify (imul ty (smax ty x (ineg ty x)) (smax ty x (ineg ty x)))) (imul ty x x))
+(rule (simplify (imul ty (umax ty (ineg ty x) x) (umax ty (ineg ty x) x))) (imul ty x x))
+(rule (simplify (imul ty (umax ty (ineg ty x) x) (umax ty x (ineg ty x)))) (imul ty x x))
+(rule (simplify (imul ty (umax ty x (ineg ty x)) (umax ty (ineg ty x) x))) (imul ty x x))
+(rule (simplify (imul ty (umax ty x (ineg ty x)) (umax ty x (ineg ty x)))) (imul ty x x))

--- a/cranelift/filetests/filetests/egraph/arithmetic.clif
+++ b/cranelift/filetests/filetests/egraph/arithmetic.clif
@@ -613,3 +613,95 @@ block0(v0: i32, v1: i32):
     ; check: v6 = ineg v5
     ; check: return v6
 }
+
+;; (max(-x, x) * max(-x, x)) --> x * x
+function %imul_smax_ineg_x_ineg_x(i32) -> i32 {
+block0(v0: i32):
+    v1 = ineg v0
+    v2 = smax v1, v0
+    v3 = imul v2, v2
+    return v3
+    ; check: v4 = imul v0, v0
+    ; check: return v4
+}
+
+;; (max(-x, x) * max(x, -x)) --> x * x
+function %imul_smax_ineg_x_x_ineg(i32) -> i32 {
+block0(v0: i32):
+    v1 = ineg v0
+    v2 = smax v1, v0
+    v3 = smax v0, v1
+    v4 = imul v2, v3
+    return v4
+    ; check: v5 = imul v0, v0
+    ; check: return v5
+}
+
+;; (max(x, -x) * max(-x, x)) --> x * x
+function %imul_smax_x_ineg_ineg_x(i32) -> i32 {
+block0(v0: i32):
+    v1 = ineg v0
+    v2 = smax v0, v1
+    v3 = smax v1, v0
+    v4 = imul v2, v3
+    return v4
+    ; check: v5 = imul v0, v0
+    ; check: return v5
+}
+
+;; (max(x, -x) * max(x, -x)) --> x * x
+function %imul_smax_x_ineg_x_ineg(i32) -> i32 {
+block0(v0: i32):
+    v1 = ineg v0
+    v2 = smax v0, v1
+    v3 = imul v2, v2
+    return v3
+    ; check: v4 = imul v0, v0
+    ; check: return v4
+}
+
+;; (max(-x, x) * max(-x, x)) --> x * x
+function %imul_umax_ineg_x_ineg_x(i32) -> i32 {
+block0(v0: i32):
+    v1 = ineg v0
+    v2 = umax v1, v0
+    v3 = imul v2, v2
+    return v3
+    ; check: v4 = imul v0, v0
+    ; check: return v4
+}
+
+;; (max(-x, x) * max(x, -x)) --> x * x
+function %imul_umax_ineg_x_x_ineg(i32) -> i32 {
+block0(v0: i32):
+    v1 = ineg v0
+    v2 = umax v1, v0
+    v3 = umax v0, v1
+    v4 = imul v2, v3
+    return v4
+    ; check: v5 = imul v0, v0
+    ; check: return v5
+}
+
+;; (max(x, -x) * max(-x, x)) --> x * x
+function %imul_umax_x_ineg_ineg_x(i32) -> i32 {
+block0(v0: i32):
+    v1 = ineg v0
+    v2 = umax v0, v1
+    v3 = umax v1, v0
+    v4 = imul v2, v3
+    return v4
+    ; check: v5 = imul v0, v0
+    ; check: return v5
+}
+
+;; (max(x, -x) * max(x, -x)) --> x * x
+function %imul_umax_x_ineg_x_ineg(i32) -> i32 {
+block0(v0: i32):
+    v1 = ineg v0
+    v2 = umax v0, v1
+    v3 = imul v2, v2
+    return v3
+    ; check: v4 = imul v0, v0
+    ; check: return v4
+}

--- a/cranelift/filetests/filetests/runtests/arithmetic.clif
+++ b/cranelift/filetests/filetests/runtests/arithmetic.clif
@@ -1091,3 +1091,31 @@ block0(v0: i32, v1: i32, v2: i32):
 ; run: %isub_ishl_ineg_rt(10, -2, 4) == -22
 ; run: %isub_ishl_ineg_rt(0x80000000, 1, 31) == 0
 ; run: %isub_ishl_ineg_rt(7, 1, 32) == 8
+
+function %imul_smax_ineg_rt(i32) -> i32 fast {
+block0(v0: i32):
+    v1 = ineg v0
+    v2 = smax v1, v0
+    v3 = imul v2, v2
+    return v3
+}
+
+; run: %imul_smax_ineg_rt(0) == 0
+; run: %imul_smax_ineg_rt(1) == 1
+; run: %imul_smax_ineg_rt(-1) == 1
+; run: %imul_smax_ineg_rt(0x7fffffff) == 1
+; run: %imul_smax_ineg_rt(0x80000000) == 0
+
+function %imul_umax_ineg_rt(i32) -> i32 fast {
+block0(v0: i32):
+    v1 = ineg v0
+    v2 = umax v1, v0
+    v3 = imul v2, v2
+    return v3
+}
+
+; run: %imul_umax_ineg_rt(0) == 0
+; run: %imul_umax_ineg_rt(1) == 1
+; run: %imul_umax_ineg_rt(-1) == 1
+; run: %imul_umax_ineg_rt(0x7fffffff) == 1
+; run: %imul_umax_ineg_rt(0x80000000) == 0


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please review the Bytecode Alliance's AI tool usage policy at
https://github.com/bytecodealliance/governance/blob/main/AI_TOOL_POLICY.md

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

Hi, this PR adds an arithmetic peephole optimization which performs
`(max (-x) x) * (max (-x) x) = x * x`.
This PR includes commutative variants and the filetests (both egraph and runtest).

Thanks for reading!