### PR TITLE
Thread component-model-implements into the C API

### DIFF
--- a/crates/c-api/include/wasmtime/component/types/component.h
+++ b/crates/c-api/include/wasmtime/component/types/component.h
@@ -40,23 +40,23 @@ size_t wasmtime_component_type_import_count(const wasmtime_component_type_t *ty,
 
 /// \brief Retrieves the import with the specified name.
 ///
-/// The returned `wasmtime_component_item_t` must be deallocated with
-/// `wasmtime_component_item_delete`.
+/// The returned `wasmtime_component_extern_t` must be deallocated with
+/// `wasmtime_component_extern_delete`.
 WASM_API_EXTERN
-bool wasmtime_component_type_import_get(const wasmtime_component_type_t *ty,
-                                        const wasm_engine_t *engine,
-                                        const char *name, size_t name_len,
-                                        struct wasmtime_component_item_t *ret);
+bool wasmtime_component_type_import_get(
+    const wasmtime_component_type_t *ty, const wasm_engine_t *engine,
+    const char *name, size_t name_len,
+    struct wasmtime_component_extern_t **ret);
 
 /// \brief Retrieves the nth import.
 ///
-/// The returned `wasmtime_component_item_t` must be deallocated with
-/// `wasmtime_component_item_delete`.
+/// The returned `wasmtime_component_extern_t` must be deallocated with
+/// `wasmtime_component_extern_delete`.
 WASM_API_EXTERN
 bool wasmtime_component_type_import_nth(
     const wasmtime_component_type_t *ty, const wasm_engine_t *engine,
     size_t nth, const char **name_ret, size_t *name_len_ret,
-    struct wasmtime_component_item_t *type_ret);
+    struct wasmtime_component_extern_t **ret);
 
 /// \brief Returns the number of exports of a component type.
 WASM_API_EXTERN
@@ -65,23 +65,23 @@ size_t wasmtime_component_type_export_count(const wasmtime_component_type_t *ty,
 
 /// \brief Retrieves the export with the specified name.
 ///
-/// The returned `wasmtime_component_item_t` must be deallocated with
-/// `wasmtime_component_item_delete`.
+/// The returned `wasmtime_component_extern_t` must be deallocated with
+/// `wasmtime_component_extern_delete`.
 WASM_API_EXTERN
-bool wasmtime_component_type_export_get(const wasmtime_component_type_t *ty,
-                                        const wasm_engine_t *engine,
-                                        const char *name, size_t name_len,
-                                        struct wasmtime_component_item_t *ret);
+bool wasmtime_component_type_export_get(
+    const wasmtime_component_type_t *ty, const wasm_engine_t *engine,
+    const char *name, size_t name_len,
+    struct wasmtime_component_extern_t **ret);
 
 /// \brief Retrieves the nth export.
 ///
-/// The returned `wasmtime_component_item_t` must be deallocated with
-/// `wasmtime_component_item_delete`.
+/// The returned `wasmtime_component_extern_t` must be deallocated with
+/// `wasmtime_component_extern_delete`.
 WASM_API_EXTERN
 bool wasmtime_component_type_export_nth(
     const wasmtime_component_type_t *ty, const wasm_engine_t *engine,
     size_t nth, const char **name_ret, size_t *name_len_ret,
-    struct wasmtime_component_item_t *type_ret);
+    struct wasmtime_component_extern_t **ret);
 
 /// \brief Value of #wasmtime_component_item_kind_t meaning that
 /// #wasmtime_component_item_t is a component.
