### PR TITLE
Reduce recursion limits necessary to prove types `Send`

### DIFF
--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -46,6 +46,24 @@ pub struct Engine {
     inner: Arc<EngineInner>,
 }
 
+// These impls are strictly not necessary but they're currently serving the
+// purpose of the reducing the recursion limit necessary to prove
+// types/futures/etc are `Send` in Wasmtime. This is related to
+// rust-lang/rust#159228.
+//
+// SAFETY: we're re-stating what rustc itself is already going to infer. The
+// `_assert_send_sync` function beneath this is intended to serve as a
+// double-assertion that this actually holds.
+unsafe impl Send for Engine {}
+unsafe impl Sync for Engine {}
+
+fn _assert_send_sync(e: &Engine) {
+    fn _assert<T: Send + Sync>(_: &T) {}
+    let Engine { inner } = e;
+    _assert(e);
+    _assert(inner);
+}
+
 struct EngineInner {
     config: Config,
     features: WasmFeatures,

--- a/crates/wasmtime/src/runtime/component/component.rs
+++ b/crates/wasmtime/src/runtime/component/component.rs
@@ -61,6 +61,19 @@ pub struct Component {
     inner: Arc<ComponentInner>,
 }
 
+// SAFETY: restating what rustc already infers to reduce work on rustc.
+//
+// See comments on the similar impls for `Engine` for more details.
+unsafe impl Send for Component {}
+unsafe impl Sync for Component {}
+
+fn _assert_send_sync(e: &Component) {
+    fn _assert<T: Send + Sync>(_: &T) {}
+    let Component { inner } = e;
+    _assert(e);
+    _assert(inner);
+}
+
 struct ComponentInner {
     /// Unique id for this component within this process.
     ///

--- a/crates/wasmtime/src/runtime/module.rs
+++ b/crates/wasmtime/src/runtime/module.rs
@@ -129,6 +129,19 @@ pub struct Module {
     inner: Arc<ModuleInner>,
 }
 
+// SAFETY: restating what rustc already infers to reduce work on rustc.
+//
+// See comments on the similar impls for `Engine` for more details.
+unsafe impl Send for Module {}
+unsafe impl Sync for Module {}
+
+fn _assert_send_sync(e: &Module) {
+    fn _assert<T: Send + Sync>(_: &T) {}
+    let Module { inner } = e;
+    _assert(e);
+    _assert(inner);
+}
+
 struct ModuleInner {
     engine: Engine,
     /// The compiled artifacts for this module that will be instantiated and
@@ -1239,11 +1252,6 @@ pub struct ModuleExport {
     pub(crate) module: CompiledModuleId,
     /// A raw index into the wasm module.
     pub(crate) entity: EntityIndex,
-}
-
-fn _assert_send_sync() {
-    fn _assert<T: Send + Sync>() {}
-    _assert::<Module>();
 }
 
 /// Helper method to construct a `ModuleMemoryImages` for an associated

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -720,11 +720,7 @@ impl ServeCommand {
             // concurrent requests can't be served. Otherwise though spawn a
             // task to handle this client.
             match &mut debuggee_store {
-                Some(store) => {
-                    // Boxed to avoid triggering rustc's recursion limit.
-                    let client = handle_client(stream, &handler, Some(store));
-                    client.await;
-                }
+                Some(store) => handle_client(stream, &handler, Some(store)).await,
                 None => {
                     let handler = handler.clone();
                     tokio::task::spawn(async move {
@@ -1101,17 +1097,7 @@ async fn handle_client(
                     None => None,
                 };
                 let debuggee_store = debuggee_store.as_mut().map(|s| &mut ***s);
-                // Boxed trait object to avoid triggering rustc's recursion limit.
-                let handle_request = Box::pin(handle_request(handler, debuggee_store, req))
-                    as Pin<
-                        Box<
-                            dyn Future<
-                                    Output = Result<hyper::Response<wasmtime_wasi_http::WasiBody>>,
-                                > + Send
-                                + '_,
-                        >,
-                    >;
-                match handle_request.await {
+                match handle_request(handler, debuggee_store, req).await {
                     Ok(r) => Ok::<_, Infallible>(r),
                     Err(e) => {
                         eprintln!("error: {e:?}");

--- a/tests/all/component_model/async.rs
+++ b/tests/all/component_model/async.rs
@@ -203,8 +203,7 @@ async fn poll_through_wasm_activation() -> Result<()> {
     let component = Component::new(&engine, component)?;
     let linker = Linker::new(&engine);
 
-    // Boxed trait object to avoid rustc overflow:
-    let invoke_component = Box::pin({
+    let invoke_component = {
         let engine = engine.clone();
         async move {
             let mut store = Store::new(&engine, ());
@@ -215,11 +214,10 @@ async fn poll_through_wasm_activation() -> Result<()> {
             func.call_async(&mut store, (vec![1, 2, 3],)).await?;
             Ok::<_, wasmtime::Error>(())
         }
-    })
-        as Pin<Box<dyn Future<Output = Result<(), wasmtime::Error>> + Send + 'static>>;
+    };
 
     execute_across_threads(async move {
-        let mut store = Store::new(&engine, Some(invoke_component));
+        let mut store = Store::new(&engine, Some(Box::pin(invoke_component)));
         let poll_once = wasmtime::Func::wrap_async(&mut store, |mut cx, _: ()| {
             let invoke_component = cx.data_mut().take().unwrap();
             Box::new(async move {
@@ -236,12 +234,7 @@ async fn poll_through_wasm_activation() -> Result<()> {
             })
         });
         let poll_once = poll_once.typed::<(), i32>(&mut store)?;
-        // Boxed trait object to avoid rustc overflow:
-        while (Box::pin(poll_once.call_async(&mut store, ()))
-            as Pin<Box<dyn Future<Output = Result<i32, wasmtime::Error>> + Send>>)
-            .await?
-            != 1
-        {
+        while poll_once.call_async(&mut store, ()).await? != 1 {
             // loop around to call again
         }
         Ok::<_, wasmtime::Error>(())


### PR DESCRIPTION
I'm not really entirely sure why this works but it seems to work. The genesis of the idea here is LLM-sourced and I'm hopeful that the upstream rust-lang/rust issue might see some continued work to improve the result, but for now this in theory is a relatively small change for us to carry which doesn't require workarounds in embedders/tests/etc.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please review the Bytecode Alliance's AI tool usage policy at
https://github.com/bytecodealliance/governance/blob/main/AI_TOOL_POLICY.md

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
