### PR TITLE
Trim the size of the `wast` test suite

### DIFF
--- a/tests/wast.rs
+++ b/tests/wast.rs
@@ -23,41 +23,8 @@ fn main() {
         .ok()
         .map(|s| s.split(" ").map(|s| s.to_string()).collect::<Vec<_>>());
 
-    let mut add_trial = |test: &WastTest, config: WastConfig| {
-        let name = format!(
-            "{:?}/{}{}{}",
-            config.compiler,
-            if config.pooling { "pooling/" } else { "" },
-            if config.collector != Collector::Auto {
-                format!("{:?}/", config.collector)
-            } else {
-                String::new()
-            },
-            test.path.to_str().unwrap()
-        );
-
-        // Don't add this trial if we are only running GC-related tests and it
-        // doesn't look like a GC-related test.
-        if let Some(ks) = &gc_keywords {
-            if config.collector == Collector::Auto && !ks.iter().any(|kw| name.contains(kw)) {
-                return;
-            }
-        }
-
-        let trial = Trial::test(name, {
-            let test = test.clone();
-            move || run_wast(&test, config).map_err(|e| format!("{e:?}").into())
-        });
-
-        trials.push(trial);
-    };
-
     // List of supported compilers, filtered by what our current host supports.
-    let mut compilers = vec![
-        Compiler::CraneliftNative,
-        Compiler::Winch,
-        Compiler::CraneliftPulley,
-    ];
+    let mut compilers = vec![Compiler::CraneliftNative, Compiler::Winch];
     compilers.retain(|c| c.supports_host());
 
     // Only test one compiler in ASAN since we're mostly interested in testing
@@ -74,62 +41,31 @@ fn main() {
         {
             continue;
         }
-        let collector = if test.test_uses_gc_types() {
-            Collector::DeferredReferenceCounting
-        } else {
-            Collector::Auto
-        };
 
-        // Run this test in all supported compilers.
-        for compiler in compilers.iter().copied() {
-            add_trial(
-                &test,
-                WastConfig {
-                    compiler,
-                    pooling: false,
-                    collector,
-                },
-            );
+        let name = test.path.to_str().unwrap();
+
+        // Don't add this trial if we are only running GC-related tests and it
+        // doesn't look like a GC-related test.
+        if let Some(ks) = &gc_keywords {
+            if !ks.iter().any(|kw| name.contains(kw)) {
+                return;
+            }
         }
 
-        // Don't do extra tests in ASAN as it takes awhile and is unlikely to
-        // reap much benefit.
-        if cfg!(asan) {
-            continue;
-        }
+        for compiler in compilers.iter() {
+            let config = WastConfig {
+                compiler: *compiler,
+                pooling: false,
+                collector: Collector::Auto,
+            };
+            let name = format!("{compiler:?}/{name}");
 
-        let compiler = compilers[0];
+            let trial = Trial::test(name.to_string(), {
+                let test = test.clone();
+                move || run_wast(&test, config).map_err(|e| format!("{e:?}").into())
+            });
 
-        // Run this test with the pooling allocator under the default compiler.
-        add_trial(
-            &test,
-            WastConfig {
-                compiler,
-                pooling: true,
-                collector,
-            },
-        );
-
-        // If applicable, also run with the null collector in addition to the
-        // default collector.
-        if test.test_uses_gc_types() {
-            add_trial(
-                &test,
-                WastConfig {
-                    compiler,
-                    pooling: false,
-                    collector: Collector::Null,
-                },
-            );
-
-            add_trial(
-                &test,
-                WastConfig {
-                    compiler,
-                    pooling: false,
-                    collector: Collector::Copying,
-                },
-            );
+            trials.push(trial);
         }
     }
 


### PR DESCRIPTION
Right now we defer the full combinatorial set of configuration options to fuzzing when running `*.wast` tests, but CI and locally we run at least some combination of options. I've found that this generally just inflates the execution time and size of the `*.wast` test suite without a whole lot of benefit, and there's additionally no increased coverage because everything is tested via fuzzing anyway.

This commit instead scales back `tests/wast.rs` to run each test fewer times. Configurations like the pooling allocator and separate GC implementations haven't surfaced issues in quite some time, and despite removing them here they'll still be executed in fuzzing. The goal of this change is to reduce CI load, reduce local testing load, and improve debugging failing tests (as instead of 4+ tests failing for the same reason it's less now).

This preserves testing with Winch in CI as that's surfaced a number of issues historically which seem best to handle immediately as opposed to deferring to fixing issues until after the fuzzers find them.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please review the Bytecode Alliance's AI tool usage policy at
https://github.com/bytecodealliance/governance/blob/main/AI_TOOL_POLICY.md

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
