### PR TITLE
Cranelift: add/modify mid-end opt rules

### DIFF
--- a/cranelift/codegen/src/opts/bitops.isle
+++ b/cranelift/codegen/src/opts/bitops.isle
@@ -41,10 +41,13 @@
 (rule (simplify (band ty x (iconst_s ty -1)))
       (subsume x))
 
-;; x & 0 == x & not(x) == not(x) & x == 0.
-(rule (simplify (band (ty_int_vec128 ty) _ zero @ (iconst_u ty 0))) (subsume zero))
-(rule (simplify (band (ty_int_vec128 ty) x (bnot ty x))) (subsume (iconst_u ty 0)))
-(rule (simplify (band (ty_int_vec128 ty) (bnot ty x) x)) (subsume (iconst_u ty 0)))
+;; x & 0 == 0; 0 & x == 0.
+(rule (simplify (band ty x zero @ (all_zero ty))) (subsume zero))
+(rule (simplify (band ty zero @ (all_zero ty) x)) (subsume zero))
+
+;; x & not(x) == 0; not(x) & x == 0.
+(rule (simplify (band ty x (bnot ty x))) (subsume (all_zero ty)))
+(rule (simplify (band ty (bnot ty x) x)) (subsume (all_zero ty)))
 
 ;; (x & y) ^ (x ^ y) == x | y
 (rule (simplify (bxor ty (band ty X Y) (bxor ty X Y))) (bor ty X Y))

--- a/cranelift/codegen/src/opts/icmp.isle
+++ b/cranelift/codegen/src/opts/icmp.isle
@@ -512,3 +512,24 @@
 ;; smin(x, y) != smax(x, y) --> x != y
 (rule (simplify (ne ty (smin cty x y) (smax cty x y))) (ne ty x y))
 (rule (simplify (ne ty (smin cty x y) (smax cty y x))) (ne ty x y))
+
+;; (x - y) == 0 ==> x == y
+(rule (simplify (eq ty (isub cty x y) (all_zero cty))) (eq ty x y))
+
+;; (x - y) != 0 ==> x != y
+(rule (simplify (ne ty (isub cty x y) (all_zero cty))) (ne ty x y))
+
+;; (x ^ y) == 0 ==> x == y
+(rule (simplify (eq ty (bxor cty x y) (all_zero cty))) (eq ty x y))
+
+;; (x ^ y) != 0 ==> x != y
+(rule (simplify (ne ty (bxor cty x y) (all_zero cty))) (ne ty x y))
+
+;; (x ^ y) == x ==> y == 0
+(rule (simplify (eq ty (bxor cty x y) x)) (eq ty y (all_zero cty)))
+
+;; (x + y) != x ==> y != 0
+(rule (simplify (ne ty (iadd cty x y) x)) (ne ty y (all_zero cty)))
+
+;; -x != -y ==> x != y
+(rule (simplify (ne ty (ineg cty x) (ineg cty y))) (ne ty x y))

--- a/cranelift/codegen/src/opts/selects.isle
+++ b/cranelift/codegen/src/opts/selects.isle
@@ -200,3 +200,15 @@
 (rule (simplify (select ty x (eq ty z y) (eq ty y (iconst_u cty p)))) (eq ty y (select cty x z (iconst_u cty p))))
 (rule (simplify (select ty x (eq ty y z) (eq ty (iconst_u cty p) y))) (eq ty y (select cty x z (iconst_u cty p))))
 (rule (simplify (select ty x (eq ty y z) (eq ty y (iconst_u cty p)))) (eq ty y (select cty x z (iconst_u cty p))))
+
+;; (x == y) ? 0 : (x - y) ==> x - y
+(rule (simplify (select ty (eq cty x y) (all_zero ty) (isub ty x y)))
+      (isub ty x y))
+
+;; (c ? y : z) + (c ? z : y) ==> z + y
+(rule (simplify (iadd ty (select ty c y z) (select ty c z y)))
+      (iadd ty z y))
+
+;; (x != y) ? (x - y) : 0 ==> x - y
+(rule (simplify (select ty (ne cty x y) (isub ty x y) (all_zero ty)))
+      (isub ty x y))

--- a/cranelift/filetests/filetests/egraph/bitops.clif
+++ b/cranelift/filetests/filetests/egraph/bitops.clif
@@ -401,8 +401,8 @@ block0(v0: i32x4):
 }
 
 ; check: const0 = 0x00000000000000000000000000000000
