### PR TITLE
Fix writing the json configuration file in fuzzing

### DIFF
--- a/crates/fuzzing/src/generators/module.rs
+++ b/crates/fuzzing/src/generators/module.rs
@@ -126,17 +126,17 @@ impl ModuleConfig {
             config.limit_arrays_in_const_exprs = true;
         }
 
-        let mut module = wasm_smith::Module::new(config, input)?;
+        let mut module = wasm_smith::Module::new(config.clone(), input)?;
 
         if let Some(before) = input_before {
             static GEN_CNT: AtomicUsize = AtomicUsize::new(0);
             let used = before.len() - input.len();
             let i = GEN_CNT.fetch_add(1, Relaxed);
             let dna = format!("testcase{i}.dna");
-            let config = format!("testcase{i}.json");
-            log::debug!("writing `{dna}` and `{config}`");
+            let config_file = format!("testcase{i}.json");
+            log::debug!("writing `{dna}` and `{config_file}`");
             std::fs::write(&dna, &before[..used]).unwrap();
-            std::fs::write(&config, serde_json::to_string_pretty(&config).unwrap()).unwrap();
+            std::fs::write(&config_file, serde_json::to_string_pretty(&config).unwrap()).unwrap();
         }
 
         if let Some(default_fuel) = default_fuel {


### PR DESCRIPTION
A mistake in the code meant that just a bland string was written out instead of the actual configuration.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please review the Bytecode Alliance's AI tool usage policy at
https://github.com/bytecodealliance/governance/blob/main/AI_TOOL_POLICY.md

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
