### PR TITLE
Cranelift comparison and select rules

### DIFF
--- a/cranelift/codegen/src/opts/icmp.isle
+++ b/cranelift/codegen/src/opts/icmp.isle
@@ -490,3 +490,25 @@
 (rule (simplify (ule rty (ushr ty x y) x)) (cmp_true rty))
 (rule (simplify (ugt rty (ushr ty x y) x)) (subsume (all_zero rty)))
 (rule (simplify (ult rty x (ushr ty x y))) (subsume (all_zero rty)))
+
+;; smin(x, y) > smax(x, y) --> false
+(rule (simplify (sgt ty (smin cty x y) (smax cty x y))) (iconst_u ty 0))
+
+;; umin(x, y) > umax(x, y) --> false
+(rule (simplify (ugt ty (umin cty x y) (umax cty x y))) (iconst_u ty 0))
+
+;; smin(x, y) <= smax(x, y) --> true
+(rule (simplify (sle ty (smin cty x y) (smax cty x y))) (cmp_true ty))
+(rule (simplify (sle ty (smin cty x y) (smax cty y x))) (cmp_true ty))
+
+;; umin(x, y) <= umax(x, y) --> true
+(rule (simplify (ule ty (umin cty x y) (umax cty x y))) (cmp_true ty))
+(rule (simplify (ule ty (umin cty x y) (umax cty y x))) (cmp_true ty))
+
+;; smin(x, y) == smax(x, y) --> x == y
+(rule (simplify (eq ty (smin cty x y) (smax cty x y))) (eq ty x y))
+(rule (simplify (eq ty (smin cty x y) (smax cty y x))) (eq ty x y))
+
+;; smin(x, y) != smax(x, y) --> x != y
+(rule (simplify (ne ty (smin cty x y) (smax cty x y))) (ne ty x y))
+(rule (simplify (ne ty (smin cty x y) (smax cty y x))) (ne ty x y))

--- a/cranelift/codegen/src/opts/selects.isle
+++ b/cranelift/codegen/src/opts/selects.isle
@@ -87,6 +87,13 @@
                            (sextend ty b @ (value_type small))))
       (sextend ty (select small cond a b)))
 
+;; select(c, ~x, ~y) --> ~select(c, x, y)
+(rule (simplify (select ty c (bnot ty x) (bnot ty y))) (bnot ty (select ty c x y)))
+
+;; select(c, -x, -y) --> -select(c, x, y)
+;; Lifts arithmetic negation outside of select.
+(rule (simplify (select ty c (ineg ty x) (ineg ty y))) (ineg ty (select ty c x y)))
+
 (rule (simplify (select ty (sgt _ x (iconst_u ty 0)) x (ineg ty x))) (subsume (iabs ty x)))
 (rule (simplify (select ty (sge _ x (iconst_u ty 0)) x (ineg ty x))) (subsume (iabs ty x)))
 (rule (simplify (select ty (sle _ x (iconst_u ty 0)) (ineg ty x) x)) (subsume (iabs ty x)))

--- a/cranelift/filetests/filetests/egraph/icmp.clif
+++ b/cranelift/filetests/filetests/egraph/icmp.clif
@@ -548,3 +548,123 @@ block0(v0: i32, v1: i32):
 ;     v6 = icmp ult v0, v1
 ;     return v6
 ; }
