### PR TITLE
Bump Wasmtime to 50.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,7 +287,7 @@ dependencies = [
 
 [[package]]
 name = "byte-array-literals"
-version = "49.0.0-dev"
+version = "50.0.0-dev"
 
 [[package]]
 name = "byteorder"
@@ -649,7 +649,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.136.0-dev"
+version = "0.137.0-dev"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -662,7 +662,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.136.0-dev"
+version = "0.137.0-dev"
 dependencies = [
  "arbitrary",
  "arbtest",
@@ -681,14 +681,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.136.0-dev"
+version = "0.137.0-dev"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.136.0-dev"
+version = "0.137.0-dev"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -696,7 +696,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.136.0-dev"
+version = "0.137.0-dev"
 dependencies = [
  "arbitrary",
  "serde",
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.136.0-dev"
+version = "0.137.0-dev"
 dependencies = [
  "anyhow",
  "bumpalo",
@@ -743,7 +743,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.136.0-dev"
+version = "0.137.0-dev"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -754,18 +754,18 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.136.0-dev"
+version = "0.137.0-dev"
 
 [[package]]
 name = "cranelift-control"
-version = "0.136.0-dev"
+version = "0.137.0-dev"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.136.0-dev"
+version = "0.137.0-dev"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -807,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.136.0-dev"
+version = "0.137.0-dev"
 dependencies = [
  "cranelift-codegen",
  "env_logger 0.11.5",
@@ -832,7 +832,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.136.0-dev"
+version = "0.137.0-dev"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -846,7 +846,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.136.0-dev"
+version = "0.137.0-dev"
 dependencies = [
  "codespan-reporting",
  "log",
@@ -930,7 +930,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.136.0-dev"
+version = "0.137.0-dev"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.136.0-dev"
+version = "0.137.0-dev"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -964,7 +964,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.136.0-dev"
+version = "0.137.0-dev"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -973,7 +973,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.136.0-dev"
+version = "0.137.0-dev"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -989,7 +989,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-reader"
-version = "0.136.0-dev"
+version = "0.137.0-dev"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -999,7 +999,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.136.0-dev"
+version = "0.137.0-dev"
 dependencies = [
  "clap",
  "cranelift-codegen",
@@ -1009,7 +1009,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.136.0-dev"
+version = "0.137.0-dev"
 
 [[package]]
 name = "cranelift-tools"
@@ -1270,7 +1270,7 @@ checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "embedding"
-version = "49.0.0-dev"
+version = "50.0.0-dev"
 dependencies = [
  "dlmalloc",
  "raw-cpuid",
@@ -2435,7 +2435,7 @@ dependencies = [
 
 [[package]]
 name = "min-platform-host"
-version = "49.0.0-dev"
+version = "50.0.0-dev"
 dependencies = [
  "libloading",
  "object 0.40.0",
@@ -2960,7 +2960,7 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "49.0.0-dev"
+version = "50.0.0-dev"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -2984,7 +2984,7 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "49.0.0-dev"
+version = "50.0.0-dev"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4260,7 +4260,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "verify-component-adapter"
-version = "49.0.0-dev"
+version = "50.0.0-dev"
 dependencies = [
  "anyhow",
  "wasmparser 0.258.0",
@@ -4334,7 +4334,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter"
-version = "49.0.0-dev"
+version = "50.0.0-dev"
 dependencies = [
  "bitflags 2.11.1",
  "byte-array-literals",
@@ -4566,7 +4566,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "49.0.0-dev"
+version = "50.0.0-dev"
 dependencies = [
  "addr2line 0.26.0",
  "async-trait",
@@ -4627,7 +4627,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-bench-api"
-version = "49.0.0-dev"
+version = "50.0.0-dev"
 dependencies = [
  "clap",
  "shuffling-allocator",
@@ -4641,14 +4641,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api"
-version = "49.0.0-dev"
+version = "50.0.0-dev"
 dependencies = [
  "wasmtime-c-api-impl",
 ]
 
 [[package]]
 name = "wasmtime-c-api-impl"
-version = "49.0.0-dev"
+version = "50.0.0-dev"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4667,7 +4667,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "49.0.0-dev"
+version = "50.0.0-dev"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4744,7 +4744,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "49.0.0-dev"
+version = "50.0.0-dev"
 dependencies = [
  "clap",
  "file-per-thread-logger",
@@ -4758,7 +4758,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "49.0.0-dev"
+version = "50.0.0-dev"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -4875,7 +4875,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-c-api-macros"
-version = "49.0.0-dev"
+version = "50.0.0-dev"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4883,7 +4883,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "49.0.0-dev"
+version = "50.0.0-dev"
 dependencies = [
  "base64",
  "directories-next",
@@ -4904,7 +4904,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "49.0.0-dev"
+version = "50.0.0-dev"
 dependencies = [
  "anyhow",
  "component-macro-test-helpers",
@@ -4924,11 +4924,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "49.0.0-dev"
+version = "50.0.0-dev"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "49.0.0-dev"
+version = "50.0.0-dev"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.0",
@@ -4938,7 +4938,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "49.0.0-dev"
+version = "50.0.0-dev"
 dependencies = [
  "cranelift-codegen",
  "cranelift-control",
@@ -4962,7 +4962,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-debugger"
-version = "49.0.0-dev"
+version = "50.0.0-dev"
 dependencies = [
  "async-trait",
  "env_logger 0.11.5",
@@ -4975,7 +4975,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-explorer"
-version = "49.0.0-dev"
+version = "50.0.0-dev"
 dependencies = [
  "capstone",
  "serde",
@@ -4989,7 +4989,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "49.0.0-dev"
+version = "50.0.0-dev"
 dependencies = [
  "backtrace",
  "cc",
@@ -5002,7 +5002,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-gdbstub-component"
-version = "49.0.0-dev"
+version = "50.0.0-dev"
 dependencies = [
  "anyhow",
  "clap",
@@ -5018,11 +5018,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-gdbstub-component-artifact"
-version = "49.0.0-dev"
+version = "50.0.0-dev"
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "49.0.0-dev"
+version = "50.0.0-dev"
 dependencies = [
  "cc",
  "object 0.40.0",
@@ -5032,7 +5032,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "49.0.0-dev"
+version = "50.0.0-dev"
 dependencies = [
  "libc",
  "wasmtime-internal-core",
@@ -5041,7 +5041,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "49.0.0-dev"
+version = "50.0.0-dev"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -5051,7 +5051,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "49.0.0-dev"
+version = "50.0.0-dev"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5060,7 +5060,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-winch"
-version = "49.0.0-dev"
+version = "50.0.0-dev"
 dependencies = [
  "cranelift-codegen",
  "gimli 0.33.0",
@@ -5075,7 +5075,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "49.0.0-dev"
+version = "50.0.0-dev"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
@@ -5087,7 +5087,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-wmemcheck"
-version = "49.0.0-dev"
+version = "50.0.0-dev"
 
 [[package]]
 name = "wasmtime-publish"
@@ -5113,7 +5113,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-test-util"
-version = "49.0.0-dev"
+version = "50.0.0-dev"
 dependencies = [
  "arbitrary",
  "arbtest",
@@ -5136,7 +5136,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "49.0.0-dev"
+version = "50.0.0-dev"
 dependencies = [
  "async-trait",
  "bitflags 2.11.1",
@@ -5165,7 +5165,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-config"
-version = "49.0.0-dev"
+version = "50.0.0-dev"
 dependencies = [
  "test-programs-artifacts",
  "tokio",
@@ -5175,7 +5175,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "49.0.0-dev"
+version = "50.0.0-dev"
 dependencies = [
  "async-trait",
  "base64",
@@ -5208,7 +5208,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-io"
-version = "49.0.0-dev"
+version = "50.0.0-dev"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5219,7 +5219,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-keyvalue"
-version = "49.0.0-dev"
+version = "50.0.0-dev"
 dependencies = [
  "test-programs-artifacts",
  "tokio",
@@ -5229,7 +5229,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "49.0.0-dev"
+version = "50.0.0-dev"
 dependencies = [
  "libtest-mimic",
  "openvino",
@@ -5248,7 +5248,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-tls"
-version = "49.0.0-dev"
+version = "50.0.0-dev"
 dependencies = [
  "bytes",
  "futures",
@@ -5268,7 +5268,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "49.0.0-dev"
+version = "50.0.0-dev"
 dependencies = [
  "json-from-wast",
  "log",
@@ -5282,7 +5282,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wizer"
-version = "49.0.0-dev"
+version = "50.0.0-dev"
 dependencies = [
  "clap",
  "criterion",
@@ -5363,7 +5363,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "49.0.0-dev"
+version = "50.0.0-dev"
 dependencies = [
  "bitflags 2.11.1",
  "proptest",
@@ -5379,7 +5379,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "49.0.0-dev"
+version = "50.0.0-dev"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -5391,7 +5391,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "49.0.0-dev"
+version = "50.0.0-dev"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5446,7 +5446,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "49.0.0-dev"
+version = "50.0.0-dev"
 dependencies = [
  "cranelift-assembler-x64",
  "cranelift-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -220,7 +220,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "49.0.0-dev"
+version = "50.0.0-dev"
 authors = ["The Wasmtime Project Developers"]
 edition = "2024"
 # Wasmtime's current policy is that this number can be no larger than the
@@ -281,17 +281,17 @@ extra_unused_type_parameters = 'warn'
 # tooling but aren't intended to be widely depended on.
 #
 # All of these crates are supported though in the sense that
-wasmtime = { path = "crates/wasmtime", version = "49.0.0-dev", default-features = false }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=49.0.0-dev" }
-wasmtime-environ = { path = "crates/environ", version = "=49.0.0-dev" }
-wasmtime-wasi = { path = "crates/wasi", version = "49.0.0-dev", default-features = false }
-wasmtime-wasi-io = { path = "crates/wasi-io", version = "49.0.0-dev", default-features = false }
-wasmtime-wasi-http = { path = "crates/wasi-http", version = "49.0.0-dev", default-features = false }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "49.0.0-dev" }
-wasmtime-wasi-config = { path = "crates/wasi-config", version = "49.0.0-dev" }
-wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "49.0.0-dev" }
-wasmtime-wasi-tls = { path = "crates/wasi-tls", version = "49.0.0-dev" }
-wasmtime-wast = { path = "crates/wast", version = "=49.0.0-dev" }
+wasmtime = { path = "crates/wasmtime", version = "50.0.0-dev", default-features = false }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=50.0.0-dev" }
+wasmtime-environ = { path = "crates/environ", version = "=50.0.0-dev" }
+wasmtime-wasi = { path = "crates/wasi", version = "50.0.0-dev", default-features = false }
+wasmtime-wasi-io = { path = "crates/wasi-io", version = "50.0.0-dev", default-features = false }
+wasmtime-wasi-http = { path = "crates/wasi-http", version = "50.0.0-dev", default-features = false }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "50.0.0-dev" }
+wasmtime-wasi-config = { path = "crates/wasi-config", version = "50.0.0-dev" }
+wasmtime-wasi-keyvalue = { path = "crates/wasi-keyvalue", version = "50.0.0-dev" }
+wasmtime-wasi-tls = { path = "crates/wasi-tls", version = "50.0.0-dev" }
+wasmtime-wast = { path = "crates/wast", version = "=50.0.0-dev" }
 
 # Internal Wasmtime-specific crates.
 #
@@ -300,54 +300,54 @@ wasmtime-wast = { path = "crates/wast", version = "=49.0.0-dev" }
 # that these are internal unsupported crates for external use. These exist as
 # part of the project organization of other public crates in Wasmtime and are
 # otherwise not supported in terms of CVEs for example.
-wasmtime-core = { path = "crates/core", version = "=49.0.0-dev", package = 'wasmtime-internal-core' }
-wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=49.0.0-dev", package = 'wasmtime-internal-wmemcheck' }
-wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=49.0.0-dev", package = 'wasmtime-internal-c-api-macros' }
-wasmtime-cache = { path = "crates/cache", version = "=49.0.0-dev", package = 'wasmtime-internal-cache' }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=49.0.0-dev", package = 'wasmtime-internal-cranelift' }
-wasmtime-winch = { path = "crates/winch", version = "=49.0.0-dev", package = 'wasmtime-internal-winch'  }
-wasmtime-explorer = { path = "crates/explorer", version = "=49.0.0-dev", package = 'wasmtime-internal-explorer'  }
-wasmtime-fiber = { path = "crates/fiber", version = "=49.0.0-dev", package = 'wasmtime-internal-fiber' }
-wasmtime-jit-debug = { path = "crates/jit-debug", version = "=49.0.0-dev", package = 'wasmtime-internal-jit-debug' }
-wasmtime-component-util = { path = "crates/component-util", version = "=49.0.0-dev", package = 'wasmtime-internal-component-util' }
-wasmtime-component-macro = { path = "crates/component-macro", version = "=49.0.0-dev", package = 'wasmtime-internal-component-macro' }
-wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=49.0.0-dev", package = 'wasmtime-internal-versioned-export-macros' }
-wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=49.0.0-dev", package = 'wasmtime-internal-jit-icache-coherence' }
-wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=49.0.0-dev", package = 'wasmtime-internal-wit-bindgen' }
-wasmtime-unwinder = { path = "crates/unwinder", version = "=49.0.0-dev", package = 'wasmtime-internal-unwinder' }
-wasmtime-debugger = { path = "crates/debugger", version = "=49.0.0-dev", package = "wasmtime-internal-debugger" }
-gdbstub-component-artifact = { path = "crates/gdbstub-component/artifact", version = "=49.0.0-dev", package = "wasmtime-internal-gdbstub-component-artifact" }
-wasmtime-wizer = { path = "crates/wizer", version = "49.0.0-dev" }
+wasmtime-core = { path = "crates/core", version = "=50.0.0-dev", package = 'wasmtime-internal-core' }
+wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=50.0.0-dev", package = 'wasmtime-internal-wmemcheck' }
+wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=50.0.0-dev", package = 'wasmtime-internal-c-api-macros' }
+wasmtime-cache = { path = "crates/cache", version = "=50.0.0-dev", package = 'wasmtime-internal-cache' }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=50.0.0-dev", package = 'wasmtime-internal-cranelift' }
+wasmtime-winch = { path = "crates/winch", version = "=50.0.0-dev", package = 'wasmtime-internal-winch'  }
+wasmtime-explorer = { path = "crates/explorer", version = "=50.0.0-dev", package = 'wasmtime-internal-explorer'  }
+wasmtime-fiber = { path = "crates/fiber", version = "=50.0.0-dev", package = 'wasmtime-internal-fiber' }
+wasmtime-jit-debug = { path = "crates/jit-debug", version = "=50.0.0-dev", package = 'wasmtime-internal-jit-debug' }
+wasmtime-component-util = { path = "crates/component-util", version = "=50.0.0-dev", package = 'wasmtime-internal-component-util' }
+wasmtime-component-macro = { path = "crates/component-macro", version = "=50.0.0-dev", package = 'wasmtime-internal-component-macro' }
+wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=50.0.0-dev", package = 'wasmtime-internal-versioned-export-macros' }
+wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=50.0.0-dev", package = 'wasmtime-internal-jit-icache-coherence' }
+wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=50.0.0-dev", package = 'wasmtime-internal-wit-bindgen' }
+wasmtime-unwinder = { path = "crates/unwinder", version = "=50.0.0-dev", package = 'wasmtime-internal-unwinder' }
+wasmtime-debugger = { path = "crates/debugger", version = "=50.0.0-dev", package = "wasmtime-internal-debugger" }
+gdbstub-component-artifact = { path = "crates/gdbstub-component/artifact", version = "=50.0.0-dev", package = "wasmtime-internal-gdbstub-component-artifact" }
+wasmtime-wizer = { path = "crates/wizer", version = "50.0.0-dev" }
 
 # Miscellaneous crates without a `wasmtime-*` prefix in their name but still
 # used in the `wasmtime-*` family of crates depending on various features/etc.
-wiggle = { path = "crates/wiggle", version = "=49.0.0-dev", default-features = false }
-wiggle-macro = { path = "crates/wiggle/macro", version = "=49.0.0-dev" }
-wiggle-generate = { path = "crates/wiggle/generate", version = "=49.0.0-dev" }
-pulley-interpreter = { path = 'pulley', version = "=49.0.0-dev" }
-pulley-macros = { path = 'pulley/macros', version = "=49.0.0-dev" }
+wiggle = { path = "crates/wiggle", version = "=50.0.0-dev", default-features = false }
+wiggle-macro = { path = "crates/wiggle/macro", version = "=50.0.0-dev" }
+wiggle-generate = { path = "crates/wiggle/generate", version = "=50.0.0-dev" }
+pulley-interpreter = { path = 'pulley', version = "=50.0.0-dev" }
+pulley-macros = { path = 'pulley/macros', version = "=50.0.0-dev" }
 
 # Cranelift crates in this workspace
-cranelift-assembler-x64 = { path = "cranelift/assembler-x64", version = "0.136.0-dev" }
-cranelift-codegen = { path = "cranelift/codegen", version = "0.136.0-dev", default-features = false, features = ["unwind"] }
-cranelift-frontend = { path = "cranelift/frontend", version = "0.136.0-dev" }
-cranelift-entity = { path = "cranelift/entity", version = "0.136.0-dev" }
-cranelift-native = { path = "cranelift/native", version = "0.136.0-dev" }
-cranelift-module = { path = "cranelift/module", version = "0.136.0-dev" }
-cranelift-interpreter = { path = "cranelift/interpreter", version = "0.136.0-dev" }
-cranelift-reader = { path = "cranelift/reader", version = "0.136.0-dev" }
+cranelift-assembler-x64 = { path = "cranelift/assembler-x64", version = "0.137.0-dev" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.137.0-dev", default-features = false, features = ["unwind"] }
+cranelift-frontend = { path = "cranelift/frontend", version = "0.137.0-dev" }
+cranelift-entity = { path = "cranelift/entity", version = "0.137.0-dev" }
+cranelift-native = { path = "cranelift/native", version = "0.137.0-dev" }
+cranelift-module = { path = "cranelift/module", version = "0.137.0-dev" }
+cranelift-interpreter = { path = "cranelift/interpreter", version = "0.137.0-dev" }
+cranelift-reader = { path = "cranelift/reader", version = "0.137.0-dev" }
 cranelift-filetests = { path = "cranelift/filetests" }
-cranelift-object = { path = "cranelift/object", version = "0.136.0-dev" }
-cranelift-jit = { path = "cranelift/jit", version = "0.136.0-dev" }
+cranelift-object = { path = "cranelift/object", version = "0.137.0-dev" }
+cranelift-jit = { path = "cranelift/jit", version = "0.137.0-dev" }
 cranelift-fuzzgen = { path = "cranelift/fuzzgen" }
-cranelift-bforest = { path = "cranelift/bforest", version = "0.136.0-dev" }
-cranelift-bitset = { path = "cranelift/bitset", version = "0.136.0-dev" }
-cranelift-control = { path = "cranelift/control", version = "0.136.0-dev", default-features = false }
-cranelift-srcgen = { path = "cranelift/srcgen", version = "0.136.0-dev" }
-cranelift = { path = "cranelift/umbrella", version = "0.136.0-dev" }
+cranelift-bforest = { path = "cranelift/bforest", version = "0.137.0-dev" }
+cranelift-bitset = { path = "cranelift/bitset", version = "0.137.0-dev" }
+cranelift-control = { path = "cranelift/control", version = "0.137.0-dev", default-features = false }
+cranelift-srcgen = { path = "cranelift/srcgen", version = "0.137.0-dev" }
+cranelift = { path = "cranelift/umbrella", version = "0.137.0-dev" }
 
 # Winch crates in this workspace.
-winch-codegen = { path = "winch/codegen", version = "=49.0.0-dev" }
+winch-codegen = { path = "winch/codegen", version = "=50.0.0-dev" }
 
 # Internal crates not published to crates.io used in testing, builds, etc
 wasi-preview1-component-adapter = { path = "crates/wasi-preview1-component-adapter" }

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,4 +1,4 @@
-## 49.0.0
+## 50.0.0
 
 Unreleased.
 
@@ -6,19 +6,13 @@ Unreleased.
 
 ### Changed
 
-* `Config::operator_cost` now applies to operators inside constant expressions
-  (global initializers, element and data segment offsets, element segment
-  expressions) and to the synthesized call to a module's `start` function.
-  Previously each of those was charged 1 fuel unit regardless of the configured
-  cost.
-  [#14215](https://github.com/bytecodealliance/wasmtime/pull/14215)
-
 --------------------------------------------------------------------------------
 
 Release notes for previous releases of Wasmtime can be found on the respective
 release branches of the Wasmtime repository.
 
 <!-- ARCHIVE_START -->
+* [49.0.x](https://github.com/bytecodealliance/wasmtime/blob/release-49.0.0/RELEASES.md)
 * [48.0.x](https://github.com/bytecodealliance/wasmtime/blob/release-48.0.0/RELEASES.md)
 * [47.0.x](https://github.com/bytecodealliance/wasmtime/blob/release-47.0.0/RELEASES.md)
 * [46.0.x](https://github.com/bytecodealliance/wasmtime/blob/release-46.0.0/RELEASES.md)

--- a/cranelift/assembler-x64/Cargo.toml
+++ b/cranelift/assembler-x64/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-assembler-x64"
 description = "A Cranelift-specific x64 assembler"
-version = "0.136.0-dev"
+version = "0.137.0-dev"
 license = "Apache-2.0 WITH LLVM-exception"
 edition.workspace = true
 rust-version.workspace = true
@@ -25,7 +25,7 @@ arbtest = { workspace = true }
 capstone = { workspace = true }
 
 [build-dependencies]
-cranelift-assembler-x64-meta = { path = "meta", version = "0.136.0-dev" }
+cranelift-assembler-x64-meta = { path = "meta", version = "0.137.0-dev" }
 
 [lints]
 workspace = true

--- a/cranelift/assembler-x64/meta/Cargo.toml
+++ b/cranelift/assembler-x64/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-assembler-x64-meta"
 description = "Generate a Cranelift-specific assembler for x64 instructions"
-version = "0.136.0-dev"
+version = "0.137.0-dev"
 license = "Apache-2.0 WITH LLVM-exception"
 edition.workspace = true
 rust-version.workspace = true

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.136.0-dev"
+version = "0.137.0-dev"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"

--- a/cranelift/bitset/Cargo.toml
+++ b/cranelift/bitset/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bitset"
-version = "0.136.0-dev"
+version = "0.137.0-dev"
 description = "Various bitset stuff for use inside Cranelift"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bitset"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.136.0-dev"
+version = "0.137.0-dev"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -25,7 +25,7 @@ anyhow = { workspace = true, optional = true, features = ['std'] }
 bumpalo = { workspace = true }
 capstone = { workspace = true, optional = true }
 cranelift-assembler-x64 = { workspace = true }
-cranelift-codegen-shared = { path = "./shared", version = "0.136.0-dev" }
+cranelift-codegen-shared = { path = "./shared", version = "0.137.0-dev" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
 cranelift-bitset = { workspace = true }
@@ -58,8 +58,8 @@ proptest = { workspace = true }
 mutatis = { workspace = true }
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.136.0-dev" }
-cranelift-isle = { path = "../isle/isle", version = "=0.136.0-dev" }
+cranelift-codegen-meta = { path = "meta", version = "0.137.0-dev" }
+cranelift-isle = { path = "../isle/isle", version = "=0.137.0-dev" }
 
 [features]
 default = ["std", "unwind", "host-arch", "timing"]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.136.0-dev"
+version = "0.137.0-dev"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -17,8 +17,8 @@ rustdoc-args = ["--document-private-items"]
 
 [dependencies]
 cranelift-srcgen = { workspace = true }
-cranelift-assembler-x64-meta = { path = "../../assembler-x64/meta", version = "0.136.0-dev" }
-cranelift-codegen-shared = { path = "../shared", version = "0.136.0-dev" }
+cranelift-assembler-x64-meta = { path = "../../assembler-x64/meta", version = "0.137.0-dev" }
+cranelift-codegen-shared = { path = "../shared", version = "0.137.0-dev" }
 pulley-interpreter = { workspace = true, optional = true }
 heck = "0.5.0"
 

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.136.0-dev"
+version = "0.137.0-dev"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/control/Cargo.toml
+++ b/cranelift/control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-control"
-version = "0.136.0-dev"
+version = "0.137.0-dev"
 description = "White-box fuzz testing framework"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.136.0-dev"
+version = "0.137.0-dev"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.136.0-dev"
+version = "0.137.0-dev"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.136.0-dev"
+version = "0.137.0-dev"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
-version = "0.136.0-dev"
+version = "0.137.0-dev"
 
 [lints]
 workspace = true

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.136.0-dev"
+version = "0.137.0-dev"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.136.0-dev"
+version = "0.137.0-dev"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.136.0-dev"
+version = "0.137.0-dev"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.136.0-dev"
+version = "0.137.0-dev"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.136.0-dev"
+version = "0.137.0-dev"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.136.0-dev"
+version = "0.137.0-dev"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/srcgen/Cargo.toml
+++ b/cranelift/srcgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-srcgen"
-version = "0.136.0-dev"
+version = "0.137.0-dev"
 authors = ["The Wasmtime Project Developers"]
 description = "Helper functions for generating Rust and ISLE files"
 license = "Apache-2.0 WITH LLVM-exception"

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.136.0-dev"
+version = "0.137.0-dev"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -229,11 +229,11 @@
 /**
  * \brief Wasmtime version string.
  */
-#define WASMTIME_VERSION "49.0.0-dev"
+#define WASMTIME_VERSION "50.0.0-dev"
 /**
  * \brief Wasmtime major version number.
  */
-#define WASMTIME_VERSION_MAJOR 49
+#define WASMTIME_VERSION_MAJOR 50
 /**
  * \brief Wasmtime minor version number.
  */

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -5,221 +5,441 @@
 version = "0.136.0-dev"
 audited_as = "0.134.3"
 
+[[unpublished.cranelift]]
+version = "0.137.0-dev"
+audited_as = "0.135.1"
+
 [[unpublished.cranelift-assembler-x64]]
 version = "0.136.0-dev"
 audited_as = "0.134.3"
+
+[[unpublished.cranelift-assembler-x64]]
+version = "0.137.0-dev"
+audited_as = "0.135.1"
 
 [[unpublished.cranelift-assembler-x64-meta]]
 version = "0.136.0-dev"
 audited_as = "0.134.3"
 
+[[unpublished.cranelift-assembler-x64-meta]]
+version = "0.137.0-dev"
+audited_as = "0.135.1"
+
 [[unpublished.cranelift-bforest]]
 version = "0.136.0-dev"
 audited_as = "0.134.3"
+
+[[unpublished.cranelift-bforest]]
+version = "0.137.0-dev"
+audited_as = "0.135.1"
 
 [[unpublished.cranelift-bitset]]
 version = "0.136.0-dev"
 audited_as = "0.134.3"
 
+[[unpublished.cranelift-bitset]]
+version = "0.137.0-dev"
+audited_as = "0.135.1"
+
 [[unpublished.cranelift-codegen]]
 version = "0.136.0-dev"
 audited_as = "0.134.3"
+
+[[unpublished.cranelift-codegen]]
+version = "0.137.0-dev"
+audited_as = "0.135.1"
 
 [[unpublished.cranelift-codegen-meta]]
 version = "0.136.0-dev"
 audited_as = "0.134.3"
 
+[[unpublished.cranelift-codegen-meta]]
+version = "0.137.0-dev"
+audited_as = "0.135.1"
+
 [[unpublished.cranelift-codegen-shared]]
 version = "0.136.0-dev"
 audited_as = "0.134.3"
+
+[[unpublished.cranelift-codegen-shared]]
+version = "0.137.0-dev"
+audited_as = "0.135.1"
 
 [[unpublished.cranelift-control]]
 version = "0.136.0-dev"
 audited_as = "0.134.3"
 
+[[unpublished.cranelift-control]]
+version = "0.137.0-dev"
+audited_as = "0.135.1"
+
 [[unpublished.cranelift-entity]]
 version = "0.136.0-dev"
 audited_as = "0.134.3"
+
+[[unpublished.cranelift-entity]]
+version = "0.137.0-dev"
+audited_as = "0.135.1"
 
 [[unpublished.cranelift-frontend]]
 version = "0.136.0-dev"
 audited_as = "0.134.3"
 
+[[unpublished.cranelift-frontend]]
+version = "0.137.0-dev"
+audited_as = "0.135.1"
+
 [[unpublished.cranelift-interpreter]]
 version = "0.136.0-dev"
 audited_as = "0.134.3"
+
+[[unpublished.cranelift-interpreter]]
+version = "0.137.0-dev"
+audited_as = "0.135.1"
 
 [[unpublished.cranelift-isle]]
 version = "0.136.0-dev"
 audited_as = "0.134.3"
 
+[[unpublished.cranelift-isle]]
+version = "0.137.0-dev"
+audited_as = "0.135.1"
+
 [[unpublished.cranelift-jit]]
 version = "0.136.0-dev"
 audited_as = "0.134.3"
+
+[[unpublished.cranelift-jit]]
+version = "0.137.0-dev"
+audited_as = "0.135.1"
 
 [[unpublished.cranelift-module]]
 version = "0.136.0-dev"
 audited_as = "0.134.3"
 
+[[unpublished.cranelift-module]]
+version = "0.137.0-dev"
+audited_as = "0.135.1"
+
 [[unpublished.cranelift-native]]
 version = "0.136.0-dev"
 audited_as = "0.134.3"
+
+[[unpublished.cranelift-native]]
+version = "0.137.0-dev"
+audited_as = "0.135.1"
 
 [[unpublished.cranelift-object]]
 version = "0.136.0-dev"
 audited_as = "0.134.3"
 
+[[unpublished.cranelift-object]]
+version = "0.137.0-dev"
+audited_as = "0.135.1"
+
 [[unpublished.cranelift-reader]]
 version = "0.136.0-dev"
 audited_as = "0.134.3"
+
+[[unpublished.cranelift-reader]]
+version = "0.137.0-dev"
+audited_as = "0.135.1"
 
 [[unpublished.cranelift-serde]]
 version = "0.136.0-dev"
 audited_as = "0.134.3"
 
+[[unpublished.cranelift-serde]]
+version = "0.137.0-dev"
+audited_as = "0.135.1"
+
 [[unpublished.cranelift-srcgen]]
 version = "0.136.0-dev"
 audited_as = "0.134.3"
+
+[[unpublished.cranelift-srcgen]]
+version = "0.137.0-dev"
+audited_as = "0.135.1"
 
 [[unpublished.pulley-interpreter]]
 version = "49.0.0-dev"
 audited_as = "47.0.3"
 
+[[unpublished.pulley-interpreter]]
+version = "50.0.0-dev"
+audited_as = "48.0.1"
+
 [[unpublished.pulley-macros]]
 version = "49.0.0-dev"
 audited_as = "47.0.3"
+
+[[unpublished.pulley-macros]]
+version = "50.0.0-dev"
+audited_as = "48.0.1"
 
 [[unpublished.wasmtime]]
 version = "49.0.0-dev"
 audited_as = "47.0.3"
 
+[[unpublished.wasmtime]]
+version = "50.0.0-dev"
+audited_as = "48.0.1"
+
 [[unpublished.wasmtime-cli]]
 version = "49.0.0-dev"
 audited_as = "47.0.3"
+
+[[unpublished.wasmtime-cli]]
+version = "50.0.0-dev"
+audited_as = "48.0.1"
 
 [[unpublished.wasmtime-cli-flags]]
 version = "49.0.0-dev"
 audited_as = "47.0.3"
 
+[[unpublished.wasmtime-cli-flags]]
+version = "50.0.0-dev"
+audited_as = "48.0.1"
+
 [[unpublished.wasmtime-environ]]
 version = "49.0.0-dev"
 audited_as = "47.0.3"
+
+[[unpublished.wasmtime-environ]]
+version = "50.0.0-dev"
+audited_as = "48.0.1"
 
 [[unpublished.wasmtime-internal-c-api-macros]]
 version = "49.0.0-dev"
 audited_as = "47.0.3"
 
+[[unpublished.wasmtime-internal-c-api-macros]]
+version = "50.0.0-dev"
+audited_as = "48.0.1"
+
 [[unpublished.wasmtime-internal-cache]]
 version = "49.0.0-dev"
 audited_as = "47.0.3"
+
+[[unpublished.wasmtime-internal-cache]]
+version = "50.0.0-dev"
+audited_as = "48.0.1"
 
 [[unpublished.wasmtime-internal-component-macro]]
 version = "49.0.0-dev"
 audited_as = "47.0.3"
 
+[[unpublished.wasmtime-internal-component-macro]]
+version = "50.0.0-dev"
+audited_as = "48.0.1"
+
 [[unpublished.wasmtime-internal-component-util]]
 version = "49.0.0-dev"
 audited_as = "47.0.3"
+
+[[unpublished.wasmtime-internal-component-util]]
+version = "50.0.0-dev"
+audited_as = "48.0.1"
 
 [[unpublished.wasmtime-internal-core]]
 version = "49.0.0-dev"
 audited_as = "47.0.3"
 
+[[unpublished.wasmtime-internal-core]]
+version = "50.0.0-dev"
+audited_as = "48.0.1"
+
 [[unpublished.wasmtime-internal-cranelift]]
 version = "49.0.0-dev"
 audited_as = "47.0.3"
+
+[[unpublished.wasmtime-internal-cranelift]]
+version = "50.0.0-dev"
+audited_as = "48.0.1"
 
 [[unpublished.wasmtime-internal-debugger]]
 version = "49.0.0-dev"
 audited_as = "47.0.3"
 
+[[unpublished.wasmtime-internal-debugger]]
+version = "50.0.0-dev"
+audited_as = "48.0.1"
+
 [[unpublished.wasmtime-internal-explorer]]
 version = "49.0.0-dev"
 audited_as = "47.0.3"
+
+[[unpublished.wasmtime-internal-explorer]]
+version = "50.0.0-dev"
+audited_as = "48.0.1"
 
 [[unpublished.wasmtime-internal-fiber]]
 version = "49.0.0-dev"
 audited_as = "47.0.3"
 
+[[unpublished.wasmtime-internal-fiber]]
+version = "50.0.0-dev"
+audited_as = "48.0.1"
+
 [[unpublished.wasmtime-internal-gdbstub-component-artifact]]
 version = "49.0.0-dev"
 audited_as = "47.0.3"
+
+[[unpublished.wasmtime-internal-gdbstub-component-artifact]]
+version = "50.0.0-dev"
+audited_as = "48.0.1"
 
 [[unpublished.wasmtime-internal-jit-debug]]
 version = "49.0.0-dev"
 audited_as = "47.0.3"
 
+[[unpublished.wasmtime-internal-jit-debug]]
+version = "50.0.0-dev"
+audited_as = "48.0.1"
+
 [[unpublished.wasmtime-internal-jit-icache-coherence]]
 version = "49.0.0-dev"
 audited_as = "47.0.3"
+
+[[unpublished.wasmtime-internal-jit-icache-coherence]]
+version = "50.0.0-dev"
+audited_as = "48.0.1"
 
 [[unpublished.wasmtime-internal-unwinder]]
 version = "49.0.0-dev"
 audited_as = "47.0.3"
 
+[[unpublished.wasmtime-internal-unwinder]]
+version = "50.0.0-dev"
+audited_as = "48.0.1"
+
 [[unpublished.wasmtime-internal-versioned-export-macros]]
 version = "49.0.0-dev"
 audited_as = "47.0.3"
+
+[[unpublished.wasmtime-internal-versioned-export-macros]]
+version = "50.0.0-dev"
+audited_as = "48.0.1"
 
 [[unpublished.wasmtime-internal-winch]]
 version = "49.0.0-dev"
 audited_as = "47.0.3"
 
+[[unpublished.wasmtime-internal-winch]]
+version = "50.0.0-dev"
+audited_as = "48.0.1"
+
 [[unpublished.wasmtime-internal-wit-bindgen]]
 version = "49.0.0-dev"
 audited_as = "47.0.3"
+
+[[unpublished.wasmtime-internal-wit-bindgen]]
+version = "50.0.0-dev"
+audited_as = "48.0.1"
 
 [[unpublished.wasmtime-internal-wmemcheck]]
 version = "49.0.0-dev"
 audited_as = "47.0.3"
 
+[[unpublished.wasmtime-internal-wmemcheck]]
+version = "50.0.0-dev"
+audited_as = "48.0.1"
+
 [[unpublished.wasmtime-wasi]]
 version = "49.0.0-dev"
 audited_as = "47.0.3"
+
+[[unpublished.wasmtime-wasi]]
+version = "50.0.0-dev"
+audited_as = "48.0.1"
 
 [[unpublished.wasmtime-wasi-config]]
 version = "49.0.0-dev"
 audited_as = "47.0.3"
 
+[[unpublished.wasmtime-wasi-config]]
+version = "50.0.0-dev"
+audited_as = "48.0.1"
+
 [[unpublished.wasmtime-wasi-http]]
 version = "49.0.0-dev"
 audited_as = "47.0.3"
+
+[[unpublished.wasmtime-wasi-http]]
+version = "50.0.0-dev"
+audited_as = "48.0.1"
 
 [[unpublished.wasmtime-wasi-io]]
 version = "49.0.0-dev"
 audited_as = "47.0.3"
 
+[[unpublished.wasmtime-wasi-io]]
+version = "50.0.0-dev"
+audited_as = "48.0.1"
+
 [[unpublished.wasmtime-wasi-keyvalue]]
 version = "49.0.0-dev"
 audited_as = "47.0.3"
+
+[[unpublished.wasmtime-wasi-keyvalue]]
+version = "50.0.0-dev"
+audited_as = "48.0.1"
 
 [[unpublished.wasmtime-wasi-nn]]
 version = "49.0.0-dev"
 audited_as = "47.0.3"
 
+[[unpublished.wasmtime-wasi-nn]]
+version = "50.0.0-dev"
+audited_as = "48.0.1"
+
 [[unpublished.wasmtime-wasi-tls]]
 version = "49.0.0-dev"
 audited_as = "47.0.3"
+
+[[unpublished.wasmtime-wasi-tls]]
+version = "50.0.0-dev"
+audited_as = "48.0.1"
 
 [[unpublished.wasmtime-wast]]
 version = "49.0.0-dev"
 audited_as = "47.0.3"
 
+[[unpublished.wasmtime-wast]]
+version = "50.0.0-dev"
+audited_as = "48.0.1"
+
 [[unpublished.wasmtime-wizer]]
 version = "49.0.0-dev"
 audited_as = "47.0.3"
+
+[[unpublished.wasmtime-wizer]]
+version = "50.0.0-dev"
+audited_as = "48.0.1"
 
 [[unpublished.wiggle]]
 version = "49.0.0-dev"
 audited_as = "47.0.3"
 
+[[unpublished.wiggle]]
+version = "50.0.0-dev"
+audited_as = "48.0.1"
+
 [[unpublished.wiggle-generate]]
 version = "49.0.0-dev"
 audited_as = "47.0.3"
 
+[[unpublished.wiggle-generate]]
+version = "50.0.0-dev"
+audited_as = "48.0.1"
+
 [[unpublished.wiggle-macro]]
 version = "49.0.0-dev"
 audited_as = "47.0.3"
+
+[[unpublished.wiggle-macro]]
+version = "50.0.0-dev"
+audited_as = "48.0.1"
 
 [[unpublished.wiggle-test]]
 version = "0.0.0"
@@ -228,6 +448,10 @@ audited_as = "0.1.0"
 [[unpublished.winch-codegen]]
 version = "49.0.0-dev"
 audited_as = "47.0.3"
+
+[[unpublished.winch-codegen]]
+version = "50.0.0-dev"
+audited_as = "48.0.1"
 
 [[publisher.aho-corasick]]
 version = "1.0.2"
@@ -411,103 +635,103 @@ user-login = "jrmuizel"
 user-name = "Jeff Muizelaar"
 
 [[publisher.cranelift]]
-version = "0.134.3"
-when = "2026-07-31"
+version = "0.135.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-assembler-x64]]
-version = "0.134.3"
-when = "2026-07-31"
+version = "0.135.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-assembler-x64-meta]]
-version = "0.134.3"
-when = "2026-07-31"
+version = "0.135.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-bforest]]
-version = "0.134.3"
-when = "2026-07-31"
+version = "0.135.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-bitset]]
-version = "0.134.3"
-when = "2026-07-31"
+version = "0.135.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-codegen]]
-version = "0.134.3"
-when = "2026-07-31"
+version = "0.135.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-codegen-meta]]
-version = "0.134.3"
-when = "2026-07-31"
+version = "0.135.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-codegen-shared]]
-version = "0.134.3"
-when = "2026-07-31"
+version = "0.135.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-control]]
-version = "0.134.3"
-when = "2026-07-31"
+version = "0.135.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-entity]]
-version = "0.134.3"
-when = "2026-07-31"
+version = "0.135.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-frontend]]
-version = "0.134.3"
-when = "2026-07-31"
+version = "0.135.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-interpreter]]
-version = "0.134.3"
-when = "2026-07-31"
+version = "0.135.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-isle]]
-version = "0.134.3"
-when = "2026-07-31"
+version = "0.135.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-jit]]
-version = "0.134.3"
-when = "2026-07-31"
+version = "0.135.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-module]]
-version = "0.134.3"
-when = "2026-07-31"
+version = "0.135.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-native]]
-version = "0.134.3"
-when = "2026-07-31"
+version = "0.135.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-object]]
-version = "0.134.3"
-when = "2026-07-31"
+version = "0.135.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-reader]]
-version = "0.134.3"
-when = "2026-07-31"
+version = "0.135.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-serde]]
-version = "0.134.3"
-when = "2026-07-31"
+version = "0.135.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.cranelift-srcgen]]
-version = "0.134.3"
-when = "2026-07-31"
+version = "0.135.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.derive_arbitrary]]
@@ -846,13 +1070,13 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.pulley-interpreter]]
-version = "47.0.3"
-when = "2026-07-31"
+version = "48.0.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.pulley-macros]]
-version = "47.0.3"
-when = "2026-07-31"
+version = "48.0.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.quote]]
@@ -1245,153 +1469,153 @@ when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wasmtime]]
-version = "47.0.3"
-when = "2026-07-31"
+version = "48.0.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-cli]]
-version = "47.0.3"
-when = "2026-07-31"
+version = "48.0.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-cli-flags]]
-version = "47.0.3"
-when = "2026-07-31"
+version = "48.0.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-environ]]
-version = "47.0.3"
-when = "2026-07-31"
+version = "48.0.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-c-api-macros]]
-version = "47.0.3"
-when = "2026-07-31"
+version = "48.0.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-cache]]
-version = "47.0.3"
-when = "2026-07-31"
+version = "48.0.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-component-macro]]
-version = "47.0.3"
-when = "2026-07-31"
+version = "48.0.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-component-util]]
-version = "47.0.3"
-when = "2026-07-31"
+version = "48.0.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-core]]
-version = "47.0.3"
-when = "2026-07-31"
+version = "48.0.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-cranelift]]
-version = "47.0.3"
-when = "2026-07-31"
+version = "48.0.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-debugger]]
-version = "47.0.3"
-when = "2026-07-31"
+version = "48.0.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-explorer]]
-version = "47.0.3"
-when = "2026-07-31"
+version = "48.0.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-fiber]]
-version = "47.0.3"
-when = "2026-07-31"
+version = "48.0.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-gdbstub-component-artifact]]
-version = "47.0.3"
-when = "2026-07-31"
+version = "48.0.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-jit-debug]]
-version = "47.0.3"
-when = "2026-07-31"
+version = "48.0.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-jit-icache-coherence]]
-version = "47.0.3"
-when = "2026-07-31"
+version = "48.0.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-unwinder]]
-version = "47.0.3"
-when = "2026-07-31"
+version = "48.0.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-versioned-export-macros]]
-version = "47.0.3"
-when = "2026-07-31"
+version = "48.0.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-winch]]
-version = "47.0.3"
-when = "2026-07-31"
+version = "48.0.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-wit-bindgen]]
-version = "47.0.3"
-when = "2026-07-31"
+version = "48.0.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-internal-wmemcheck]]
-version = "47.0.3"
-when = "2026-07-31"
+version = "48.0.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi]]
-version = "47.0.3"
-when = "2026-07-31"
+version = "48.0.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-config]]
-version = "47.0.3"
-when = "2026-07-31"
+version = "48.0.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-http]]
-version = "47.0.3"
-when = "2026-07-31"
+version = "48.0.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-io]]
-version = "47.0.3"
-when = "2026-07-31"
+version = "48.0.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-keyvalue]]
-version = "47.0.3"
-when = "2026-07-31"
+version = "48.0.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-nn]]
-version = "47.0.3"
-when = "2026-07-31"
+version = "48.0.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wasi-tls]]
-version = "47.0.3"
-when = "2026-07-31"
+version = "48.0.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wast]]
-version = "47.0.3"
-when = "2026-07-31"
+version = "48.0.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wasmtime-wizer]]
-version = "47.0.3"
-when = "2026-07-31"
+version = "48.0.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wast]]
@@ -1405,18 +1629,18 @@ when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasm-tools"
 
 [[publisher.wiggle]]
-version = "47.0.3"
-when = "2026-07-31"
+version = "48.0.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wiggle-generate]]
-version = "47.0.3"
-when = "2026-07-31"
+version = "48.0.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wiggle-macro]]
-version = "47.0.3"
-when = "2026-07-31"
+version = "48.0.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.wiggle-test]]
@@ -1434,8 +1658,8 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.winch-codegen]]
-version = "47.0.3"
-when = "2026-07-31"
+version = "48.0.1"
+when = "2026-08-24"
 trusted-publisher = "github:bytecodealliance/wasmtime"
 
 [[publisher.windows]]


### PR DESCRIPTION
This is an [automated pull request][process] from CI which indicates that the next [`release-49.0.0` branch][branch] has been created and the `main` branch is getting its version number bumped from 49.0.0 to 50.0.0.

Maintainers should take a moment to review the [release notes][RELEASES.md] for 49.0.0 and any updates should be made directly to the [release branch][branch].

A second automated PR has been opened against the [release branch][branch] to publish `49.0.0-rc.1` as a release candidate, and another automated PR will be made in roughly 2 weeks time for the actual release itself.

If any issues arise on the `main` branch before the release is made then the issue should first be fixed on `main` and then backport to the `release-49.0.0` branch.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/release-49.0.0/RELEASES.md
[branch]: https://github.com/bytecodealliance/wasmtime/tree/release-49.0.0
[process]: https://docs.wasmtime.dev/contributing-release-process.html
