### PR TITLE
Cranelift: extend all-zero helper

### DIFF
--- a/cranelift/codegen/src/opts.rs
+++ b/cranelift/codegen/src/opts.rs
@@ -206,6 +206,14 @@ impl<'a, 'b, 'c> generated_code::Context for IsleContext<'a, 'b, 'c> {
         self.ctx.func.dfg.constants.insert(data.into())
     }
 
+    fn f16_zero(&mut self) -> Ieee16 {
+        Ieee16::with_bits(0)
+    }
+
+    fn ty_vector(&mut self, ty: Type) -> Option<Type> {
+        ty.is_vector().then_some(ty)
+    }
+
     type inst_data_value_etor_returns = InstDataEtorIter<'a, 'b, 'c>;
 
     fn inst_data_value_etor(&mut self, eclass: Value, returns: &mut InstDataEtorIter<'a, 'b, 'c>) {
@@ -291,6 +299,37 @@ impl<'a, 'b, 'c> generated_code::Context for IsleContext<'a, 'b, 'c> {
         } else {
             None
         }
+    }
+
+    fn all_zero_etor(&mut self, (ty, inst_data): (Type, InstructionData)) -> Option<Type> {
+        let is_all_zero = match inst_data {
+            InstructionData::UnaryImm {
+                opcode: Opcode::Iconst,
+                imm,
+            } => imm.bits() == 0,
+            InstructionData::UnaryIeee16 {
+                opcode: Opcode::F16const,
+                imm,
+            } => imm.bits() == 0,
+            InstructionData::UnaryIeee32 {
+                opcode: Opcode::F32const,
+                imm,
+            } => imm.bits() == 0,
+            InstructionData::UnaryIeee64 {
+                opcode: Opcode::F64const,
+                imm,
+            } => imm.bits() == 0,
+            InstructionData::UnaryConst {
+                opcode: Opcode::F128const | Opcode::Vconst,
+                constant_handle,
+            } => {
+                let constant = self.ctx.func.dfg.constants.get(constant_handle);
+                constant.len() == ty.bytes() as usize && constant.iter().all(|&byte| byte == 0)
+            }
+            _ => false,
+        };
+
+        is_all_zero.then_some(ty)
     }
 
     fn remat(&mut self, value: Value) -> Value {

--- a/cranelift/codegen/src/opts/bitops.isle
+++ b/cranelift/codegen/src/opts/bitops.isle
@@ -1,30 +1,33 @@
 ;; Rewrites for `band`, `bnot`, `bor`, `bxor`
 
+;; Match or create an all-zero bit pattern for all bitwise types.
+(decl all_zero_etor (Type) TypeAndInstructionData)
+(extern extractor all_zero_etor all_zero_etor)
+(decl f16_zero () Ieee16)
+(extern constructor f16_zero f16_zero)
+(decl ty_vector (Type) Type)
+(extern extractor ty_vector ty_vector)
+
+(decl rec all_zero (Type) Value)
+(extractor (all_zero ty) (inst_data_value_tupled (all_zero_etor ty)))
+(rule 0 (all_zero (ty_int ty)) (iconst_u ty 0))
+(rule 1 (all_zero $F16) (f16const $F16 (f16_zero)))
+(rule 2 (all_zero $F32) (f32const $F32 (f32_from_uint 0)))
+(rule 3 (all_zero $F64) (f64const $F64 (f64_from_uint 0)))
+(rule 4 (all_zero $F128) (f128const $F128 (zero_constant $F128)))
+(rule 5 (all_zero (ty_vector ty)) (vconst ty (zero_constant ty)))
+
 ;; x | 0 == x | x == x.
-(rule (simplify (bor ty
-                     x
-                     (iconst_u ty 0)))
-      (subsume x))
-(rule (simplify (bor ty x x))
-      (subsume x))
+(rule bor_x_zero (simplify (bor ty x (all_zero ty))) (subsume x))
+(rule bor_zero_x (simplify (bor ty (all_zero ty) x)) (subsume x))
+(rule (simplify (bor ty x x)) (subsume x))
 
 ;; x ^ 0 == x.
-(rule (simplify (bxor ty
-                     x
-                     (iconst_u ty 0)))
-      (subsume x))
-
-;; Create an all-zero bit pattern for integer, float, and vector types.
-(decl rec all_zero (Type) Value)
-(rule 0 (all_zero (ty_int ty)) (iconst_u ty 0))
-(rule 1 (all_zero $F32) (f32const $F32 (f32_from_uint 0)))
-(rule 2 (all_zero $F64) (f64const $F64 (f64_from_uint 0)))
-(rule 3 (all_zero (ty_vec64 ty)) (vconst ty (zero_constant ty)))
-(rule 4 (all_zero (ty_vec128 ty)) (vconst ty (zero_constant ty)))
+(rule bxor_x_zero (simplify (bxor ty x (all_zero ty))) (subsume x))
+(rule bxor_zero_x (simplify (bxor ty (all_zero ty) x)) (subsume x))
 
 ;; x ^ x == 0.
-(rule (simplify (bxor ty x x))
-      (subsume (all_zero ty)))
+(rule (simplify (bxor ty x x)) (subsume (all_zero ty)))
 
 ;; x ^ not(x) == not(x) ^ x == x | not(x) == not(x) | x == -1.
 ;; This identity also holds for non-integer types, vectors, and wider types.

--- a/cranelift/filetests/filetests/egraph/bitops.clif
+++ b/cranelift/filetests/filetests/egraph/bitops.clif
@@ -186,6 +186,158 @@ block0(v0: f32x2):
 ; check: v2 = vconst.f32x2 const0
 ; check: return v2
 
+function %bor_all_zero_i32(i32) -> i32 {
+block0(v0: i32):
+    v1 = iconst.i32 0
+    v2 = bor v0, v1
+    return v2
+}
+
+; check: return v0
+
+function %bor_all_zero_lhs_f16(f16) -> f16 {
+block0(v0: f16):
+    v1 = f16const 0.0
+    v2 = bor v1, v0
+    return v2
+}
+
+; check: return v0
+
+function %bxor_all_zero_f32(f32) -> f32 {
+block0(v0: f32):
+    v1 = f32const 0.0
+    v2 = bxor v0, v1
+    return v2
+}
+
+; check: return v0
+
+function %bxor_all_zero_f16(f16) -> f16 {
+block0(v0: f16):
+    v1 = f16const 0.0
+    v2 = bxor v0, v1
+    return v2
+}
+
+; check: return v0
+
+function %bxor_all_zero_lhs_f128(f128) -> f128 {
+block0(v0: f128):
+    v1 = f128const 0.0
+    v2 = bxor v1, v0
+    return v2
+}
+
+; check: return v0
+
+function %bxor_negative_zero_f32(f32) -> f32 {
+block0(v0: f32):
+    v1 = f32const -0.0
+    v2 = bxor v0, v1
+    return v2
+}
+
+; check: v1 = f32const -0.0
+; check: v2 = bxor v0, v1
+; check: return v2
+
+function %bxor_negative_zero_f16(f16) -> f16 {
+block0(v0: f16):
+    v1 = f16const -0.0
+    v2 = bxor v0, v1
+    return v2
+}
+
+; check: v1 = f16const -0.0
+; check: v2 = bxor v0, v1
+; check: return v2
+
+function %bxor_negative_zero_f128(f128) -> f128 {
+block0(v0: f128):
+    v1 = f128const -0.0
+    v2 = bxor v0, v1
+    return v2
+}
+
+; check: const0 = 0x80000000000000000000000000000000
+; check: v1 = f128const const0
+; check: v2 = bxor v0, v1
+; check: return v2
+
+function %bxor_all_zero_i32x4(i32x4) -> i32x4 {
+    const0 = 0x00000000000000000000000000000000
+
+block0(v0: i32x4):
+    v1 = vconst.i32x4 const0
+    v2 = bxor v0, v1
+    return v2
+}
+
+; check: return v0
+
+function %bor_all_zero_lhs_i32x4(i32x4) -> i32x4 {
+    const0 = 0x00000000000000000000000000000000
+
+block0(v0: i32x4):
+    v1 = vconst.i32x4 const0
+    v2 = bor v1, v0
+    return v2
+}
+
+; check: return v0
+
+function %bor_all_zero_i32x2(i32x2) -> i32x2 {
+    const0 = 0x0000000000000000
+
+block0(v0: i32x2):
+    v1 = vconst.i32x2 const0
+    v2 = bor v0, v1
+    return v2
+}
+
+; check: return v0
+
+function %bxor_all_zero_lhs_i32x2(i32x2) -> i32x2 {
+    const0 = 0x0000000000000000
+
+block0(v0: i32x2):
+    v1 = vconst.i32x2 const0
+    v2 = bxor v1, v0
+    return v2
+}
+
+; check: return v0
+
+function %bxor_x_x_f16(f16) -> f16 {
+block0(v0: f16):
+    v1 = bxor v0, v0
+    return v1
+}
+
+; check: v2 = f16const 0.0
+; check: return v2
+
+function %bxor_x_x_f128(f128) -> f128 {
+block0(v0: f128):
+    v1 = bxor v0, v0
+    return v1
+}
+
+; check: const0 = 0x00000000000000000000000000000000
+; check: v2 = f128const const0
+; check: return v2
+
+function %bxor_x_x_i32x8(i32x8) -> i32x8 {
+block0(v0: i32x8):
+    v1 = bxor v0, v0
+    return v1
+}
+
+; check: const0 = 0x0000000000000000000000000000000000000000000000000000000000000000
+; check: v2 = vconst.i32x8 const0
+; check: return v2
+
 function %vector_bxor_x_bnot_x(i32x4) -> i32x4 {
 block0(v0: i32x4):
     v1 = bnot v0


### PR DESCRIPTION
Hi, this PR adds an extractor so the `all_zero` helper(#14084) can also be used on the LHS.
Also extends it to support F16, F128, and vector types.