### PR TITLE
docs: fix typo paramters -> parameters

### DIFF
--- a/cranelift/isle/veri/docs/language.md
+++ b/cranelift/isle/veri/docs/language.md
@@ -283,7 +283,7 @@ Spec macros may be declared:
 ```
 
 Macro expansions are of the form `(<name>! <args...>)`. The body of the macro is
-evaluated in a scope with paramters set to argument values, and the result
+evaluated in a scope with parameters set to argument values, and the result
 substituted for the expansion expression.
 
 ## Type Instantiation


### PR DESCRIPTION
Corrects the misspelling `paramters` -> `parameters` in `cranelift/isle/veri/docs/language.md`.

Documentation only, no behaviour change.