+
+function %smin_sgt_smax(i32, i32) -> i8 fast {
+block0(v0: i32, v1: i32):
+    v2 = smin.i32 v0, v1
+    v3 = smax.i32 v0, v1
+    v4 = icmp sgt v2, v3
+    return v4
+}
+
+; function %smin_sgt_smax(i32, i32) -> i8 fast {
+; block0(v0: i32, v1: i32):
+;     v5 = iconst.i8 0
+;     return v5  ; v5 = 0
+; }
+
+function %umin_ugt_umax(i32, i32) -> i8 fast {
+block0(v0: i32, v1: i32):
+    v2 = umin.i32 v0, v1
+    v3 = umax.i32 v0, v1
+    v4 = icmp ugt v2, v3
+    return v4
+}
+
+; function %umin_ugt_umax(i32, i32) -> i8 fast {
+; block0(v0: i32, v1: i32):
+;     v5 = iconst.i8 0
+;     return v5  ; v5 = 0
+; }
+
+function %smin_sle_smax(i32, i32) -> i8 fast {
+block0(v0: i32, v1: i32):
+    v2 = smin.i32 v0, v1
+    v3 = smax.i32 v0, v1
+    v4 = icmp sle v2, v3
+    return v4
+}
+
+; function %smin_sle_smax(i32, i32) -> i8 fast {
+; block0(v0: i32, v1: i32):
+;     v5 = iconst.i8 1
+;     return v5  ; v5 = 1
+; }
+
+function %umin_ule_umax(i32, i32) -> i8 fast {
+block0(v0: i32, v1: i32):
+    v2 = umin.i32 v0, v1
+    v3 = umax.i32 v0, v1
+    v4 = icmp ule v2, v3
+    return v4
+}
+
+; function %umin_ule_umax(i32, i32) -> i8 fast {
+; block0(v0: i32, v1: i32):
+;     v5 = iconst.i8 1
+;     return v5  ; v5 = 1
+; }
+
+function %smin_eq_smax(i32, i32) -> i8 fast {
+block0(v0: i32, v1: i32):
+    v2 = smin.i32 v0, v1
+    v3 = smax.i32 v0, v1
+    v4 = icmp.i8 eq v2, v3
+    return v4
+}
+
+; function %smin_eq_smax(i32, i32) -> i8 fast {
+; block0(v0: i32, v1: i32):
+;     v5 = icmp eq v0, v1
+;     return v5
+; }
+
+function %smin_ne_smax(i32, i32) -> i8 fast {
+block0(v0: i32, v1: i32):
+    v2 = smin.i32 v0, v1
+    v3 = smax.i32 v0, v1
+    v4 = icmp.i8 ne v2, v3
+    return v4
+}
+
+; function %smin_ne_smax(i32, i32) -> i8 fast {
+; block0(v0: i32, v1: i32):
+;     v5 = icmp ne v0, v1
+;     return v5
+; }
+
+;; select(c, ~x, ~y) --> ~select(c, x, y)
+function %select_bnot_bnot(i32, i32, i32, i32) -> i32 {
+block0(v0: i32, v1: i32, v2: i32, v3: i32):
+    v4 = icmp.i8 eq v0, v1
+    v5 = bnot.i32 v2
+    v6 = bnot.i32 v3
+    v7 = select.i32 v4, v5, v6
+    return v7
+}
+
+; function %select_bnot_bnot(i32, i32, i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32, v2: i32, v3: i32):
+;     v4 = icmp eq v0, v1
+;     v8 = select v4, v2, v3
+;     v9 = bnot v8
+;     return v9
+; }
+
+;; select(c, -x, -y) --> -select(c, x, y)
+function %select_ineg_ineg(i32, i32, i32, i32) -> i32 {
+block0(v0: i32, v1: i32, v2: i32, v3: i32):
+    v4 = icmp eq v0, v1
+    v5 = ineg v2
+    v6 = ineg v3
+    v7 = select v4, v5, v6
+    return v7
+}
+
+; function %select_ineg_ineg(i32, i32, i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32, v2: i32, v3: i32):
+;     v4 = icmp eq v0, v1
+;     v8 = select v4, v2, v3
+;     v9 = ineg v8
+;     return v9
+; }


### PR DESCRIPTION
This commit adds the following integer comparison involving min/max and select rules that lift bitwise and arithmetic not.

```
smin(x, y) > smax(x, y) --> false
umin(x, y) > umax(x, y) --> false
smin(x, y) <= smax(x, y) --> true
umin(x, y) <= umax(x, y) --> true
smin(x, y) == smax(x, y) --> x == y
smin(x, y) != smax(x, y) --> x != y
select(c, ~x, ~y) --> ~select(c, x, y)
select(c, -x, -y) --> -select(c, x, y)
```
