### PR TITLE
Remove "status" section from Pulley's `README.md`

### DIFF
--- a/pulley/README.md
+++ b/pulley/README.md
@@ -37,11 +37,6 @@ Alliance RFC that originally proposed Pulley][rfc].
 
 [rfc]: https://github.com/bytecodealliance/rfcs/blob/main/accepted/pulley.md
 
-## Status
-
-Pulley is very much still a work in progress! Expect the details of the bytecode
-to change, instructions to appear and disappear, and APIs to be overhauled.
-
 ## Example
 
 Here is the disassembly of `f(a, b) = a + b` in Pulley today:


### PR DESCRIPTION
We already have https://docs.wasmtime.dev/stability-tiers.html for documenting status/stability, and this section was additionally outdated.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please review the Bytecode Alliance's AI tool usage policy at
https://github.com/bytecodealliance/governance/blob/main/AI_TOOL_POLICY.md

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