@@ -152,6 +152,71 @@ void wasmtime_component_item_clone(const wasmtime_component_item_t *item,
 /// \brief Deallocates a component item.
 WASM_API_EXTERN
 void wasmtime_component_item_delete(wasmtime_component_item_t *ptr);
+
+/// \brief Full description of a single component or component instance export
+/// or import.
+///
+/// This carries the type of the item being imported or exported along with
+/// any metadata attached to it such as `(implements "...")` or
+/// `(external-id "...")` annotations.
+///
+/// Note that this structure contains pointers to the original component or
+/// instance type that it's acquired from. This must always be
+/// destroyed/accessed before those original types are destroyed.
+typedef struct wasmtime_component_extern_t wasmtime_component_extern_t;
+
+/// \brief Clones a component extern.
+///
+/// The returned pointer must be deallocated with
+/// `wasmtime_component_extern_delete`.
+///
+/// Note that this does not clone the internal pointers that the
+/// `wasmtime_component_extern_t` struct refers to, so the returned structure
+/// still cannot outlive the original source that this comes from.
+WASM_API_EXTERN
+wasmtime_component_extern_t *
+wasmtime_component_extern_clone(const wasmtime_component_extern_t *e);
+
+/// \brief Returns the type of the item that this import/export refers to.
+///
+/// The returned `wasmtime_component_item_t` must be deallocated with
+/// `wasmtime_component_item_delete`.
+WASM_API_EXTERN
+void wasmtime_component_extern_type(const wasmtime_component_extern_t *e,
+                                    wasmtime_component_item_t *ret);
+
+/// \brief Returns the `implements` attribute of this import/export.
+///
+/// Returns `NULL` if this isn't present. Writes the length of the return value
+/// to `len`. The returned pointer cannot be used outside the lifetime of `e`.
+WASM_API_EXTERN
+const char *
+wasmtime_component_extern_implements(const wasmtime_component_extern_t *e,
+                                     size_t *len);
+
+/// \brief Returns whether this import/export `e` has an `implements` attribute
+/// which matches the `name` provided (which is `len` bytes long).
+///
+/// This returns `false` if `e` has no `implements` attribute. Otherwise this
+/// returns `true` if the attribute is exactly equal to `name` or if it's a
+/// semver-compatible version of `name`. For example `(implements
+/// "a:b/c@1.1.0")` matches both `a:b/c@1.0.0` and `a:b/c@1.2.0`.
+WASM_API_EXTERN
+bool wasmtime_component_extern_is_implements(
+    const wasmtime_component_extern_t *e, const char *name, size_t len);
+
+/// \brief Returns the `external-id` attribute of this import/export.
+///
+/// Returns `NULL` if this isn't present. Writes the length of the return value
+/// to `len`. The returned pointer cannot be used outside the lifetime of `e`.
+WASM_API_EXTERN
+const char *
+wasmtime_component_extern_external_id(const wasmtime_component_extern_t *e,
+                                      size_t *len);
+
+/// \brief Deallocates a component extern.
+WASM_API_EXTERN
+void wasmtime_component_extern_delete(wasmtime_component_extern_t *ptr);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/crates/c-api/include/wasmtime/component/types/component.hh
+++ b/crates/c-api/include/wasmtime/component/types/component.hh
@@ -22,6 +22,7 @@ namespace wasmtime {
 namespace component {
 
 class ComponentItem;
+class ComponentExtern;
 
 /**
  * \brief Represents the type of a WebAssembly component.
@@ -35,11 +36,17 @@ class ComponentType {
   }
 
   /// Retrieves the import with the specified name.
-  std::optional<ComponentItem> import_get(const Engine &engine,
-                                          std::string_view name) const;
+  ///
+  /// The returned `ComponentExtern` borrows from this type and the engine and
+  /// must not outlive either of them.
+  std::optional<ComponentExtern> import_get(const Engine &engine,
+                                            std::string_view name) const;
 
   /// Retrieves the nth import.
-  std::optional<std::pair<std::string_view, ComponentItem>>
+  ///
+  /// The returned `ComponentExtern` borrows from this type and the engine and
+  /// must not outlive either of them.
+  std::optional<std::pair<std::string_view, ComponentExtern>>
   import_nth(const Engine &engine, size_t nth) const;
 
   /// Returns the number of exports of this component type.
@@ -48,11 +55,17 @@ class ComponentType {
   }
 
   /// Retrieves the export with the specified name.
-  std::optional<ComponentItem> export_get(const Engine &engine,
-                                          std::string_view name) const;
+  ///
+  /// The returned `ComponentExtern` borrows from this type and the engine and
+  /// must not outlive either of them.
+  std::optional<ComponentExtern> export_get(const Engine &engine,
+                                            std::string_view name) const;
 
   /// Retrieves the nth export.
-  std::optional<std::pair<std::string_view, ComponentItem>>
+  ///
+  /// The returned `ComponentExtern` borrows from this type and the engine and
+  /// must not outlive either of them.
+  std::optional<std::pair<std::string_view, ComponentExtern>>
   export_nth(const Engine &engine, size_t nth) const;
 };
 
@@ -170,6 +183,59 @@ public:
   const ValType &type() const;
 };
 
+/**
+ * \brief Full description of a single import or export of a component or a
+ * component instance.
+ *
+ * This carries the type of the item being imported or exported along with any
+ * `(implements "...")` or `(external-id "...")` annotations attached to it.
+ *
+ * Note that this borrows string data from the `ComponentType` or
+ * `ComponentInstanceType` it was acquired from (and the `Engine` used to
+ * acquire it), so it must not outlive either of those. Copies of this class
+ * share the same borrow and are subject to the same restriction.
+ */
+class ComponentExtern {
+  WASMTIME_CLONE_WRAPPER(ComponentExtern, wasmtime_component_extern);
+
+  /// Returns the type of the item that this import/export refers to.
+  ComponentItem type() const;
+
+  /// Returns the `(implements "...")` annotation of this import/export, if
+  /// present.
+  std::optional<std::string_view> implements() const {
+    size_t len = 0;
+    const char *ptr = wasmtime_component_extern_implements(capi(), &len);
+    if (ptr == nullptr) {
+      return std::nullopt;
+    }
+    return std::string_view(ptr, len);
+  }
+
+  /// Returns whether this import/export has an `(implements "...")`
+  /// annotation which is compatible with `name`.
+  ///
+  /// This returns `false` if there is no `implements` annotation. Otherwise
+  /// this returns `true` if the annotation is exactly `name` or a
+  /// semver-compatible version of it, for example `a:b/c@1.1.0` matches
+  /// `a:b/c@1.0.0` and `a:b/c@1.2.0`.
+  bool is_implements(std::string_view name) const {
+    return wasmtime_component_extern_is_implements(capi(), name.data(),
+                                                   name.size());
+  }
+
+  /// Returns the `(external-id "...")` annotation of this import/export, if
+  /// present.
+  std::optional<std::string_view> external_id() const {
+    size_t len = 0;
+    const char *ptr = wasmtime_component_extern_external_id(capi(), &len);
+    if (ptr == nullptr) {
+      return std::nullopt;
+    }
+    return std::string_view(ptr, len);
+  }
+};
+
 } // namespace component
 } // namespace wasmtime
 
@@ -178,60 +244,67 @@ public:
 #include <wasmtime/component/types/module.hh>
 #include <wasmtime/component/types/val.hh>
 
-inline std::optional<wasmtime::component::ComponentItem>
+inline wasmtime::component::ComponentItem
+wasmtime::component::ComponentExtern::type() const {
+  wasmtime_component_item_t item;
+  wasmtime_component_extern_type(capi(), &item);
+  return wasmtime::component::ComponentItem(std::move(item));
+}
+
+inline std::optional<wasmtime::component::ComponentExtern>
 wasmtime::component::ComponentType::import_get(const wasmtime::Engine &engine,
                                                std::string_view name) const {
-  wasmtime_component_item_t item;
-  bool found = wasmtime_component_type_import_get(
-      capi(), engine.capi(), name.data(), name.size(), &item);
+  wasmtime_component_extern_t *e;
+  bool found = wasmtime_component_type_import_get(capi(), engine.capi(),
+                                                  name.data(), name.size(), &e);
   if (!found) {
     return std::nullopt;
   }
-  return wasmtime::component::ComponentItem(std::move(item));
+  return wasmtime::component::ComponentExtern(e);
 }
 
 inline std::optional<
-    std::pair<std::string_view, wasmtime::component::ComponentItem>>
+    std::pair<std::string_view, wasmtime::component::ComponentExtern>>
 wasmtime::component::ComponentType::import_nth(const wasmtime::Engine &engine,
                                                size_t nth) const {
-  wasmtime_component_item_t item;
+  wasmtime_component_extern_t *e;
   const char *name_data;
   size_t name_size;
-  bool found = wasmtime_component_type_import_nth(
-      capi(), engine.capi(), nth, &name_data, &name_size, &item);
+  bool found = wasmtime_component_type_import_nth(capi(), engine.capi(), nth,
+                                                  &name_data, &name_size, &e);
   if (!found) {
     return std::nullopt;
   }
   return std::make_pair(std::string_view(name_data, name_size),
-                        wasmtime::component::ComponentItem(std::move(item)));
+                        wasmtime::component::ComponentExtern(e));
 }
 