-; check: v5 = vconst.i32x4 const0
-; check: return v5
+; check: v3 = vconst.i32x4 const0
+; check: return v3
 
 function %vector_band_bnot_x_x(i32x4) -> i32x4 {
 block0(v0: i32x4):
@@ -412,8 +412,8 @@ block0(v0: i32x4):
 }
 
 ; check: const0 = 0x00000000000000000000000000000000
-; check: v5 = vconst.i32x4 const0
-; check: return v5
+; check: v3 = vconst.i32x4 const0
+; check: return v3
 
 function %issue_13229_band_not_f64(f64) {
 block0(v0: f64):
@@ -1462,5 +1462,39 @@ block0(v0: i32):
     v2 = popcnt v1
     return v2
     ; check: v3 = popcnt v0
+    ; check: return v3
+}
+
+function %band_x_zero_f32(f32) -> f32 {
+block0(v0: f32):
+    v1 = f32const 0.0
+    v2 = band v0, v1
+    return v2
+    ; check: return v1
+}
+
+function %band_zero_x_f32(f32) -> f32 {
+block0(v0: f32):
+    v1 = f32const 0.0
+    v2 = band v1, v0
+    return v2
+    ; check: return v1
+}
+
+function %band_x_bnot_x_f32(f32) -> f32 {
+block0(v0: f32):
+    v1 = bnot v0
+    v2 = band v0, v1
+    return v2
+    ; check: v3 = f32const 0.0
+    ; check: return v3
+}
+
+function %band_bnot_x_x_f32(f32) -> f32 {
+block0(v0: f32):
+    v1 = bnot v0
+    v2 = band v1, v0
+    return v2
+    ; check: v3 = f32const 0.0
     ; check: return v3
 }

--- a/cranelift/filetests/filetests/egraph/icmp.clif
+++ b/cranelift/filetests/filetests/egraph/icmp.clif
@@ -668,3 +668,108 @@ block0(v0: i32, v1: i32, v2: i32, v3: i32):
 ;     v9 = ineg v8
 ;     return v9
 ; }
+
+;; (x - y) == 0 --> x == y
+function %eq_isub_zero(i32, i32) -> i8 {
+block0(v0: i32, v1: i32):
+    v2 = isub v0, v1
+    v3 = iconst.i32 0
+    v4 = icmp eq v2, v3
+    return v4
+}
+
+; function %eq_isub_zero(i32, i32) -> i8 fast {
+; block0(v0: i32, v1: i32):
+;     v5 = icmp eq v0, v1
+;     return v5
+; }
+
+;; (x - y) != 0 --> x != y
+function %ne_isub_zero(i32, i32) -> i8 {
+block0(v0: i32, v1: i32):
+    v2 = isub v0, v1
+    v3 = iconst.i32 0
+    v4 = icmp ne v2, v3
+    return v4
+}
+
+; function %ne_isub_zero(i32, i32) -> i8 fast {
+; block0(v0: i32, v1: i32):
+;     v5 = icmp ne v0, v1
+;     return v5
+; }
+
+;; (x ^ y) == 0 --> x == y
+function %eq_bxor_zero(i32, i32) -> i8 {
+block0(v0: i32, v1: i32):
+    v2 = bxor v0, v1
+    v3 = iconst.i32 0
+    v4 = icmp eq v2, v3
+    return v4
+}
+
+; function %eq_bxor_zero(i32, i32) -> i8 fast {
+; block0(v0: i32, v1: i32):
+;     v5 = icmp eq v0, v1
+;     return v5
+; }
+
+;; (x ^ y) != 0 --> x != y
+function %ne_bxor_zero(i32, i32) -> i8 {
+block0(v0: i32, v1: i32):
+    v2 = bxor v0, v1
+    v3 = iconst.i32 0
+    v4 = icmp ne v2, v3
+    return v4
+}
+
+; function %ne_bxor_zero(i32, i32) -> i8 fast {
+; block0(v0: i32, v1: i32):
+;     v5 = icmp ne v0, v1
+;     return v5
+; }
+
+;; (x ^ y) == x --> y == 0
+function %eq_bxor_x(i32, i32) -> i8 {
+block0(v0: i32, v1: i32):
+    v2 = bxor v0, v1
+    v3 = icmp eq v2, v0
+    return v3
+}
+
+; function %eq_bxor_x(i32, i32) -> i8 fast {
+; block0(v0: i32, v1: i32):
+;     v4 = iconst.i32 0
+;     v5 = icmp eq v1, v4  ; v4 = 0
+;     return v5
+; }
+
+;; (x + y) != x --> y != 0
+function %ne_iadd_x(i32, i32) -> i8 {
+block0(v0: i32, v1: i32):
+    v2 = iadd v0, v1
+    v3 = icmp ne v2, v0
+    return v3
+}
+
+; function %ne_iadd_x(i32, i32) -> i8 fast {
+; block0(v0: i32, v1: i32):
+;     v4 = iconst.i32 0
+;     v5 = icmp ne v1, v4  ; v4 = 0
+;     return v5
+; }
+
+;; -x != -y --> x != y
+function %ne_ineg(i32, i32) -> i8 {
+block0(v0: i32, v1: i32):
+    v2 = ineg v0
+    v3 = ineg v1
+    v4 = icmp ne v2, v3
+    return v4
+}
+
+; function %ne_ineg(i32, i32) -> i8 fast {
+; block0(v0: i32, v1: i32):
+;     v5 = icmp ne v0, v1
+;     return v5
+; }

