### PR TITLE
wasmtime: add `Component::same`

### DIFF
--- a/crates/wasmtime/src/runtime/component/component.rs
+++ b/crates/wasmtime/src/runtime/component/component.rs
@@ -905,6 +905,22 @@ impl Component {
         &self.inner.engine
     }
 
+    /// Is this `Component` the same as another?
+    ///
+    /// Ordinarily, component identity does not matter: a Wasmtime user
+    /// will create or obtain a component from some source and
+    /// instantiate it, and any two `Component` objects created from the
+    /// same source component are interchangeable. However, introspecting
+    /// component identity may be useful when examining Wasm VM state,
+    /// e.g. via debug APIs. It is guaranteed that `Component::same`
+    /// returns true for `Component` objects that reference the same
+    /// underlying component (e.g., one created via a `clone` of the
+    /// other).
+    #[inline]
+    pub fn same(a: &Component, b: &Component) -> bool {
+        Arc::ptr_eq(&a.inner, &b.inner)
+    }
+
     pub(crate) fn realloc_func_ty(&self) -> &Arc<FuncType> {
         &self.inner.realloc_func_type
     }


### PR DESCRIPTION
Add `Component::same`, just like `Module::same`: https://github.com/bytecodealliance/wasmtime/blob/27d68db258/crates/wasmtime/src/runtime/module.rs#L1188-L1202