-inline std::optional<wasmtime::component::ComponentItem>
+inline std::optional<wasmtime::component::ComponentExtern>
 wasmtime::component::ComponentType::export_get(const wasmtime::Engine &engine,
                                                std::string_view name) const {
-  wasmtime_component_item_t item;
-  bool found = wasmtime_component_type_export_get(
-      capi(), engine.capi(), name.data(), name.size(), &item);
+  wasmtime_component_extern_t *e;
+  bool found = wasmtime_component_type_export_get(capi(), engine.capi(),
+                                                  name.data(), name.size(), &e);
   if (!found) {
     return std::nullopt;
   }
-  return wasmtime::component::ComponentItem(std::move(item));
+  return wasmtime::component::ComponentExtern(e);
 }
 
 inline std::optional<
-    std::pair<std::string_view, wasmtime::component::ComponentItem>>
+    std::pair<std::string_view, wasmtime::component::ComponentExtern>>
 wasmtime::component::ComponentType::export_nth(const wasmtime::Engine &engine,
                                                size_t nth) const {
-  wasmtime_component_item_t item;
+  wasmtime_component_extern_t *e;
   const char *name_data;
   size_t name_size;
-  bool found = wasmtime_component_type_export_nth(
-      capi(), engine.capi(), nth, &name_data, &name_size, &item);
+  bool found = wasmtime_component_type_export_nth(capi(), engine.capi(), nth,
+                                                  &name_data, &name_size, &e);
   if (!found) {
     return std::nullopt;
   }
   return std::make_pair(std::string_view(name_data, name_size),
-                        wasmtime::component::ComponentItem(std::move(item)));
+                        wasmtime::component::ComponentExtern(e));
 }
 
 inline const wasmtime::component::ComponentInstanceType &

