### PR TITLE
aarch64: add missing F16 and F128 rules for scalar_size in ISLE

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst.isle
@@ -1596,7 +1596,6 @@
 (rule (scalar_size $F16) (ScalarSize.Size16))
 (rule (scalar_size $F32) (ScalarSize.Size32))
 (rule (scalar_size $F64) (ScalarSize.Size64))
-(rule (scalar_size $F128) (ScalarSize.Size128))
 
 ;; Helper for calculating the `ScalarSize` lane type from vector type
 (attr lane_size (tag vector))

--- a/cranelift/codegen/src/isa/aarch64/inst.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst.isle
@@ -1593,8 +1593,10 @@
 (rule (scalar_size $I64) (ScalarSize.Size64))
 (rule (scalar_size $I128) (ScalarSize.Size128))
 
+(rule (scalar_size $F16) (ScalarSize.Size16))
 (rule (scalar_size $F32) (ScalarSize.Size32))
 (rule (scalar_size $F64) (ScalarSize.Size64))
+(rule (scalar_size $F128) (ScalarSize.Size128))
 
 ;; Helper for calculating the `ScalarSize` lane type from vector type
 (attr lane_size (tag vector))

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -764,8 +764,10 @@
 (model I32 (const (struct (bits 32))))
 (model I64 (const (struct (bits 64))))
 (model I128 (const (struct (bits 128))))
+(model F16 (const (struct (bits 16))))
 (model F32 (const (struct (bits 32))))
 (model F64 (const (struct (bits 64))))
+(model F128 (const (struct (bits 128))))
 (model I8X16 (const (struct (bits 128))))
 
 (spec (i64_neg x) (provide (= result (bvneg x))))

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -767,7 +767,6 @@
 (model F16 (const (struct (bits 16))))
 (model F32 (const (struct (bits 32))))
 (model F64 (const (struct (bits 64))))
-(model F128 (const (struct (bits 128))))
 (model I8X16 (const (struct (bits 128))))
 
 (spec (i64_neg x) (provide (= result (bvneg x))))

--- a/cranelift/filetests/filetests/isa/aarch64/fma-f16.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/fma-f16.clif
@@ -1,4 +1,5 @@
-test compile
+test compile precise-output
+set unwind_info=false
 target aarch64
 
 function %f0(f16, f16, f16) -> f16 {
@@ -6,3 +7,13 @@ block0(v0: f16, v1: f16, v2: f16):
     v3 = fma v0, v1, v2
     return v3
 }
+
+; VCode:
+; block0:
+;   fmadd h0, h0, h1, h2
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   fmadd h0, h0, h1, h2
+;   ret

--- a/cranelift/filetests/filetests/isa/aarch64/fma-f16.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/fma-f16.clif
@@ -1,0 +1,8 @@
+test compile
+target aarch64
+
+function %f0(f16, f16, f16) -> f16 {
+block0(v0: f16, v1: f16, v2: f16):
+    v3 = fma v0, v1, v2
+    return v3
+}


### PR DESCRIPTION
Add missing `F16` and `F128` rules to `scalar_size` in `inst.isle`, as well as their corresponding models in `prelude.isle`.

Without these, rules that pass `f16` or `f128` types to `scalar_size` (like `fma.f16`) trigger an ISLE panic because `scalar_size` is a total term.