### PR TITLE
concurrency tweaks to match recent spec changes

### DIFF
--- a/crates/test-programs/src/bin/async_cancel_caller.rs
+++ b/crates/test-programs/src/bin/async_cancel_caller.rs
@@ -284,13 +284,14 @@ unsafe extern "C" fn callback_run(event0: u32, event1: u32, event2: u32) -> u32 
                 assert_eq!(event1, *waitable);
                 assert_eq!(event2, STATUS_RETURNED);
 
+                waitable_join(*waitable, 0);
+
                 if *mode == MODE_TRAP_CANCEL_GUEST_AFTER_RETURN {
                     // This should trap, since `waitable` has already returned:
                     subtask_cancel_async(*waitable);
                     unreachable!()
                 }
 
-                waitable_join(*waitable, 0);
                 subtask_drop(*waitable);
 
                 // Next, call and cancel `yield_with_options::yield_times` with

--- a/crates/wasmtime/src/runtime/component/concurrent.rs
+++ b/crates/wasmtime/src/runtime/component/concurrent.rs
@@ -3914,6 +3914,12 @@ impl Instance {
             GuestThread::from_instance(self.id().get_mut(store), runtime_instance, thread_idx)?;
         let state = store.concurrent_state_mut()?;
         let guest_thread = QualifiedThreadId::qualify(state, thread_id)?;
+
+        if store.current_guest_thread()? == guest_thread {
+            bail!(Trap::CannotResumeThread);
+        }
+
+        let state = store.concurrent_state_mut()?;
         let thread = state.get_mut(guest_thread.thread)?;
         let priority = match how {
             ResumeThread::Promote | ResumeThread::Resume => Priority::Switch,
@@ -4172,9 +4178,7 @@ impl Instance {
 
         log::trace!("subtask_cancel {waitable:?} (handle {task_id}; async {async_})");
 
-        if !async_ {
-            waitable.trap_if_in_waitable_set(concurrent_state)?;
-        }
+        waitable.trap_if_in_waitable_set(concurrent_state)?;
 
         let needs_block;
         if let Waitable::Host(host_task) = waitable {
@@ -4976,6 +4980,22 @@ enum GuestThreadState {
         cancellable: bool,
     },
     Completed,
+}
+
+impl fmt::Debug for GuestThreadState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotStartedImplicit => f.debug_tuple("NotStartedImplicit").finish(),
+            Self::NotStartedExplicit(_) => f.debug_tuple("NotStartedExplicit").finish(),
+            Self::Running => f.debug_tuple("Running").finish(),
+            Self::Suspended(_) => f.debug_tuple("Suspended").finish(),
+            Self::Ready { cancellable, .. } => f
+                .debug_struct("Ready")
+                .field("cancellable", cancellable)
+                .finish(),
+            Self::Completed => f.debug_tuple("Completed").finish(),
+        }
+    }
 }
 
 pub struct GuestThread {


### PR DESCRIPTION
- Per https://github.com/WebAssembly/component-model/pull/715, trap if `subtask.cancel` is called for a subtask that's in a waitable set regardless of whether it's called sync or async.

- Per https://github.com/WebAssembly/component-model/pull/687, trap if a thread tries to promote or resume itself.

Also, add a `Debug` impl for `GuestThreadState` for future debugging convenience.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please review the Bytecode Alliance's AI tool usage policy at
https://github.com/bytecodealliance/governance/blob/main/AI_TOOL_POLICY.md

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
