### PR TITLE
Cranelift bitops mid-end optimization rules

### DIFF
--- a/cranelift/codegen/src/opts/bitops.isle
+++ b/cranelift/codegen/src/opts/bitops.isle
@@ -573,6 +573,25 @@
 (rule (simplify (bor ty (band ty (bnot ty y) x) (bxor ty y x))) (bxor ty x y))
 (rule (simplify (bor ty (bxor ty y x) (band ty (bnot ty y) x))) (bxor ty x y))
 
+;; ~x ^ ~y --> x ^ y
+(rule (simplify (bxor ty (bnot ty x) (bnot ty y))) (bxor ty x y))
+
+;; ~x & (x ^ y) --> ~x & y
+(rule (simplify (band ty (bnot ty x) (bxor ty x y))) (band ty (bnot ty x) y))
+(rule (simplify (band ty (bnot ty x) (bxor ty y x))) (band ty (bnot ty x) y))
+(rule (simplify (band ty (bxor ty x y) (bnot ty x))) (band ty (bnot ty x) y))
+(rule (simplify (band ty (bxor ty y x) (bnot ty x))) (band ty (bnot ty x) y))
+
+;; x & (x ^ y) --> x & ~y
+(rule (simplify (band ty x (bxor ty x y))) (band ty x (bnot ty y)))
+(rule (simplify (band ty x (bxor ty y x))) (band ty x (bnot ty y)))
+(rule (simplify (band ty (bxor ty x y) x)) (band ty x (bnot ty y)))
+(rule (simplify (band ty (bxor ty y x) x)) (band ty x (bnot ty y)))
+
+;; ~(~x ^ y) --> x ^ y
+(rule (simplify (bnot ty (bxor ty (bnot ty x) y))) (bxor ty x y))
+(rule (simplify (bnot ty (bxor ty y (bnot ty x)))) (bxor ty x y))
+
 ;; (x & ~y) ^ ~x --> ~(x & y)
 (rule (simplify (bxor ty (band ty x (bnot ty y)) (bnot ty x))) (bnot ty (band ty x y)))
 (rule (simplify (bxor ty (bnot ty x) (band ty x (bnot ty y)))) (bnot ty (band ty x y)))
@@ -584,6 +603,18 @@
 (rule (simplify (bxor ty x (band ty (bnot ty x) y))) (bor ty x y))
 (rule (simplify (bxor ty (band ty y (bnot ty x)) x)) (bor ty x y))
 (rule (simplify (bxor ty x (band ty y (bnot ty x)))) (bor ty x y))
+
+;; x ^ (x & y) --> x & ~y
+(rule (simplify (bxor ty x (band ty x y))) (band ty x (bnot ty y)))
+(rule (simplify (bxor ty x (band ty y x))) (band ty x (bnot ty y)))
+(rule (simplify (bxor ty (band ty x y) x)) (band ty x (bnot ty y)))
+(rule (simplify (bxor ty (band ty y x) x)) (band ty x (bnot ty y)))
+
+;; (x | y) ^ y --> x & ~y
+(rule (simplify (bxor ty (bor ty x y) y)) (band ty x (bnot ty y)))
+(rule (simplify (bxor ty (bor ty y x) y)) (band ty x (bnot ty y)))
+(rule (simplify (bxor ty y (bor ty x y))) (band ty x (bnot ty y)))
+(rule (simplify (bxor ty y (bor ty y x))) (band ty x (bnot ty y)))
 
 ;; (x | y) & ~(x ^ y) --> x & y
 (rule (simplify (band ty (bor ty x y) (bnot ty (bxor ty x y)))) (band ty x y))
@@ -747,4 +778,3 @@
 (rule (simplify (band ty (band ty x y) (band ty y z))) (band ty (band ty y x) z))
 (rule (simplify (band ty (band ty x y) (band ty z x))) (band ty (band ty x y) z))
 (rule (simplify (band ty (band ty x y) (band ty z y))) (band ty (band ty y x) z))
-

--- a/cranelift/filetests/filetests/egraph/bitops.clif
+++ b/cranelift/filetests/filetests/egraph/bitops.clif
@@ -216,8 +216,8 @@ block0(v0: i32x4):
 }
 
 ; check: const0 = 0x00000000000000000000000000000000
-; check: v3 = vconst.i32x4 const0
-; check: return v3
+; check: v4 = vconst.i32x4 const0
+; check: return v4
 
 function %vector_bor_x_bnot_x(i32x4) -> i32x4 {
 block0(v0: i32x4):
@@ -1225,3 +1225,70 @@ block0(v0: i16x8, v1: i16x8):
 ;     v5 = vconst.i16x8 const0
 ;     return v5
 ; }
+
+;; ~x ^ ~y --> x ^ y
+function %bxor_bnot_bnot(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = bnot.i32 v0
+    v3 = bnot.i32 v1
+    v4 = bxor.i32 v2, v3
+    return v4
+    ; check: v5 = bxor v0, v1
+    ; check: return v5
+}
+
+;; ~x & (x ^ y) --> ~x & y
+function %band_bnot_bxor(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = bnot.i32 v0
+    v3 = bxor.i32 v0, v1
+    v4 = band.i32 v2, v3
+    return v4
+    ; check: v2 = bnot v0
+    ; check: v5 = band v2, v1
+    ; check: return v5
+}
+
+;; ~(~x ^ y) --> x ^ y
+function %bnot_bxor_bnot(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = bnot.i32 v0
+    v3 = bxor.i32 v2, v1
+    v4 = bnot.i32 v3
+    return v4
+    ; check: v5 = bxor v0, v1
+    ; check: return v5
+}
+
+;; x & (x ^ y) --> x & ~y
+function %band_bxor_to_band_bnot(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = bxor.i32 v0, v1
+    v3 = band.i32 v0, v2
+    return v3
+    ; check: v4 = bnot v1
+    ; check: v5 = band v0, v4
+    ; check: return v5
+}
+
+;; x ^ (x & y) --> x & ~y
+function %bxor_band_to_band_bnot(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = band.i32 v0, v1
+    v3 = bxor.i32 v0, v2
+    return v3
+    ; check: v4 = bnot v1
+    ; check: v5 = band v0, v4
+    ; check: return v5
+}
+
+;; (x | y) ^ y --> x & ~y
+function %bxor_bor_to_band_bnot(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = bor.i32 v0, v1
+    v3 = bxor.i32 v2, v1
+    return v3
+    ; check: v4 = bnot v1
+    ; check: v5 = band v0, v4
+    ; check: return v5
+}


### PR DESCRIPTION
This commit adds several bitops mid-end optimization rules and filetests that target them. These filetests fail to optimize on main without these new rules.

```
~x ^ ~y       -->  x ^  y
~x & (x ^ y)  --> ~x &  y
x & (x ^ y)   -->  x & ~y
~(~x ^ y)     -->  x ^  y
x ^ (x & y)   -->  x & ~y
(x | y) ^ y   -->  x & ~y
```
