### PR TITLE
Cranelift: fix `uadd_overflow` + load sinking.

### DIFF
--- a/cranelift/codegen/src/machinst/lower.rs
+++ b/cranelift/codegen/src/machinst/lower.rs
@@ -1837,25 +1837,4 @@ mod tests {
         assert_eq!(uses[v4], ValueUseState::Once);
         assert_eq!(uses[v5], ValueUseState::Once);
     }
-
-    #[test]
-    fn results_used_twice_but_not_operands() {
-        let mut func = Function::new();
-        let block0 = func.dfg.make_block();
-        let mut pos = FuncCursor::new(&mut func);
-        pos.insert_block(block0);
-        let v1 = pos.ins().iconst(types::I64, 0);
-        let v2 = pos.ins().iconst(types::I64, 1);
-        let v3 = pos.ins().iconcat(v1, v2);
-        let (v4, v5) = pos.ins().isplit(v3);
-        pos.ins().return_(&[v4, v4]);
-        let func = pos.func;
-
-        let uses = super::compute_use_states(&func, None);
-        assert_eq!(uses[v1], ValueUseState::Once);
-        assert_eq!(uses[v2], ValueUseState::Once);
-        assert_eq!(uses[v3], ValueUseState::Once);
-        assert_eq!(uses[v4], ValueUseState::Multiple);
-        assert_eq!(uses[v5], ValueUseState::Unused);
-    }
 }

--- a/cranelift/codegen/src/machinst/lower.rs
+++ b/cranelift/codegen/src/machinst/lower.rs
@@ -1422,11 +1422,7 @@ fn compute_use_states(
     let uses = |value| {
         trace!(" -> pushing args for {} onto stack", value);
         if let ValueDef::Result(src_inst, _) = f.dfg.value_def(value) {
-            if is_value_use_root(f, src_inst) {
-                None
-            } else {
-                Some(f.dfg.inst_values(src_inst))
-            }
+            Some(f.dfg.inst_values(src_inst))
         } else {
             None
         }
@@ -1484,26 +1480,6 @@ fn compute_use_states(
     }
 
     value_ir_uses
-}
-
-/// Definition of a "root" instruction for the calculation of `ValueUseState`.
-///
-/// This function calculates whether `inst` is considered a "root" for value-use
-/// information. This concept is used to forcibly prevent looking-through the
-/// instruction during `get_value_as_source_or_const` as it additionally
-/// prevents propagating `Multiple`-used results of the `inst` here to the
-/// operands of the instruction.
-///
-/// Currently this is defined as multi-result instructions. That means that
-/// lowerings are never allowed to look through a multi-result instruction to
-/// generate patterns. Note that this isn't possible in ISLE today anyway so
-/// this isn't currently much of a loss.
-///
-/// The main purpose of this function is to prevent the operands of a
-/// multi-result instruction from being forcibly considered `Multiple`-used
-/// regardless of circumstances.
-fn is_value_use_root(f: &Function, inst: Inst) -> bool {
-    f.dfg.inst_results(inst).len() > 1
 }
 
 /// Function-level queries.
@@ -1710,16 +1686,7 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
                 let src_side_effect = src_entry_color.get() != 0;
                 trace!(" -> src inst {}", self.f.dfg.display_inst(src_inst));
                 trace!(" -> has lowering side effect: {}", src_side_effect);
-                if is_value_use_root(self.f, src_inst) {
-                    // If this instruction is a "root instruction" then it's
-                    // required that we can't look through it to see the
-                    // definition. This means that the `ValueUseState` for the
-                    // operands of this result assume that this instruction is
-                    // generated exactly once which might get violated were we
-                    // to allow looking through it.
-                    trace!(" -> is a root instruction");
-                    InputSourceInst::None
-                } else if !src_side_effect {
+                if !src_side_effect {
                     // Otherwise if this instruction has no side effects and the
                     // value is used only once then we can look through it with
                     // a "unique" tag. A non-unique `Use` can be shown for other

--- a/cranelift/filetests/filetests/isa/x64/uadd_overflow_brif.clif
+++ b/cranelift/filetests/filetests/isa/x64/uadd_overflow_brif.clif
@@ -322,3 +322,59 @@ block3:
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
+
+function %no_load_sinking(i64) -> i8 {
+block0(v0: i64):
+  v1 = load.i64 v0
+  v2, v3 = uadd_overflow v0, v1
+  brif v3, block1(v3), block2
+
+block1(v4: i8):
+  return v4
+
+block2:
+  v5 = iconst.i8 42
+  return v5
+}
+
+; VCode:
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block0:
+;   movq (%rdi), %rsi
+;   movq %rdi, %r8
+;   addq %rsi, %r8
+;   setb %al
+;   addq %rsi, %rdi
+;   jb      label2; j label1
+; block1:
+;   movl $0x2a, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+; block2:
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movq (%rdi), %rsi ; trap: heap_oob
+;   movq %rdi, %r8
+;   addq %rsi, %r8
+;   setb %al
+;   addq %rsi, %rdi
+;   jb 0x23
+; block2: ; offset 0x19
+;   movl $0x2a, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+; block3: ; offset 0x23
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+


### PR DESCRIPTION
In #14271 we got a fuzzbug that had a `uadd_overflow` with (i) a sinkable load as one argument, (ii) multiple uses of the flag output, so its flag result would have to be materialized anyway.

This results in the lowering happening twice: once to feed the flags into the branch, and once to actually materialize the bool value. That's fine: the whole point of the new mechanism is that the common case is to use the overflow as a branch input only, not as a materialized bool, so a double lowering here is harmless (two extra cycles).

The issue arises because of a bit of logic I had forgotten we added several years ago in #9510 that declares *all* multi-def instructions as "value roots" that will only be lowered *once*. This allows loads to sink into such instructions always (if only used once by that instruction of course), but in turn requires a promise that we will do what we say on the tin: we will only *ever* lower any multi-def instruction once.

I believe that this eliminates any practical way of optimizing overflow-flag insts, or doing fusion of bool flags into conditional branches at all, because these inherently require lowering at use sites (because of the way that we don't regalloc flags).

It is also a somewhat dangerous (IMHO, now with perspective) exception to our otherwise principled "multiplicity" analysis: we otherwise assume (i) that any given instruction is only lowered once, unless (ii) truly used multiple times in the DFG. That is what allows us to reason about code motion of loads in a princpled way (because we can't duplicate a load). That principle is pretty simple; declaring some instructions "roots" and allowing them to "kill" multiplicity adds this footgun that will strike whenever we forget the exception and write a lowering rule like the overflow cases.

Fortunately it seems we don't actually get any test failures when removing that feature (and the test from #9510 is still in-tree?), so it's not required anymore; so this PR removes the feature. The attached test will panic without the fix.

Fixes #14271.

(Some more philosophical thought: our pre-pass that computes multiplicity is itself a choice, but the alternative requires us to give up single-pass lowering altogether and forces code motion into an iterative/fixpoint kind of framework. Consider: we have multiple uses of a given load; when we see the first use, how do we know whether it's the only use (and we can sink it into here) or there will be another? The multiplicity analysis is what answers that ahead of time, and despite its main limitation (it cannot be updated live), it seems to work well overall if we stick to the framework.)

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please review the Bytecode Alliance's AI tool usage policy at
https://github.com/bytecodealliance/governance/blob/main/AI_TOOL_POLICY.md

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
