### PR TITLE
Document component model proposal statuses

### DIFF
--- a/docs/stability-wasm-proposals.md
+++ b/docs/stability-wasm-proposals.md
@@ -111,12 +111,52 @@ The emoji legend is:
 [`custom-page-sizes`]: https://github.com/WebAssembly/custom-page-sizes
 [`compact-import-section`]: https://github.com/WebAssembly/compact-import-section
 
+## Component-model Proposals
+
+Changes to the component model aren't currently of the same shape as changes to
+core WebAssembly itself. There are not proposal repositories at this time but
+instead the main specification has "emoji gates" where parts of the
+specification are considered gated when the descriptive text or binary form is
+annotated with a specific emoji. This is the status of the emojis and
+implementations within Wasmtime.
+
+**On-by-default proposals**
+
+|  Proposal                 | Emoji | Phase 4 | Tests | Finished | Fuzzed | API | C API  |
+|---------------------------|-------|---------|-------|----------|--------|-----|--------|
+| async                     | 🔀    | ✅      | ✅    | ✅       | ✅     | ✅  | 🚧[^c1]|
+
+**Off-by-default proposals**
+
+|  Proposal                 | Emoji | Phase 4 | Tests | Finished | Fuzzed | API | C API  |
+|---------------------------|-------|---------|-------|----------|--------|-----|--------|
+| map                       | 🗺️     | ✅      | ✅    | ✅       | ✅     | ✅  | ✅     |
+| implements                | 🏷️     | ✅      | ✅    | ✅       | ❌     | ✅  | ❌     |
+| more async options [^c2]  | 🚝    | ❌      | ✅    | ❌       | ❌     | ✅  | ✅     |
+| stackful async [^c2]      | 🚟    | ❌      | ✅    | ❌       | ❌     | ✅  | ✅     |
+| threading                 | 🧵    | ❌      | ✅    | ❌       | ❌     | ✅  | ❌     |
+| fixed-length-lists        | 🔧    | ❌      | ✅    | 🚧       | ❌     | ✅  | ❌     |
+| memory64                  | 🐘    | ❌      | 🚧    | 🚧       | ❌     | 🚧  | ❌     |
+| error-context [^c2]       | 📝    | ❌      | ❌    | ❌       | ❌     | 🚧  | ❌     |
+| values                    | 🪙    | ❌      | ❌    | ❌       | ❌     | ❌  | ❌     |
+| nested names              | 🪺    | ❌      | ❌    | ❌       | ❌     | ❌  | ❌     |
+| canonical names           | 🔗    | ❌      | ❌    | ❌       | ❌     | ❌  | ❌     |
+| shared-everything-threads | 🧵②   | ❌      | ❌    | ❌       | ❌     | ❌  | ❌     |
+
+[^c1]: Tracked in [#13705](https://github.com/bytecodealliance/wasmtime/issues/13705)
+[^c2]: These features were sliced out of the original async proposal for the
+    component model but the implementation remains in Wasmtime.
+
+
+
 ## Feature requirements
 
 For each column in the above tables, this is a further explanation of its meaning:
 
 * **Phase 4** - The proposal must be in phase 4, or greater, of [the
-  WebAssembly standardization process][phases].
+  WebAssembly standardization process][phases]. For component model proposals
+  this means that the WASI subgroup has voted to include this feature in a
+  release of WASI
 
 * **Tests** - All spec tests must be passing in Wasmtime and where appropriate
   Wasmtime-specific tests, for example for the API, should be passing. Tests

--- a/docs/stability-wasm-proposals.md
+++ b/docs/stability-wasm-proposals.md
@@ -111,7 +111,7 @@ The emoji legend is:
 [`custom-page-sizes`]: https://github.com/WebAssembly/custom-page-sizes
 [`compact-import-section`]: https://github.com/WebAssembly/compact-import-section
 
-## Component-model Proposals
+## Component-Model Proposals
 
 Changes to the component model aren't currently of the same shape as changes to
 core WebAssembly itself. There are not proposal repositories at this time but
@@ -131,7 +131,7 @@ implementations within Wasmtime.
 |  Proposal                 | Emoji | Phase 4 | Tests | Finished | Fuzzed | API | C API  |
 |---------------------------|-------|---------|-------|----------|--------|-----|--------|
 | map                       | 🗺️     | ✅      | ✅    | ✅       | ✅     | ✅  | ✅     |
-| implements                | 🏷️     | ✅      | ✅    | ✅       | ❌     | ✅  | ❌     |
+| implements                | 🏷️     | ✅      | ✅    | ✅       | ❌     | ✅  | ✅     |
 | more async options [^c2]  | 🚝    | ❌      | ✅    | ❌       | ❌     | ✅  | ✅     |
 | stackful async [^c2]      | 🚟    | ❌      | ✅    | ❌       | ❌     | ✅  | ✅     |
 | threading                 | 🧵    | ❌      | ✅    | ❌       | ❌     | ✅  | ❌     |


### PR DESCRIPTION
Currently we don't actually have any documentation for the status of various changes to the component model and how they're implemented in Wasmtime. WASI 0.3.1 requires that the map and implements features are active, and we didn't previously have a place to look at to see the status of the implementation of these features. I've attempted to write things down here and fill in the boxes for the various proposals/changes in-flight.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please review the Bytecode Alliance's AI tool usage policy at
https://github.com/bytecodealliance/governance/blob/main/AI_TOOL_POLICY.md

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
