### PR TITLE
ISLE: veri: full run, lower timeout.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1431,10 +1431,10 @@ jobs:
       env:
         # Per-SMT-query timeout, in seconds (see the `--timeout` option in
         # cranelift/isle/veri/veri/src/bin/veri.rs).
-        ISLE_VERI_TIMEOUT: "120"
+        ISLE_VERI_TIMEOUT: "90"
       run: |
         mkdir -p cranelift/isle/veri/cache
-        ./cranelift/isle/veri/verify.sh rebuild-cache aarch64-fast opt-fast x64-iadd-base-case
+        ./cranelift/isle/veri/verify.sh rebuild-cache aarch64 opt x64-iadd-base-case
     - name: Package rebuilt cache
       run: tar czf isle-veri-cache.tar.gz -C cranelift/isle/veri cache
     - name: Upload cache tarball as run artifact

--- a/cranelift/isle/veri/veri/src/bin/veri.rs
+++ b/cranelift/isle/veri/veri/src/bin/veri.rs
@@ -73,7 +73,7 @@ struct Opts {
     ignore_solver_tags: bool,
 
     /// Per-query timeout, in seconds.
-    #[arg(long, default_value = "300", env = "ISLE_VERI_TIMEOUT")]
+    #[arg(long, default_value = "90", env = "ISLE_VERI_TIMEOUT")]
     timeout: u64,
 
     /// Number of threads to use (0 defaults to # of logical cores)

--- a/cranelift/isle/veri/verify.sh
+++ b/cranelift/isle/veri/verify.sh
@@ -43,6 +43,7 @@ CACHE_DIR="cranelift/isle/veri/cache"
 # The default set of configurations to verify.
 CONFIGS=(
     cranelift/isle/veri/configs/aarch64.args
+    cranelift/isle/veri/configs/opt.args
     cranelift/isle/veri/configs/x64-iadd-base-case.args
 )
 # CI passes its own list (see the isle_veri_full_check job in


### PR DESCRIPTION
Per discussion in #14207, switch the CI verifier to run the full configuration but with a lower timeout (expecting some `unknown`s). See how long this takes with a partially-warm cache.