--- a/crates/c-api/include/wasmtime/component/types/instance.h
+++ b/crates/c-api/include/wasmtime/component/types/instance.h
@@ -13,7 +13,7 @@
 extern "C" {
 #endif
 
-struct wasmtime_component_item_t;
+struct wasmtime_component_extern_t;
 
 /// \brief Represents the type of a component instance.
 typedef struct wasmtime_component_instance_type
@@ -39,22 +39,23 @@ size_t wasmtime_component_instance_type_export_count(
 
 /// \brief Retrieves the export with the specified name.
 ///
-/// The returned `wasmtime_component_item_t` must be deallocated with
-/// `wasmtime_component_item_delete`.
+/// The returned `wasmtime_component_extern_t` must be deallocated with
+/// `wasmtime_component_extern_delete`.
 WASM_API_EXTERN
 bool wasmtime_component_instance_type_export_get(
     const wasmtime_component_instance_type_t *ty, const wasm_engine_t *engine,
-    const char *name, size_t name_len, struct wasmtime_component_item_t *ret);
+    const char *name, size_t name_len,
+    struct wasmtime_component_extern_t **ret);
 
 /// \brief Retrieves the nth export.
 ///
-/// The returned `wasmtime_component_item_t` must be deallocated with
-/// `wasmtime_component_item_delete`.
+/// The returned `wasmtime_component_extern_t` must be deallocated with
+/// `wasmtime_component_extern_delete`.
 WASM_API_EXTERN
 bool wasmtime_component_instance_type_export_nth(
     const wasmtime_component_instance_type_t *ty, const wasm_engine_t *engine,
     size_t nth, const char **name_ret, size_t *name_len_ret,
-    struct wasmtime_component_item_t *type_ret);
+    struct wasmtime_component_extern_t **ret);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/crates/c-api/include/wasmtime/component/types/instance.hh
+++ b/crates/c-api/include/wasmtime/component/types/instance.hh
@@ -19,7 +19,7 @@
 namespace wasmtime {
 namespace component {
 
-class ComponentItem;
+class ComponentExtern;
 
 /**
  * \brief Represents the type of a component instance.
@@ -34,11 +34,17 @@ class ComponentInstanceType {
   }
 
   /// Retrieves the export with the specified name.
-  std::optional<ComponentItem> export_get(const Engine &engine,
-                                          std::string_view name) const;
+  ///
+  /// The returned `ComponentExtern` borrows from this type and the engine and
+  /// must not outlive either of them.
+  std::optional<ComponentExtern> export_get(const Engine &engine,
+                                            std::string_view name) const;
 
   /// Retrieves the nth export.
-  std::optional<std::pair<std::string_view, ComponentItem>>
+  ///
+  /// The returned `ComponentExtern` borrows from this type and the engine and
+  /// must not outlive either of them.
+  std::optional<std::pair<std::string_view, ComponentExtern>>
   export_nth(const Engine &engine, size_t nth) const;
 };
 
@@ -47,32 +53,32 @@ class ComponentInstanceType {
 
 #include <wasmtime/component/types/component.hh>
 
-inline std::optional<wasmtime::component::ComponentItem>
+inline std::optional<wasmtime::component::ComponentExtern>
 wasmtime::component::ComponentInstanceType::export_get(
     const wasmtime::Engine &engine, std::string_view name) const {
-  wasmtime_component_item_t item;
+  wasmtime_component_extern_t *e;
   bool found = wasmtime_component_instance_type_export_get(
-      capi(), engine.capi(), name.data(), name.size(), &item);
+      capi(), engine.capi(), name.data(), name.size(), &e);
   if (!found) {
     return std::nullopt;
   }
-  return wasmtime::component::ComponentItem(std::move(item));
+  return wasmtime::component::ComponentExtern(e);
 }
 
 inline std::optional<
-    std::pair<std::string_view, wasmtime::component::ComponentItem>>
+    std::pair<std::string_view, wasmtime::component::ComponentExtern>>
 wasmtime::component::ComponentInstanceType::export_nth(
     const wasmtime::Engine &engine, size_t nth) const {
-  wasmtime_component_item_t item;
+  wasmtime_component_extern_t *e;
   const char *name_data;
   size_t name_size;
   bool found = wasmtime_component_instance_type_export_nth(
-      capi(), engine.capi(), nth, &name_data, &name_size, &item);
+      capi(), engine.capi(), nth, &name_data, &name_size, &e);
   if (!found) {
     return std::nullopt;
   }
   return std::make_pair(std::string_view(name_data, name_size),
-                        wasmtime::component::ComponentItem(std::move(item)));
+                        wasmtime::component::ComponentExtern(e));
 }
 
 #endif // WASMTIME_FEATURE_COMPONENT_MODEL

--- a/crates/c-api/include/wasmtime/config.h
+++ b/crates/c-api/include/wasmtime/config.h
@@ -907,6 +907,16 @@ WASMTIME_CONFIG_PROP(void, concurrency_support, bool)
  */
 WASMTIME_CONFIG_PROP(void, wasm_component_model_map, bool)
 
+/**
+ * \brief Configures whether the WebAssembly component-model `(implements
+ * "...")` and `(external-id "...")` annotations will be enabled for
+ * compilation.
+ *
+ * For more information see the Rust documentation at
+ * https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#method.wasm_component_model_implements.
+ */
+WASMTIME_CONFIG_PROP(void, wasm_component_model_implements, bool)
+
 #endif // WASMTIME_FEATURE_COMPONENT_MODEL
 
 #ifdef WASMTIME_FEATURE_COMPONENT_MODEL_ASYNC

--- a/crates/c-api/include/wasmtime/config.hh
+++ b/crates/c-api/include/wasmtime/config.hh
@@ -449,6 +449,14 @@ class Config {
   void wasm_component_model_map(bool enable) {
     wasmtime_config_wasm_component_model_map_set(ptr.get(), enable);
   }
+
+  /// \brief Configures whether the WebAssembly component model `(implements
+  /// "...")` and `(external-id "...")` annotations will be enabled
+  ///
+  /// https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#method.wasm_component_model_implements
+  void wasm_component_model_implements(bool enable) {
+    wasmtime_config_wasm_component_model_implements_set(ptr.get(), enable);
+  }
 #endif // WASMTIME_FEATURE_COMPONENT_MODEL
 
 #ifdef WASMTIME_FEATURE_PARALLEL_COMPILATION

--- a/crates/c-api/src/component/component.rs
+++ b/crates/c-api/src/component/component.rs
@@ -19,6 +19,14 @@ pub extern "C" fn wasmtime_config_wasm_component_model_map_set(
 }
 
 #[unsafe(no_mangle)]
+pub extern "C" fn wasmtime_config_wasm_component_model_implements_set(
+    c: &mut wasm_config_t,
+    enable: bool,
+) {
+    c.config.wasm_component_model_implements(enable);
+}
+
+#[unsafe(no_mangle)]
 #[cfg(feature = "component-model-async")]
 pub extern "C" fn wasmtime_config_wasm_component_model_async_set(
     c: &mut wasm_config_t,

--- a/crates/c-api/src/component/types/component.rs
+++ b/crates/c-api/src/component/types/component.rs
@@ -4,7 +4,7 @@ use crate::{
     wasmtime_component_valtype_t, wasmtime_module_type_t,
 };
 use std::mem::{ManuallyDrop, MaybeUninit};
-use wasmtime::component::types::{Component, ComponentItem};
+use wasmtime::component::types::{Component, ComponentExtern, ComponentItem};
 
 type_wrapper! {
     pub struct wasmtime_component_type_t {
@@ -24,20 +24,20 @@ pub extern "C" fn wasmtime_component_type_import_count(
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn wasmtime_component_type_import_get(
-    ty: &wasmtime_component_type_t,
-    engine: &wasm_engine_t,
+pub unsafe extern "C" fn wasmtime_component_type_import_get<'a>(
+    ty: &'a wasmtime_component_type_t,
+    engine: &'a wasm_engine_t,
     name: *const u8,
     name_len: usize,
-    ret: &mut MaybeUninit<wasmtime_component_item_t>,
+    ret: &mut MaybeUninit<Box<wasmtime_component_extern_t<'a>>>,
 ) -> bool {
     let name = unsafe { std::slice::from_raw_parts(name, name_len) };
     let Ok(name) = std::str::from_utf8(name) else {
         return false;
     };
     match ty.ty.get_import(&engine.engine, name) {
-        Some(item) => {
-            ret.write(item.ty.into());
+        Some(e) => {
+            ret.write(Box::new(e.into()));
             true
         }
         None => false,
@@ -45,20 +45,20 @@ pub unsafe extern "C" fn wasmtime_component_type_import_get(
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn wasmtime_component_type_import_nth(
-    ty: &wasmtime_component_type_t,
-    engine: &wasm_engine_t,
+pub extern "C" fn wasmtime_component_type_import_nth<'a>(
+    ty: &'a wasmtime_component_type_t,
+    engine: &'a wasm_engine_t,
     nth: usize,
     name_ret: &mut MaybeUninit<*const u8>,
     name_len_ret: &mut MaybeUninit<usize>,
-    type_ret: &mut MaybeUninit<wasmtime_component_item_t>,
+    ret: &mut MaybeUninit<Box<wasmtime_component_extern_t<'a>>>,
 ) -> bool {
     match ty.ty.imports(&engine.engine).nth(nth) {
-        Some((name, item)) => {
+        Some((name, e)) => {
             let name: &str = name;
             name_ret.write(name.as_ptr());
             name_len_ret.write(name.len());
-            type_ret.write(item.ty.into());
+            ret.write(Box::new(e.into()));
             true
         }
         None => false,
@@ -74,20 +74,20 @@ pub extern "C" fn wasmtime_component_type_export_count(
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn wasmtime_component_type_export_get(
-    ty: &wasmtime_component_type_t,
-    engine: &wasm_engine_t,
+pub unsafe extern "C" fn wasmtime_component_type_export_get<'a>(
+    ty: &'a wasmtime_component_type_t,
+    engine: &'a wasm_engine_t,
     name: *const u8,
     name_len: usize,
-    ret: &mut MaybeUninit<wasmtime_component_item_t>,
+    ret: &mut MaybeUninit<Box<wasmtime_component_extern_t<'a>>>,
 ) -> bool {
     let name = unsafe { std::slice::from_raw_parts(name, name_len) };
     let Ok(name) = std::str::from_utf8(name) else {
         return false;
     };
     match ty.ty.get_export(&engine.engine, name) {
-        Some(item) => {
-            ret.write(item.ty.into());
+        Some(e) => {
+            ret.write(Box::new(e.into()));
             true
         }
         None => false,
@@ -95,20 +95,20 @@ pub unsafe extern "C" fn wasmtime_component_type_export_get(
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn wasmtime_component_type_export_nth(
-    ty: &wasmtime_component_type_t,
-    engine: &wasm_engine_t,
+pub extern "C" fn wasmtime_component_type_export_nth<'a>(
+    ty: &'a wasmtime_component_type_t,
+    engine: &'a wasm_engine_t,
     nth: usize,
     name_ret: &mut MaybeUninit<*const u8>,
     name_len_ret: &mut MaybeUninit<usize>,
-    type_ret: &mut MaybeUninit<wasmtime_component_item_t>,
+    ret: &mut MaybeUninit<Box<wasmtime_component_extern_t<'a>>>,
 ) -> bool {
     match ty.ty.exports(&engine.engine).nth(nth) {
-        Some((name, item)) => {
+        Some((name, e)) => {
             let name: &str = name;
             name_ret.write(name.as_ptr());
             name_len_ret.write(name.len());
-            type_ret.write(item.ty.into());
+            ret.write(Box::new(e.into()));
             true
         }
         None => false,
@@ -164,4 +164,77 @@ pub extern "C" fn wasmtime_component_item_delete(
     unsafe {
         ManuallyDrop::drop(item);
     }
+}
+
+pub struct wasmtime_component_extern_t<'a> {
+    e: ComponentExtern<'a>,
+}
+
+impl<'a> From<ComponentExtern<'a>> for wasmtime_component_extern_t<'a> {
+    fn from(e: ComponentExtern<'a>) -> Self {
+        wasmtime_component_extern_t { e }
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn wasmtime_component_extern_clone<'a>(
+    e: &wasmtime_component_extern_t<'a>,
+) -> Box<wasmtime_component_extern_t<'a>> {
+    Box::new(wasmtime_component_extern_t { e: e.e.clone() })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn wasmtime_component_extern_type(
+    e: &wasmtime_component_extern_t<'_>,
+    ret: &mut MaybeUninit<wasmtime_component_item_t>,
+) {
+    ret.write(e.e.ty.clone().into());
+}
+
+fn optional_str(s: Option<&str>, len: &mut MaybeUninit<usize>) -> *const u8 {
+    match s {
+        Some(s) => {
+            len.write(s.len());
+            s.as_ptr()
+        }
+        None => {
+            len.write(0);
+            std::ptr::null()
+        }
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn wasmtime_component_extern_implements(
+    e: &wasmtime_component_extern_t<'_>,
+    len: &mut MaybeUninit<usize>,
+) -> *const u8 {
+    optional_str(e.e.implements, len)
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn wasmtime_component_extern_is_implements(
+    e: &wasmtime_component_extern_t<'_>,
+    name: *const u8,
+    len: usize,
+) -> bool {
+    let name = unsafe { crate::slice_from_raw_parts(name, len) };
+    let Ok(name) = std::str::from_utf8(name) else {
+        return false;
+    };
+    e.e.is_implements(name)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn wasmtime_component_extern_external_id(
+    e: &wasmtime_component_extern_t<'_>,
+    len: &mut MaybeUninit<usize>,
+) -> *const u8 {
+    optional_str(e.e.external_id, len)
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn wasmtime_component_extern_delete(
+    _e: Option<Box<wasmtime_component_extern_t<'_>>>,
+) {
 }

--- a/crates/c-api/src/component/types/instance.rs
+++ b/crates/c-api/src/component/types/instance.rs
@@ -1,4 +1,4 @@
-use crate::{wasm_engine_t, wasmtime_component_item_t};
+use crate::{wasm_engine_t, wasmtime_component_extern_t};
 use std::mem::MaybeUninit;
 use wasmtime::component::types::ComponentInstance;
 
@@ -20,20 +20,20 @@ pub unsafe extern "C" fn wasmtime_component_instance_type_export_count(
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn wasmtime_component_instance_type_export_get(
-    ty: &wasmtime_component_instance_type_t,
-    engine: &wasm_engine_t,
+pub unsafe extern "C" fn wasmtime_component_instance_type_export_get<'a>(
+    ty: &'a wasmtime_component_instance_type_t,
+    engine: &'a wasm_engine_t,
     name: *const u8,
     name_len: usize,
-    ret: &mut MaybeUninit<wasmtime_component_item_t>,
+    ret: &mut MaybeUninit<Box<wasmtime_component_extern_t<'a>>>,
 ) -> bool {
     let name = unsafe { std::slice::from_raw_parts(name, name_len) };
     let Ok(name) = std::str::from_utf8(name) else {
         return false;
     };
     match ty.ty.get_export(&engine.engine, name) {
-        Some(item) => {
-            ret.write(item.ty.into());
+        Some(e) => {
+            ret.write(Box::new(e.into()));
             true
         }
         None => false,
@@ -41,20 +41,20 @@ pub unsafe extern "C" fn wasmtime_component_instance_type_export_get(
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn wasmtime_component_instance_type_export_nth(
-    ty: &wasmtime_component_instance_type_t,
-    engine: &wasm_engine_t,
+pub extern "C" fn wasmtime_component_instance_type_export_nth<'a>(
+    ty: &'a wasmtime_component_instance_type_t,
+    engine: &'a wasm_engine_t,
     nth: usize,
     name_ret: &mut MaybeUninit<*const u8>,
     name_len_ret: &mut MaybeUninit<usize>,
-    type_ret: &mut MaybeUninit<wasmtime_component_item_t>,
+    ret: &mut MaybeUninit<Box<wasmtime_component_extern_t<'a>>>,
 ) -> bool {
     match ty.ty.exports(&engine.engine).nth(nth) {
-        Some((name, item)) => {
+        Some((name, e)) => {
             let name: &str = name;
             name_ret.write(name.as_ptr());
             name_len_ret.write(name.len());
-            type_ret.write(item.ty.into());
+            ret.write(Box::new(e.into()));
             true
         }
         None => false,

--- a/crates/c-api/tests/component/types.cc
+++ b/crates/c-api/tests/component/types.cc
@@ -35,17 +35,17 @@ TEST(types, component_resource) {
                        .type();
 
   EXPECT_EQ(component.import_count(engine), 1);
-  auto ty = component.import_get(engine, "x")->resource();
+  auto ty = component.import_get(engine, "x")->type().resource();
   auto i = *component.import_nth(engine, 0);
   EXPECT_EQ(i.first, "x");
-  EXPECT_EQ(ty, i.second.resource());
+  EXPECT_EQ(ty, i.second.type().resource());
 
   EXPECT_EQ(component.export_count(engine), 1);
 
-  EXPECT_EQ(component.export_get(engine, "x")->resource(), ty);
+  EXPECT_EQ(component.export_get(engine, "x")->type().resource(), ty);
   auto e = *component.import_nth(engine, 0);
   EXPECT_EQ(e.first, "x");
-  EXPECT_EQ(ty, e.second.resource());
+  EXPECT_EQ(ty, e.second.type().resource());
 }
 
 TEST(types, component_instance) {
@@ -60,14 +60,14 @@ TEST(types, component_instance) {
                        .unwrap()
                        .type();
 
-  auto ty = component.import_get(engine, "x")->component_instance();
+  auto ty = component.import_get(engine, "x")->type().component_instance();
   EXPECT_EQ(ty.export_count(engine), 1);
-  auto resource_ty = ty.export_get(engine, "t")->resource();
-  EXPECT_EQ(resource_ty, ty.export_nth(engine, 0)->second.resource());
+  auto resource_ty = ty.export_get(engine, "t")->type().resource();
+  EXPECT_EQ(resource_ty, ty.export_nth(engine, 0)->second.type().resource());
   EXPECT_EQ("t", ty.export_nth(engine, 0)->first);
 
-  auto ty2 = component.export_get(engine, "x")->component_instance();
-  EXPECT_EQ(resource_ty, ty2.export_get(engine, "t")->resource());
+  auto ty2 = component.export_get(engine, "x")->type().component_instance();
+  EXPECT_EQ(resource_ty, ty2.export_get(engine, "t")->type().resource());
 }
 
 TEST(types, component_func) {
@@ -81,7 +81,7 @@ TEST(types, component_func) {
                        .unwrap()
                        .type();
 
-  auto ty = component.import_get(engine, "x")->component_func();
+  auto ty = component.import_get(engine, "x")->type().component_func();
   EXPECT_EQ(ty.param_count(), 0);
   EXPECT_FALSE(ty.result());
 
@@ -93,7 +93,7 @@ TEST(types, component_func) {
                   .unwrap()
                   .type();
 
-  ty = component.import_get(engine, "x")->component_func();
+  ty = component.import_get(engine, "x")->type().component_func();
   EXPECT_EQ(ty.param_count(), 1);
   EXPECT_EQ(ty.param_nth(0)->first, "x");
   EXPECT_TRUE(ty.param_nth(0)->second.is_u32());
@@ -114,7 +114,7 @@ TEST(types, module_type) {
                        .unwrap();
   auto cty = component.type();
 
-  auto ty = cty.import_get(engine, "x")->module();
+  auto ty = cty.import_get(engine, "x")->type().module();
   EXPECT_EQ(ty.import_count(engine), 0);
   EXPECT_EQ(ty.export_count(engine), 0);
 
@@ -129,7 +129,7 @@ TEST(types, module_type) {
                   .unwrap();
   cty = component.type();
 
-  ty = cty.import_get(engine, "x")->module();
+  ty = cty.import_get(engine, "x")->type().module();
   EXPECT_EQ(ty.import_count(engine), 1);
   auto import = *ty.import_nth(engine, 0);
   EXPECT_EQ(import.ref().module(), "");
@@ -151,7 +151,11 @@ TEST(types, module_type) {
 static ValType result(const char *wat) {
   Engine engine;
   auto component = Component::compile(engine, wat).unwrap();
-  return *component.type().import_get(engine, "f")->component_func().result();
+  return *component.type()
+              .import_get(engine, "f")
+              ->type()
+              .component_func()
+              .result();
 }
 
 TEST(types, valtype_primitives) {
@@ -196,8 +200,11 @@ TEST(types, valtype_map) {
       Component::compile(
           engine, "(component (import \"f\" (func (result (map u32 string)))))")
           .unwrap();
-  auto ty =
-      *component.type().import_get(engine, "f")->component_func().result();
+  auto ty = *component.type()
+                 .import_get(engine, "f")
+                 ->type()
+                 .component_func()
+                 .result();
   EXPECT_TRUE(ty.is_map());
   auto map_ty = ty.map();
   EXPECT_TRUE(map_ty.key().is_u32());
@@ -345,4 +352,102 @@ TEST(types, func_result) {
   auto result = ty.result();
   ASSERT_TRUE(result.has_value());
   EXPECT_TRUE(result->is_u32());
+}
+
+TEST(types, component_extern_annotations) {
+  Config config;
+  config.wasm_component_model_implements(true);
+  Engine engine(std::move(config));
+
+  auto component = Component::compile(engine, R"(
+(component
+  (import "a" (implements "a1:b1/c1") (external-id "user-db-prod:region-a")
+    (instance $a))
+  (import "b" (external-id "user-db-prod:region-b") (instance $b
+    (export "f" (external-id "func-b-f") (func))
+    (export "g" (implements "x:y/z@1.2.0") (instance))
+  ))
+  (import "c" (instance $c))
+  (import "v" (implements "a:b/c@1.2.0") (instance))
+  (export "d" (implements "a2:b2/c2") (external-id "queue-1") (instance $a))
+)
+      )")
+                       .unwrap()
+                       .type();
+
+  EXPECT_EQ(component.import_count(engine), 4);
+  EXPECT_EQ(component.export_count(engine), 1);
+
+  // Both annotations present on a component import.
+  auto a = *component.import_get(engine, "a");
+  EXPECT_TRUE(a.type().is_component_instance());
+  EXPECT_EQ(a.implements(), "a1:b1/c1");
+  EXPECT_EQ(a.external_id(), "user-db-prod:region-a");
+  EXPECT_TRUE(a.is_implements("a1:b1/c1"));
+  EXPECT_FALSE(a.is_implements("a:b/c"));
+  EXPECT_FALSE(a.is_implements("a1:b1/c1@1.0.0"));
+
+  // Only `external-id` present, and annotations on instance type exports.
+  auto b = *component.import_get(engine, "b");
+  EXPECT_FALSE(b.implements().has_value());
+  EXPECT_FALSE(b.is_implements("a1:b1/c1"));
+  EXPECT_EQ(b.external_id(), "user-db-prod:region-b");
+  auto b_ty = b.type().component_instance();
+  EXPECT_EQ(b_ty.export_count(engine), 2);
+  auto f = *b_ty.export_get(engine, "f");
+  EXPECT_TRUE(f.type().is_component_func());
+  EXPECT_FALSE(f.implements().has_value());
+  EXPECT_EQ(f.external_id(), "func-b-f");
+  auto [g_name, g] = *b_ty.export_nth(engine, 1);
+  EXPECT_EQ(g_name, "g");
+  EXPECT_TRUE(g.type().is_component_instance());
+  EXPECT_EQ(g.implements(), "x:y/z@1.2.0");
+  EXPECT_TRUE(g.is_implements("x:y/z@1.0.0"));
+  EXPECT_FALSE(g.external_id().has_value());
+  EXPECT_FALSE(b_ty.export_get(engine, "nope").has_value());
+  EXPECT_FALSE(b_ty.export_nth(engine, 2).has_value());
+
+  // No annotations at all.
+  auto c = *component.import_get(engine, "c");
+  EXPECT_FALSE(c.implements().has_value());
+  EXPECT_FALSE(c.external_id().has_value());
+  EXPECT_FALSE(c.is_implements(""));
+  EXPECT_FALSE(c.is_implements("c"));
+
+  // Semver-compatible matching of `implements`.
+  auto [v_name, v] = *component.import_nth(engine, 3);
+  EXPECT_EQ(v_name, "v");
+  EXPECT_EQ(v.implements(), "a:b/c@1.2.0");
+  EXPECT_FALSE(v.is_implements("a:b/c"));
+  EXPECT_TRUE(v.is_implements("a:b/c@1.2.0"));
+  EXPECT_TRUE(v.is_implements("a:b/c@1.3.0"));
+  EXPECT_TRUE(v.is_implements("a:b/c@1.0.0"));
+  EXPECT_FALSE(v.is_implements("a:b/c@2.0.0"));
+  EXPECT_FALSE(component.import_get(engine, "nope").has_value());
+  EXPECT_FALSE(component.import_nth(engine, 4).has_value());
+
+  // Annotations on component exports, via both lookup methods.
+  auto d = *component.export_get(engine, "d");
+  EXPECT_TRUE(d.type().is_component_instance());
+  EXPECT_EQ(d.implements(), "a2:b2/c2");
+  EXPECT_EQ(d.external_id(), "queue-1");
+  EXPECT_TRUE(d.is_implements("a2:b2/c2"));
+  auto [d_name, d2] = *component.export_nth(engine, 0);
+  EXPECT_EQ(d_name, "d");
+  EXPECT_EQ(d2.implements(), "a2:b2/c2");
+  EXPECT_EQ(d2.external_id(), "queue-1");
+  EXPECT_FALSE(component.export_get(engine, "nope").has_value());
+  EXPECT_FALSE(component.export_nth(engine, 1).has_value());
+
+  // Copies and assignment preserve everything.
+  ComponentExtern a_copy = a;
+  EXPECT_TRUE(a_copy.type().is_component_instance());
+  EXPECT_EQ(a_copy.implements(), "a1:b1/c1");
+  EXPECT_EQ(a_copy.external_id(), "user-db-prod:region-a");
+  EXPECT_TRUE(a_copy.is_implements("a1:b1/c1"));
+  a_copy = c;
+  EXPECT_FALSE(a_copy.implements().has_value());
+  EXPECT_FALSE(a_copy.external_id().has_value());
+  ComponentExtern a_moved = std::move(a);
+  EXPECT_EQ(a_moved.implements(), "a1:b1/c1");
 }


### PR DESCRIPTION
Expose both the `Config` accessor plus API changes necessary to reflect over this proposal in the C API.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please review the Bytecode Alliance's AI tool usage policy at
https://github.com/bytecodealliance/governance/blob/main/AI_TOOL_POLICY.md

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