--- a/cranelift/filetests/filetests/egraph/selects.clif
+++ b/cranelift/filetests/filetests/egraph/selects.clif
@@ -228,3 +228,49 @@ block0(v0: i8, v1: i32, v2: i32):
 ;     return v10
 ; }
 
+;; (x == y) ? 0 : (x - y) --> x - y
+function %select_eq_zero_isub(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = icmp eq v0, v1
+    v3 = iconst.i32 0
+    v4 = isub v0, v1
+    v5 = select v2, v3, v4
+    return v5
+}
+
+; function %select_eq_zero_isub(i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32):
+;     v4 = isub v0, v1
+;     return v4
+; }
+
+;; (c ? y : z) + (c ? z : y) --> z + y
+function %add_swapped_selects(i8, i32, i32) -> i32 {
+block0(v0: i8, v1: i32, v2: i32):
+    v3 = select v0, v1, v2
+    v4 = select v0, v2, v1
+    v5 = iadd v3, v4
+    return v5
+}
+
+; function %add_swapped_selects(i8, i32, i32) -> i32 fast {
+; block0(v0: i8, v1: i32, v2: i32):
+;     v6 = iadd v2, v1
+;     return v6
+; }
+
+;; (x != y) ? (x - y) : 0 --> x - y
+function %select_ne_isub_zero(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = icmp ne v0, v1
+    v3 = isub v0, v1
+    v4 = iconst.i32 0
+    v5 = select v2, v3, v4
+    return v5
+}
+
+; function %select_ne_isub_zero(i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32):
+;     v3 = isub v0, v1
+;     return v3
+; }

--- a/cranelift/filetests/filetests/runtests/float-bitops.clif
+++ b/cranelift/filetests/filetests/runtests/float-bitops.clif
@@ -65,3 +65,35 @@ block0(v0: f32, v1: f32):
 ; run: %bxor_f32(-NaN:0x3fffff, 0x1.aaaaaap43) == -0x1.555554p-42
 ; run: %bxor_f32(-NaN:0x3fffff, 0x1.666666p-25) == -0x1.999998p26
 ; run: %bxor_f32(0x1.aaaaaap43, -0x1.555554p-42) == -NaN:0x3fffff
+
+function %band_x_zero_f32(f32) -> f32 {
+block0(v0: f32):
+    v1 = f32const 0.0
+    v2 = band v0, v1
+    return v2
+}
+; run: %band_x_zero_f32(0x1.8p2) == 0x0.0
+
+function %band_zero_x_f32(f32) -> f32 {
+block0(v0: f32):
+    v1 = f32const 0.0
+    v2 = band v1, v0
+    return v2
+}
+; run: %band_zero_x_f32(0x1.8p2) == 0x0.0
+
+function %band_x_bnot_x_f32(f32) -> f32 {
+block0(v0: f32):
+    v1 = bnot v0
+    v2 = band v0, v1
+    return v2
+}
+; run: %band_x_bnot_x_f32(0x1.8p2) == 0x0.0
+
+function %band_bnot_x_x_f32(f32) -> f32 {
+block0(v0: f32):
+    v1 = bnot v0
+    v2 = band v1, v0
+    return v2
+}
+; run: %band_bnot_x_x_f32(0x1.8p2) == 0x0.0

--- a/cranelift/filetests/filetests/runtests/icmp.clif
+++ b/cranelift/filetests/filetests/runtests/icmp.clif
@@ -192,3 +192,71 @@ block0(v0: i32, v1: i32):
 }
 ; run: %test_ult_ne_minus_one(3, 5) == 1
 ; run: %test_ult_ne_minus_one(-1, 1) == 0
