### PR TITLE
aarch64: fix apple_aarch64 stack slot size for sext/uext spilled args

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -1210,8 +1210,14 @@ impl ABIMachineSpec for AArch64MachineDeps {
     fn get_ext_mode(
         call_conv: isa::CallConv,
         specified: ir::ArgumentExtension,
+        location: ABIArgLocation,
     ) -> ir::ArgumentExtension {
-        if call_conv == isa::CallConv::AppleAarch64 {
+        // Apple's AArch64 ABI only requires the caller to sign/zero-extend
+        // arguments in registers; stack-passed arguments use their natural
+        // (possibly sub-word) size and are not extended. See "Pass arguments
+        // to functions correctly" in:
+        // https://developer.apple.com/documentation/xcode/writing-arm64-code-for-apple-platforms
+        if call_conv == isa::CallConv::AppleAarch64 && location == ABIArgLocation::Reg {
             specified
         } else {
             ir::ArgumentExtension::None

--- a/cranelift/codegen/src/isa/pulley_shared/abi.rs
+++ b/cranelift/codegen/src/isa/pulley_shared/abi.rs
@@ -211,6 +211,7 @@ where
     fn get_ext_mode(
         _call_conv: isa::CallConv,
         specified: ir::ArgumentExtension,
+        _location: ABIArgLocation,
     ) -> ir::ArgumentExtension {
         specified
     }

--- a/cranelift/codegen/src/isa/riscv64/abi.rs
+++ b/cranelift/codegen/src/isa/riscv64/abi.rs
@@ -225,6 +225,7 @@ impl ABIMachineSpec for Riscv64MachineDeps {
     fn get_ext_mode(
         _call_conv: isa::CallConv,
         specified: ir::ArgumentExtension,
+        _location: ABIArgLocation,
     ) -> ir::ArgumentExtension {
         specified
     }

--- a/cranelift/codegen/src/isa/s390x/abi.rs
+++ b/cranelift/codegen/src/isa/s390x/abi.rs
@@ -937,6 +937,7 @@ impl ABIMachineSpec for S390xMachineDeps {
     fn get_ext_mode(
         _call_conv: isa::CallConv,
         specified: ir::ArgumentExtension,
+        _location: ABIArgLocation,
     ) -> ir::ArgumentExtension {
         specified
     }

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -906,6 +906,7 @@ impl ABIMachineSpec for X64ABIMachineSpec {
     fn get_ext_mode(
         _call_conv: isa::CallConv,
         specified: ir::ArgumentExtension,
+        _location: ABIArgLocation,
     ) -> ir::ArgumentExtension {
         specified
     }

--- a/cranelift/codegen/src/machinst/abi.rs
+++ b/cranelift/codegen/src/machinst/abi.rs
@@ -270,6 +270,17 @@ pub enum ArgsOrRets {
     Rets,
 }
 
+/// Whether an ABI argument slot lives in a register or on the stack.
+/// Passed to `get_ext_mode` so backends can apply different extension
+/// rules depending on the argument's location.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ABIArgLocation {
+    /// The argument is passed in a register.
+    Reg,
+    /// The argument is passed on the stack.
+    Stack,
+}
+
 /// Abstract location for a machine-specific ABI impl to translate into the
 /// appropriate addressing mode.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -594,9 +605,12 @@ pub trait ABIMachineSpec {
     /// the signature) specifies what extension type should be done *if* the ABI
     /// requires extension to the full register; this method's return value
     /// indicates whether the extension actually *will* be done.
+    /// The `location` parameter indicates whether the argument is in a register
+    /// or on the stack, allowing backends to apply different rules per location.
     fn get_ext_mode(
         call_conv: isa::CallConv,
         specified: ir::ArgumentExtension,
+        location: ABIArgLocation,
     ) -> ir::ArgumentExtension;
 
     /// Get a temporary register that is available to use after a call
@@ -1590,7 +1604,8 @@ impl<M: ABIMachineSpec> Callee<M> {
                 } => {
                     // However, we have to respect the extension mode for stack
                     // slots, or else we grab the wrong bytes on big-endian.
-                    let ext = M::get_ext_mode(sigs[self.sig].call_conv, extension);
+                    let ext =
+                        M::get_ext_mode(sigs[self.sig].call_conv, extension, ABIArgLocation::Stack);
                     let ty =
                         if ext != ArgumentExtension::None && M::word_bits() > ty_bits(ty) as u32 {
                             M::word_type()
@@ -1671,7 +1686,11 @@ impl<M: ABIMachineSpec> Callee<M> {
                             reg, ty, extension, ..
                         } => {
                             let from_bits = ty_bits(ty) as u8;
-                            let ext = M::get_ext_mode(sigs[self.sig].call_conv, extension);
+                            let ext = M::get_ext_mode(
+                                sigs[self.sig].call_conv,
+                                extension,
+                                ABIArgLocation::Reg,
+                            );
                             let vreg = match (ext, from_bits) {
                                 (ir::ArgumentExtension::Uext, n)
                                 | (ir::ArgumentExtension::Sext, n)
@@ -1713,7 +1732,11 @@ impl<M: ABIMachineSpec> Callee<M> {
                             let off = i32::try_from(offset).expect(
                                 "Argument stack offset greater than 2GB; should hit impl limit first",
                                 );
-                            let ext = M::get_ext_mode(sigs[self.sig].call_conv, extension);
+                            let ext = M::get_ext_mode(
+                                sigs[self.sig].call_conv,
+                                extension,
+                                ABIArgLocation::Stack,
+                            );
                             // Trash the from_reg; it should be its last use.
                             match (ext, from_bits) {
                                 (ir::ArgumentExtension::Uext, n)
@@ -1883,11 +1906,15 @@ impl<M: ABIMachineSpec> Callee<M> {
                     for (slot, from_reg) in slots.iter().zip(from_regs.regs().iter()) {
                         // Load argument slot value from `from_reg`, and perform any zero-
                         // or sign-extension that is required by the ABI.
-                        let (ty, extension) = match *slot {
-                            ABIArgSlot::Reg { ty, extension, .. } => (ty, extension),
-                            ABIArgSlot::Stack { ty, extension, .. } => (ty, extension),
+                        let (ty, extension, arg_loc) = match *slot {
+                            ABIArgSlot::Reg { ty, extension, .. } => {
+                                (ty, extension, ABIArgLocation::Reg)
+                            }
+                            ABIArgSlot::Stack { ty, extension, .. } => {
+                                (ty, extension, ABIArgLocation::Stack)
+                            }
                         };
-                        let ext = M::get_ext_mode(call_conv, extension);
+                        let ext = M::get_ext_mode(call_conv, extension, arg_loc);
                         let (vreg, ty) = if ext != ir::ArgumentExtension::None
                             && ty_bits(ty) < word_bits
                         {
@@ -2000,11 +2027,15 @@ impl<M: ABIMachineSpec> Callee<M> {
                         // and we ignore high bits in our own registers by convention.  However,
                         // we still need to use the proper extended type to access stack slots
                         // (this is critical on big-endian systems).
-                        let (ty, extension) = match *slot {
-                            ABIArgSlot::Reg { ty, extension, .. } => (ty, extension),
-                            ABIArgSlot::Stack { ty, extension, .. } => (ty, extension),
+                        let (ty, extension, arg_loc) = match *slot {
+                            ABIArgSlot::Reg { ty, extension, .. } => {
+                                (ty, extension, ABIArgLocation::Reg)
+                            }
+                            ABIArgSlot::Stack { ty, extension, .. } => {
+                                (ty, extension, ABIArgLocation::Stack)
+                            }
                         };
-                        let ext = M::get_ext_mode(callee_conv, extension);
+                        let ext = M::get_ext_mode(callee_conv, extension, arg_loc);
                         let ty = if ext != ir::ArgumentExtension::None && ty_bits(ty) < word_bits {
                             word_ty
                         } else {

--- a/cranelift/filetests/filetests/isa/aarch64/apple-aarch64-sext-stack-arg.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/apple-aarch64-sext-stack-arg.clif
@@ -1,0 +1,75 @@
+test compile precise-output
+set unwind_info=false
+target aarch64
+
+; Callee: 9th i16 sext arg is passed on the stack on apple_aarch64.
+; It must be loaded with a narrow ldrh, not a word-width ldr.
+function %callee(i16 sext, i16 sext, i16 sext, i16 sext, i16 sext, i16 sext, i16 sext, i16 sext, i16 sext) -> i16 apple_aarch64 {
+block0(v0: i16, v1: i16, v2: i16, v3: i16, v4: i16, v5: i16, v6: i16, v7: i16, v8: i16):
+    return v8
+}
+
+; VCode:
+;   stp fp, lr, [sp, #-16]!
+;   mov fp, sp
+; block0:
+;   ldrh w0, [sp, #16]
+;   ldp fp, lr, [sp], #16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+; block1: ; offset 0x8
+;   ldurh w0, [sp, #0x10]
+;   ldp x29, x30, [sp], #0x10
+;   ret
+
+function %caller(i16 sext, i16 sext, i16 sext, i16 sext, i16 sext, i16 sext, i16 sext, i16 sext, i16 sext) -> i16 apple_aarch64 {
+    fn0 = colocated %callee(i16 sext, i16 sext, i16 sext, i16 sext, i16 sext, i16 sext, i16 sext, i16 sext, i16 sext) -> i16 apple_aarch64
+block0(v0: i16, v1: i16, v2: i16, v3: i16, v4: i16, v5: i16, v6: i16, v7: i16, v8: i16):
+    v9 = call fn0(v0, v1, v2, v3, v4, v5, v6, v7, v8)
+    return v9
+}
+
+; VCode:
+;   stp fp, lr, [sp, #-16]!
+;   mov fp, sp
+;   sub sp, sp, #16
+; block0:
+;   ldrh w9, [sp, #32]
+;   sxth x0, w0
+;   sxth x1, w1
+;   sxth x2, w2
+;   sxth x3, w3
+;   sxth x4, w4
+;   sxth x5, w5
+;   sxth x6, w6
+;   sxth x7, w7
+;   strh w9, [sp]
+;   bl 0
+;   add sp, sp, #16
+;   ldp fp, lr, [sp], #16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   sub sp, sp, #0x10
+; block1: ; offset 0xc
+;   ldurh w9, [sp, #0x20]
+;   sxth x0, w0
+;   sxth x1, w1
+;   sxth x2, w2
+;   sxth x3, w3
+;   sxth x4, w4
+;   sxth x5, w5
+;   sxth x6, w6
+;   sxth x7, w7
+;   sturh w9, [sp]
+;   bl #0x34 ; reloc_external Call %callee 0
+;   add sp, sp, #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret

--- a/cranelift/filetests/filetests/isa/aarch64/stack-return-abi.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/stack-return-abi.clif
@@ -31,8 +31,7 @@ block0(v0: i8, v1: i8, v2: i8, v3: i8, v4: i128, v5: i128, v6: i128, v7: f32, v8
 ;   strb w0, [x8, #38]
 ;   strb w0, [x8, #39]
 ;   strb w0, [x8, #40]
-;   uxtb w1, w0
-;   str x0, [x8, #48]
+;   strb w0, [x8, #48]
 ;   mov x6, x4
 ;   mov x7, x5
 ;   mov x0, x6
@@ -60,8 +59,7 @@ block0(v0: i8, v1: i8, v2: i8, v3: i8, v4: i128, v5: i128, v6: i128, v7: f32, v8
 ;   sturb w0, [x8, #0x26]
 ;   sturb w0, [x8, #0x27]
 ;   sturb w0, [x8, #0x28]
-;   uxtb w1, w0
-;   stur x0, [x8, #0x30]
+;   sturb w0, [x8, #0x30]
 ;   mov x6, x4
 ;   mov x7, x5
 ;   mov x0, x6


### PR DESCRIPTION
Fixes #13973

For `apple_aarch64`, `get_ext_mode` returns specified extensions (`sext`/`uext`), which causes caller/callee to load and store full 64-bit words for stack arguments. The slot size condition previously allowed sub-word sizes for spilled arguments whenever `args_or_rets == Args`, causing 8-byte stores to overwrite adjacent stack slots.

This updates the check to only allow sub-word stack slots when `param.extension == None`.