+
+function %eq_isub_zero(i32, i32) -> i8 {
+block0(v0: i32, v1: i32):
+    v2 = isub v0, v1
+    v3 = iconst.i32 0
+    v4 = icmp eq v2, v3
+    return v4
+}
+; run: %eq_isub_zero(7, 7) == 1
+; run: %eq_isub_zero(7, 3) == 0
+
+function %ne_isub_zero(i32, i32) -> i8 {
+block0(v0: i32, v1: i32):
+    v2 = isub v0, v1
+    v3 = iconst.i32 0
+    v4 = icmp ne v2, v3
+    return v4
+}
+; run: %ne_isub_zero(7, 7) == 0
+; run: %ne_isub_zero(7, 3) == 1
+
+function %eq_bxor_zero(i32, i32) -> i8 {
+block0(v0: i32, v1: i32):
+    v2 = bxor v0, v1
+    v3 = iconst.i32 0
+    v4 = icmp eq v2, v3
+    return v4
+}
+; run: %eq_bxor_zero(7, 7) == 1
+; run: %eq_bxor_zero(7, 3) == 0
+
+function %ne_bxor_zero(i32, i32) -> i8 {
+block0(v0: i32, v1: i32):
+    v2 = bxor v0, v1
+    v3 = iconst.i32 0
+    v4 = icmp ne v2, v3
+    return v4
+}
+; run: %ne_bxor_zero(7, 7) == 0
+; run: %ne_bxor_zero(7, 3) == 1
+
+function %eq_bxor_x(i32, i32) -> i8 {
+block0(v0: i32, v1: i32):
+    v2 = bxor v0, v1
+    v3 = icmp eq v2, v0
+    return v3
+}
+; run: %eq_bxor_x(7, 0) == 1
+; run: %eq_bxor_x(7, 3) == 0
+
+function %ne_iadd_x(i32, i32) -> i8 {
+block0(v0: i32, v1: i32):
+    v2 = iadd v0, v1
+    v3 = icmp ne v2, v0
+    return v3
+}
+; run: %ne_iadd_x(7, 0) == 0
+; run: %ne_iadd_x(7, 3) == 1
+
+function %ne_ineg(i32, i32) -> i8 {
+block0(v0: i32, v1: i32):
+    v2 = ineg v0
+    v3 = ineg v1
+    v4 = icmp ne v2, v3
+    return v4
+}
+; run: %ne_ineg(7, 7) == 0
+; run: %ne_ineg(7, 3) == 1

--- a/cranelift/filetests/filetests/runtests/select.clif
+++ b/cranelift/filetests/filetests/runtests/select.clif
@@ -599,3 +599,36 @@ block0(v0: i8, v1: i32, v2: i32):
 ; run: %select_eq_eq_to_eq_select_rt(1, 5, 5) == 1
 ; run: %select_eq_eq_to_eq_select_rt(1, 5, 7) == 0
 
+function %select_eq_zero_isub(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = icmp eq v0, v1
+    v3 = iconst.i32 0
+    v4 = isub v0, v1
+    v5 = select v2, v3, v4
+    return v5
+}
+; run: %select_eq_zero_isub(7, 7) == 0
+; run: %select_eq_zero_isub(7, 3) == 4
+; run: %select_eq_zero_isub(3, 7) == -4
+
+function %add_swapped_selects(i8, i32, i32) -> i32 {
+block0(v0: i8, v1: i32, v2: i32):
+    v3 = select v0, v1, v2
+    v4 = select v0, v2, v1
+    v5 = iadd v3, v4
+    return v5
+}
+; run: %add_swapped_selects(0, 7, 3) == 10
+; run: %add_swapped_selects(1, 7, 3) == 10
+
+function %select_ne_isub_zero(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = icmp ne v0, v1
+    v3 = isub v0, v1
+    v4 = iconst.i32 0
+    v5 = select v2, v3, v4
+    return v5
+}
+; run: %select_ne_isub_zero(7, 7) == 0
+; run: %select_ne_isub_zero(7, 3) == 4
+; run: %select_ne_isub_zero(3, 7) == -4


### PR DESCRIPTION
Add new opt rules:
- `(x - y) == 0 ==> x == y`
- `(x - y) != 0 ==> x != y`
- `(x ^ y) == 0 ==> x == y`
- `(x ^ y) != 0 ==> x != y`
- `(x ^ y) == x ==> y == 0`
- `(x + y) != x ==> y != 0`
- `x != -y ==> x != y`
- `(x == y) ? 0 : (x - y) ==> x - y`
- `(c ? y : z) + (c ? z : y) ==> z + y`
- `(x != y) ? (x - y) : 0 ==> x - y`

Apply `all_zero` helper for existing rules:
- `x & 0 == 0 & x == x & not(x) == not(x) & x == 0`