### PR TITLE
Cranelift: add/modify mid-end opt rules

### DIFF
--- a/cranelift/codegen/src/opts/arithmetic.isle
+++ b/cranelift/codegen/src/opts/arithmetic.isle
@@ -7,16 +7,16 @@
 ;; x+0 == x.
 (rule iadd_x_plus_zero (simplify (iadd ty
                       x
-                      (iconst_u ty 0)))
+                      (all_zero ty)))
       (subsume x))
 ;; x-0 == x.
 (rule (simplify (isub ty
                       x
-                      (iconst_u ty 0)))
+                      (all_zero ty)))
       (subsume x))
 ;; 0-x == (ineg x).
 (rule (simplify (isub ty
-                      (iconst_u ty 0)
+                      (all_zero ty)
                       x))
       (ineg ty x))
 
@@ -47,7 +47,7 @@
       (subsume inner))
 
 ;; x-x == 0.
-(rule (simplify (isub ty x x)) (subsume (iconst_u ty 0)))
+(rule (simplify (isub ty x x)) (subsume (all_zero ty)))
 
 ;; x*1 == x.
 (rule (simplify (imul ty
@@ -58,7 +58,7 @@
 ;; x*0 == 0.
 (rule (simplify (imul ty
                       _
-                      zero @ (iconst_u ty 0)))
+                      zero @ (all_zero ty)))
       (subsume zero))
 
 ;; x*-1 == ineg(x).
@@ -127,9 +127,9 @@
       (apply_div_const_magic_s64 (Opcode.Sdiv) x d))
 
 ;; x % 1 == 0
-(rule (simplify_skeleton (urem x (iconst_u ty 1))) (iconst_u ty 0))
-(rule (simplify_skeleton (srem x (iconst_u ty 1))) (iconst_u ty 0))
-(rule (simplify_skeleton (srem x (iconst_s ty -1))) (iconst_u ty 0))
+(rule (simplify_skeleton (urem x (iconst_u ty 1))) (all_zero ty))
+(rule (simplify_skeleton (srem x (iconst_u ty 1))) (all_zero ty))
+(rule (simplify_skeleton (srem x (iconst_s ty -1))) (all_zero ty))
 
 ;; Unsigned `x % d == x & ((1 << ilog2(d)) - 1)` when `d` is a power of two.
 (rule (simplify_skeleton (urem x (iconst_u ty (u64_extract_power_of_two d))))
@@ -340,7 +340,7 @@
 (rule (simplify (isub ty (iadd ty y x) (iadd ty z x))) (isub ty y z))
 
 ;; (x - y) + (y - x) --> 0
-(rule (simplify (iadd ty (isub ty x y) (isub ty y x))) (subsume (iconst_u ty 0)))
+(rule (simplify (iadd ty (isub ty x y) (isub ty y x))) (subsume (all_zero ty)))
 
 ;; ((x - z) - (y - z)) --> (x - y)
 (rule (simplify (isub ty (isub ty x z) (isub ty y z))) (isub ty x y))
@@ -392,7 +392,7 @@
 
 ;; Helper to create a "true" value for a comparison. For scalar integers this is
 ;; a value of 1 but for vectors this is -1 since each lane is filled with all
-;; 1s. We use `(iconst_u ty 0)` for falses for both integers and vector. This is
+;; 1s. We use `(all_zero ty)` for falses for both integers and vectors. This is
 ;; because of the Cranelift semantics:
 ;; When comparing scalars, the result is 1 if the condition holds, or 0 otherwise.
 ;; When comparing vectors, the result is -1 (all-ones) if the condition holds, or 0 otherwise.
@@ -407,18 +407,18 @@
 (rule (simplify (eq ty (iadd cty y x) (iadd cty y x))) (cmp_true ty))
 
 ;; (x - y) != x --> y != 0
-(rule (simplify (ne cty (isub ty x y) x)) (ne cty y (iconst_u ty 0)))
-(rule (simplify (ne cty x (isub ty x y))) (ne cty y (iconst_u ty 0)))
+(rule (simplify (ne cty (isub ty x y) x)) (ne cty y (all_zero ty)))
+(rule (simplify (ne cty x (isub ty x y))) (ne cty y (all_zero ty)))
 
 ;; (x - y) == x --> y == 0
-(rule (simplify (eq cty (isub ty x y) x)) (eq cty y (iconst_u ty 0)))
-(rule (simplify (eq cty x (isub ty x y))) (eq cty y (iconst_u ty 0)))
+(rule (simplify (eq cty (isub ty x y) x)) (eq cty y (all_zero ty)))
+(rule (simplify (eq cty x (isub ty x y))) (eq cty y (all_zero ty)))
 
 ;; (x + y) == y --> x == 0
-(rule (simplify (eq cty (iadd ty x y) y)) (eq cty x (iconst_u ty 0)))
-(rule (simplify (eq cty (iadd ty y x) y)) (eq cty x (iconst_u ty 0)))
-(rule (simplify (eq cty y (iadd ty x y))) (eq cty x (iconst_u ty 0)))
-(rule (simplify (eq cty y (iadd ty y x))) (eq cty x (iconst_u ty 0)))
+(rule (simplify (eq cty (iadd ty x y) y)) (eq cty x (all_zero ty)))
+(rule (simplify (eq cty (iadd ty y x) y)) (eq cty x (all_zero ty)))
+(rule (simplify (eq cty y (iadd ty x y))) (eq cty x (all_zero ty)))
+(rule (simplify (eq cty y (iadd ty y x))) (eq cty x (all_zero ty)))
 
 ;; -x == -y --> x == y
 (rule (simplify (eq ty (ineg ty x) (ineg ty y))) (eq ty x y))
@@ -574,14 +574,14 @@
 (rule (simplify (umax ty (umin ty x y) (umax ty y x))) (umax ty x y))
 
 ;; x > max(x, y) --> 0
-(rule (simplify (sgt ty x (smax ty x y))) (iconst_u ty 0))
-(rule (simplify (sgt ty x (smax ty y x))) (iconst_u ty 0))
-(rule (simplify (slt ty (smax ty x y) x)) (iconst_u ty 0))
-(rule (simplify (slt ty (smax ty y x) x)) (iconst_u ty 0))
-(rule (simplify (ugt ty x (umax ty x y))) (iconst_u ty 0))
-(rule (simplify (ugt ty x (umax ty y x))) (iconst_u ty 0))
-(rule (simplify (ult ty (umax ty x y) x)) (iconst_u ty 0))
-(rule (simplify (ult ty (umax ty y x) x)) (iconst_u ty 0))
+(rule (simplify (sgt ty x (smax ty x y))) (all_zero ty))
+(rule (simplify (sgt ty x (smax ty y x))) (all_zero ty))
+(rule (simplify (slt ty (smax ty x y) x)) (all_zero ty))
+(rule (simplify (slt ty (smax ty y x) x)) (all_zero ty))
+(rule (simplify (ugt ty x (umax ty x y))) (all_zero ty))
+(rule (simplify (ugt ty x (umax ty y x))) (all_zero ty))
+(rule (simplify (ult ty (umax ty x y) x)) (all_zero ty))
+(rule (simplify (ult ty (umax ty y x) x)) (all_zero ty))
 
 ;; (-X) * C = X * (-C)
 (rule imul_ineg_const (simplify (imul (fits_in_64 ty) (ineg ty x) (iconst ty y))) (imul ty x (iconst ty (imm64_neg ty y))))
@@ -620,3 +620,7 @@
 (rule (simplify (imul ty (umax ty (ineg ty x) x) (umax ty x (ineg ty x)))) (imul ty x x))
 (rule (simplify (imul ty (umax ty x (ineg ty x)) (umax ty (ineg ty x) x))) (imul ty x x))
 (rule (simplify (imul ty (umax ty x (ineg ty x)) (umax ty x (ineg ty x)))) (imul ty x x))
+
+;; x /u (1 << y) --> x >>u y
+(rule (simplify_skeleton (udiv x (ishl ty (iconst_u ty 1) y)))
+      (ushr ty x y))

--- a/cranelift/codegen/src/opts/bitops.isle
+++ b/cranelift/codegen/src/opts/bitops.isle
@@ -117,19 +117,19 @@
 (rule (truthy (popcnt _ x)) x)
 (rule (truthy (rotl _ x _)) x)
 (rule (truthy (rotr _ x _)) x)
-(rule (truthy (select _ x (iconst_u _ (u64_when_non_zero)) (iconst_u _ 0))) x)
+(rule (truthy (select _ x (iconst_u _ (u64_when_non_zero)) (all_zero _))) x)
 ;; (ne ty (iconst 0) v) is also canonicalized into this form via another rule
-(rule (truthy (ne _ x (iconst_u _ 0))) x)
+(rule (truthy (ne _ x (all_zero _))) x)
 
 ;; All of these expressions don't care about their input as long as it is truthy.
 ;; so we can remove expressions that preserve that property from the input.
 (rule (simplify (bmask ty v)) (if-let x (truthy v)) (bmask ty x))
 (rule (simplify (select ty v t f)) (if-let c (truthy v)) (select ty c t f))
 ;; (ne ty (iconst 0) v) is also canonicalized into this form via another rule
-(rule (simplify (ne cty v (iconst_u _ 0)))
+(rule (simplify (ne cty v (all_zero _)))
       (if-let c (truthy v))
       (if-let (value_type (ty_int_ref_scalar_64_extract ty)) c)
-      (ne cty c (iconst_u ty 0)))
+      (ne cty c (all_zero ty)))
 
 
 
@@ -790,3 +790,44 @@
 
 ;; popcnt(bitrev(x)) == popcnt(x)
 (rule (simplify (popcnt ty (bitrev ty x))) (popcnt ty x))
+
+;; (x ^ y) ^ (x ^ z) --> y ^ z.
+(rule (simplify (bxor ty (bxor ty x y) (bxor ty x z))) (subsume (bxor ty y z)))
+(rule (simplify (bxor ty (bxor ty x y) (bxor ty z x))) (subsume (bxor ty y z)))
+(rule (simplify (bxor ty (bxor ty y x) (bxor ty x z))) (subsume (bxor ty y z)))
+(rule (simplify (bxor ty (bxor ty y x) (bxor ty z x))) (subsume (bxor ty y z)))
+
+;; (-x) & 1 --> x & 1.
+(rule (simplify (band ty (ineg ty x) (iconst_u ty 1))) (band ty x (iconst_u ty 1)))
+
+;; (x & y) & (x | z) --> x & y.
+(rule (simplify (band ty (band ty x y) (bor ty x z))) (subsume (band ty x y)))
+(rule (simplify (band ty (bor ty x z) (band ty x y))) (subsume (band ty x y)))
+(rule (simplify (band ty (band ty x y) (bor ty z x))) (subsume (band ty x y)))
+(rule (simplify (band ty (bor ty z x) (band ty x y))) (subsume (band ty x y)))
+(rule (simplify (band ty (band ty y x) (bor ty x z))) (subsume (band ty x y)))
+(rule (simplify (band ty (bor ty x z) (band ty y x))) (subsume (band ty x y)))
+(rule (simplify (band ty (band ty y x) (bor ty z x))) (subsume (band ty x y)))
+(rule (simplify (band ty (bor ty z x) (band ty y x))) (subsume (band ty x y)))
+
+;; (x & y) | (x | z) --> x | z.
+(rule (simplify (bor ty (band ty x y) (bor ty x z))) (subsume (bor ty x z)))
+(rule (simplify (bor ty (bor ty x z) (band ty x y))) (subsume (bor ty x z)))
+(rule (simplify (bor ty (band ty x y) (bor ty z x))) (subsume (bor ty x z)))
+(rule (simplify (bor ty (bor ty z x) (band ty x y))) (subsume (bor ty x z)))
+(rule (simplify (bor ty (band ty y x) (bor ty x z))) (subsume (bor ty x z)))
+(rule (simplify (bor ty (bor ty x z) (band ty y x))) (subsume (bor ty x z)))
+(rule (simplify (bor ty (band ty y x) (bor ty z x))) (subsume (bor ty x z)))
+(rule (simplify (bor ty (bor ty z x) (band ty y x))) (subsume (bor ty x z)))
+
+;; (x & y) | (x ^ y) --> x | y.
+(rule (simplify (bor ty (band ty x y) (bxor ty x y))) (bor ty x y))
+(rule (simplify (bor ty (bxor ty x y) (band ty x y))) (bor ty x y))
+(rule (simplify (bor ty (band ty x y) (bxor ty y x))) (bor ty x y))
+(rule (simplify (bor ty (bxor ty y x) (band ty x y))) (bor ty x y))
+
+;; ~((~x) - y) --> x + y.
+(rule (simplify (bnot ty (isub ty (bnot ty x) y))) (iadd ty x y))
+
+;; ~((~x) >>s y) --> x >>s y.
+(rule (simplify (bnot ty (sshr ty (bnot ty x) y))) (sshr ty x y))

--- a/cranelift/codegen/src/opts/cprop.isle
+++ b/cranelift/codegen/src/opts/cprop.isle
@@ -226,7 +226,7 @@
 
 (rule (simplify (select ty (iconst_u _ (u64_when_non_zero)) x _))
       (subsume x))
-(rule (simplify (select ty (iconst_u _ 0) _ y))
+(rule (simplify (select ty (all_zero _) _ y))
       (subsume y))
 
 (rule (simplify

--- a/cranelift/codegen/src/opts/extends.isle
+++ b/cranelift/codegen/src/opts/extends.isle
@@ -28,22 +28,22 @@
 (rule (simplify
        (slt ty
              (uextend $I64 x @ (value_type $I32))
-             (iconst_u _ 0)))
-      (subsume (iconst_u ty 0)))
+             (all_zero _)))
+      (subsume (all_zero ty)))
 (rule (simplify
        (sge ty
              (uextend $I64 x @ (value_type $I32))
-             (iconst_u _ 0)))
+             (all_zero _)))
       (subsume (iconst_u ty 1)))
 
 ;; Sign-extending can't change whether a number is zero nor how it signed-compares to zero
-(rule (simplify (eq _ (sextend _ x@(value_type ty)) (iconst_s _ 0)))
-      (eq ty x (iconst_s ty 0)))
-(rule (simplify (ne _ (sextend _ x@(value_type ty)) (iconst_s _ 0)))
-      (ne ty x (iconst_s ty 0)))
-(rule (simplify (icmp _ cc (sextend _ x@(value_type ty)) (iconst_s _ 0)))
+(rule (simplify (eq _ (sextend _ x@(value_type ty)) (all_zero _)))
+      (eq ty x (all_zero ty)))
+(rule (simplify (ne _ (sextend _ x@(value_type ty)) (all_zero _)))
+      (ne ty x (all_zero ty)))
+(rule (simplify (icmp _ cc (sextend _ x@(value_type ty)) (all_zero _)))
       (if (signed_cond_code cc))
-      (icmp ty cc x (iconst_s ty 0)))
+      (icmp ty cc x (all_zero ty)))
 
 ;; A reduction-of-an-extend back to the same original type is the same as not
 ;; actually doing the extend in the first place.
@@ -91,7 +91,7 @@
 (rule (simplify (ireduce ty (band _ x y))) (band ty (ireduce ty x) (ireduce ty y)))
 
 ;; Try to transform an `iconcat` into an i128 into either an sextend or uextend
-(rule (simplify (iconcat $I128 x (iconst_u _ 0))) (uextend $I128 x))
+(rule (simplify (iconcat $I128 x (all_zero _))) (uextend $I128 x))
 (rule (simplify (iconcat $I128 x (sshr _ x (iconst_u _ 63)))) (sextend $I128 x))
 
 ;; Select narrowest type

--- a/cranelift/codegen/src/opts/icmp.isle
+++ b/cranelift/codegen/src/opts/icmp.isle
@@ -3,14 +3,14 @@
 ;; `x == x` is always true for integers; `x != x` is false. Strict
 ;; inequalities are false, and loose inequalities are true.
 (rule (simplify (eq ty x x)) (subsume (cmp_true ty)))
-(rule (simplify (ne ty x x)) (subsume (iconst_u ty 0)))
-(rule (simplify (ugt ty x x)) (subsume (iconst_u ty 0)))
+(rule (simplify (ne ty x x)) (subsume (all_zero ty)))
+(rule (simplify (ugt ty x x)) (subsume (all_zero ty)))
 (rule (simplify (uge ty x x)) (subsume (cmp_true ty)))
-(rule (simplify (sgt ty x x)) (subsume (iconst_u ty 0)))
+(rule (simplify (sgt ty x x)) (subsume (all_zero ty)))
 (rule (simplify (sge ty x x)) (subsume (cmp_true ty)))
-(rule (simplify (ult ty x x)) (subsume (iconst_u ty 0)))
+(rule (simplify (ult ty x x)) (subsume (all_zero ty)))
 (rule (simplify (ule ty x x)) (subsume (cmp_true ty)))
-(rule (simplify (slt ty x x)) (subsume (iconst_u ty 0)))
+(rule (simplify (slt ty x x)) (subsume (all_zero ty)))
 (rule (simplify (sle ty x x)) (subsume (cmp_true ty)))
 
 ;; For integers, adding the same thing on both sides of an equality check
@@ -48,21 +48,21 @@
 ;; e.g. neq(ugt(x, y), 0) == ugt(x, y)
 (rule (simplify (ne ty
                       (uextend_maybe _ inner @ (icmp ty _ _ _))
-                      (iconst_u _ 0)))
+                      (all_zero _)))
       (subsume inner))
 
 ;; Likewise for icmp-of-fcmp.
 ;; ne(fcmp(ty, cc, x, y), 0) == fcmp(ty, cc, x, y)
 (rule (simplify (ne ty
                       (uextend_maybe _ inner @ (fcmp ty _ _ _))
-                      (iconst_u _ 0)))
+                      (all_zero _)))
       (subsume inner))
 
 ;; eq(icmp(ty, cc, x, y), 0) == icmp(ty, cc_complement, x, y)
 ;; e.g. eq(ugt(x, y), 0) == ule(x, y)
 (rule (simplify (eq ty
                       (uextend_maybe _ (icmp ty cc x y))
-                      (iconst_u _ 0)))
+                      (all_zero _)))
       (subsume (icmp ty (intcc_complement cc) x y)))
 
 ;; ne(icmp(ty, cc, x, y), 1) == icmp(ty, cc_complement, x, y)
@@ -101,19 +101,19 @@
 
 ;; Comparisons against largest/smallest signed/unsigned values:
 ;; ult(x, 0) == false.
-(rule (simplify (ult bty x zero @ (iconst_u _ 0)))
-      (subsume (iconst_u bty 0)))
+(rule (simplify (ult bty x zero @ (all_zero _)))
+      (subsume (all_zero bty)))
 
 ;; ule(x, 0) == eq(x, 0)
-(rule (simplify (ule (fits_in_64 (ty_int bty)) x zero @ (iconst_u _ 0)))
+(rule (simplify (ule (fits_in_64 (ty_int bty)) x zero @ (all_zero _)))
       (eq bty x zero))
 
 ;; ugt(x, 0) == ne(x, 0).
-(rule (simplify (ugt (fits_in_64 (ty_int bty)) x zero @ (iconst_u _ 0)))
+(rule (simplify (ugt (fits_in_64 (ty_int bty)) x zero @ (all_zero _)))
       (ne bty x zero))
 
 ;; uge(x, 0) == true.
-(rule (simplify (uge bty x zero @ (iconst_u _ 0)))
+(rule (simplify (uge bty x zero @ (all_zero _)))
       (subsume (cmp_true bty)))
 
 ;; ult(x, UMAX) == ne(x, UMAX).
@@ -129,7 +129,7 @@
 ;; ugt(x, UMAX) == false.
 (rule (simplify (ugt (fits_in_64 (ty_int bty)) x umax @ (iconst_u cty y)))
        (if-let true (u64_eq y (ty_umax cty)))
-       (subsume (iconst_u bty 0)))
+       (subsume (all_zero bty)))
 
 ;; uge(x, UMAX) == eq(x, UMAX).
 (rule (simplify (uge (fits_in_64 (ty_int bty)) x umax @ (iconst_u cty y)))
@@ -139,7 +139,7 @@
 ;; slt(x, SMIN) == false.
 (rule (simplify (slt (fits_in_64 (ty_int bty)) x smin @ (iconst_u cty y)))
        (if-let true (u64_eq y (ty_smin cty)))
-       (subsume (iconst_u bty 0)))
+       (subsume (all_zero bty)))
 
 ;; sle(x, SMIN) == eq(x, SMIN).
 (rule (simplify (sle (fits_in_64 (ty_int bty)) x smin @ (iconst_u cty y)))
@@ -169,7 +169,7 @@
 ;; sgt(x, SMAX) == false.
 (rule (simplify (sgt (fits_in_64 (ty_int bty)) x smax @ (iconst_u cty y)))
        (if-let true (u64_eq y (ty_smax cty)))
-       (subsume (iconst_u bty 0)))
+       (subsume (all_zero bty)))
 
 ;; sge(x, SMAX) == eq(x, SMAX).
 (rule (simplify (sge (fits_in_64 (ty_int bty)) x smax @ (iconst_u cty y)))
@@ -188,22 +188,22 @@
 ;; Prefer comparing against zero
 ;; uge(x, 1) == ne(x, 0)
 (rule (simplify (uge ty x (iconst_u cty 1)))
-      (ne ty x (iconst_u cty 0)))
+      (ne ty x (all_zero cty)))
 ;; ult(x, 1) == eq(x, 0)
 (rule (simplify (ult ty x (iconst_u cty 1)))
-      (eq ty x (iconst_u cty 0)))
+      (eq ty x (all_zero cty)))
 ;; sge(x, 1) == sgt(x, 0)
 (rule (simplify (sge ty x (iconst_s cty 1)))
-      (sgt ty x (iconst_s cty 0)))
+      (sgt ty x (all_zero cty)))
 ;; slt(x, 1) == sle(x, 0)
 (rule (simplify (slt ty x (iconst_s cty 1)))
-      (sle ty x (iconst_s cty 0)))
+      (sle ty x (all_zero cty)))
 ;; sgt(x, -1) == sge(x, 0)
 (rule (simplify (sgt ty x (iconst_s cty -1)))
-      (sge ty x (iconst_s cty 0)))
+      (sge ty x (all_zero cty)))
 ;; sle(x, -1) == slt(x, 0)
 (rule (simplify (sle ty x (iconst_s cty -1)))
-      (slt ty x (iconst_s cty 0)))
+      (slt ty x (all_zero cty)))
 
 (decl pure partial intcc_comparable (IntCC IntCC) bool)
 (rule (intcc_comparable x y)
@@ -223,7 +223,7 @@
 (rule (decompose_intcc (IntCC.NotEqual)) 6)
 
 (decl compose_icmp (Type u64 bool Value Value) Value)
-(rule (compose_icmp ty 0 _ _ _) (subsume (iconst_u ty 0)))
+(rule (compose_icmp ty 0 _ _ _) (subsume (all_zero ty)))
 (rule (compose_icmp ty 1 _ x y) (icmp ty (IntCC.Equal) x y))
 (rule (compose_icmp ty 2 false x y) (icmp ty (IntCC.UnsignedLessThan) x y))
 (rule (compose_icmp ty 2 true x y) (icmp ty (IntCC.SignedLessThan) x y))
@@ -292,8 +292,8 @@
       (slt ty (iconcat $I64 a_lo a_hi) (iconcat $I64 b_lo b_hi)))
 
 
-(rule (simplify (eq cty x (bxor (ty_int bty) x y))) (subsume (eq cty y (iconst_u bty 0))))
-(rule (simplify (ne cty x (bxor (ty_int bty) x y))) (subsume (ne cty y (iconst_u bty 0))))
+(rule (simplify (eq cty x (bxor (ty_int bty) x y))) (subsume (eq cty y (all_zero bty))))
+(rule (simplify (ne cty x (bxor (ty_int bty) x y))) (subsume (ne cty y (all_zero bty))))
 
 ; (x - y) > x == y > x
 (rule (simplify (ugt cty (isub ty x y) x)) (ugt cty y x))
@@ -317,42 +317,42 @@
 (rule (simplify (bxor ty (ult ty x y) (ult ty y x))) (ne ty x y))
 
 ;; a < b && a > b = false
-(rule (simplify (band (ty_int_vec128 ty) (sgt ty x y) (slt ty x y))) (iconst_u ty 0))
-(rule (simplify (band (ty_int_vec128 ty) (slt ty x y) (sgt ty x y))) (iconst_u ty 0))
-(rule (simplify (band (ty_int_vec128 ty) (ugt ty x y) (ult ty x y))) (iconst_u ty 0))
-(rule (simplify (band (ty_int_vec128 ty) (ult ty x y) (ugt ty x y))) (iconst_u ty 0))
+(rule (simplify (band (ty_int_vec128 ty) (sgt ty x y) (slt ty x y))) (all_zero ty))
+(rule (simplify (band (ty_int_vec128 ty) (slt ty x y) (sgt ty x y))) (all_zero ty))
+(rule (simplify (band (ty_int_vec128 ty) (ugt ty x y) (ult ty x y))) (all_zero ty))
+(rule (simplify (band (ty_int_vec128 ty) (ult ty x y) (ugt ty x y))) (all_zero ty))
 (rule
   (simplify (band ty (sgt ty x (iconst_s _ y)) (ult ty x (iconst_s _ y))))
   (if-let true (i64_gt_eq y 0))
-  (iconst_u ty 0))
+  (all_zero ty))
 (rule
   (simplify (band ty (sgt ty (iconst_s _ x) y) (ult ty (iconst_s _ x) y)))
   (if-let true (i64_lt x 0))
-  (iconst_u ty 0))
+  (all_zero ty))
 (rule
   (simplify (band ty (slt ty x (iconst_s _ y)) (ugt ty x (iconst_s _ y))))
   (if-let true (i64_lt y 0))
-  (iconst_u ty 0))
+  (all_zero ty))
 (rule
   (simplify (band ty (slt ty (iconst_s _ x) y) (ugt ty (iconst_s _ x) y)))
   (if-let true (i64_gt_eq x 0))
-  (iconst_u ty 0))
+  (all_zero ty))
 (rule
   (simplify (band ty (ugt ty x (iconst_s _ y)) (slt ty x (iconst_s _ y))))
   (if-let true (i64_lt y 0))
-  (iconst_u ty 0))
+  (all_zero ty))
 (rule
   (simplify (band ty (ugt ty (iconst_s _ x) y) (slt ty (iconst_s _ x) y)))
   (if-let true (i64_gt_eq x 0))
-  (iconst_u ty 0))
+  (all_zero ty))
 (rule
   (simplify (band ty (ult ty x (iconst_s _ y)) (sgt ty x (iconst_s _ y))))
   (if-let true (i64_gt_eq y 0))
-  (iconst_u ty 0))
+  (all_zero ty))
 (rule
   (simplify (band ty (ult ty (iconst_s _ x) y) (sgt ty (iconst_s _ x) y)))
   (if-let true (i64_lt x 0))
-  (iconst_u ty 0))
+  (all_zero ty))
 
 ;; (x < y) & (x ≠ -1) = (x < y)
 (rule
@@ -389,7 +389,7 @@
     (iconst_u _ k2))
   (iconst_u _ k1)))
   (if-let false (u64_eq k1 k2))
-  (ne select_ty inner_cond (iconst_u inner_ty 0)))
+  (ne select_ty inner_cond (all_zero inner_ty)))
 
 (rule (simplify (eq _
   (select select_ty inner_cond @ (value_type inner_ty)
@@ -397,7 +397,7 @@
     (iconst_u _ k2))
   (iconst_u _ k2)))
   (if-let false (u64_eq k1 k2))
-  (eq select_ty inner_cond (iconst_u inner_ty 0)))
+  (eq select_ty inner_cond (all_zero inner_ty)))
 
 (rule (simplify (ne _
   (select select_ty inner_cond @ (value_type inner_ty)
@@ -405,7 +405,7 @@
     (iconst_u _ k2))
   (iconst_u _ k1)))
   (if-let false (u64_eq k1 k2))
-  (eq select_ty inner_cond (iconst_u inner_ty 0)))
+  (eq select_ty inner_cond (all_zero inner_ty)))
 
 (rule (simplify (ne _
   (select select_ty inner_cond @ (value_type inner_ty)
@@ -413,7 +413,7 @@
     (iconst_u _ k2))
   (iconst_u _ k2)))
   (if-let false (u64_eq k1 k2))
-  (ne select_ty inner_cond (iconst_u inner_ty 0)))
+  (ne select_ty inner_cond (all_zero inner_ty)))
 
 ;;;;; Boolean-context simplifications for `ctz` and `clz` ;;;;;;;;;;;;;;;;;;;;;;
 ;;
@@ -435,21 +435,21 @@
 ;; on cranelift JITs even when produced unconditionally.
 
 ;; ctz(X) == 0  iff  the LSB of X is 1, i.e.  (X & 1) != 0.
-(rule (simplify (eq result_ty (ctz x_ty X) (iconst_u _ 0)))
-      (ne result_ty (band x_ty X (iconst_u x_ty 1)) (iconst_u x_ty 0)))
+(rule (simplify (eq result_ty (ctz x_ty X) (all_zero _)))
+      (ne result_ty (band x_ty X (iconst_u x_ty 1)) (all_zero x_ty)))
 
 ;; ctz(X) != 0  iff  the LSB of X is 0, i.e.  (X & 1) == 0.
-(rule (simplify (ne result_ty (ctz x_ty X) (iconst_u _ 0)))
-      (eq result_ty (band x_ty X (iconst_u x_ty 1)) (iconst_u x_ty 0)))
+(rule (simplify (ne result_ty (ctz x_ty X) (all_zero _)))
+      (eq result_ty (band x_ty X (iconst_u x_ty 1)) (all_zero x_ty)))
 
 ;; clz(X) == 0  iff  the MSB of X is 1, i.e.  X is signed-negative.
 ;; Lowers to `test X, X; js` on x86_64 — single-instruction sign-bit test.
-(rule (simplify (eq result_ty (clz x_ty X) (iconst_u _ 0)))
-      (slt result_ty X (iconst_u x_ty 0)))
+(rule (simplify (eq result_ty (clz x_ty X) (all_zero _)))
+      (slt result_ty X (all_zero x_ty)))
 
 ;; clz(X) != 0  iff  the MSB of X is 0, i.e.  X is signed-non-negative.
-(rule (simplify (ne result_ty (clz x_ty X) (iconst_u _ 0)))
-      (sge result_ty X (iconst_u x_ty 0)))
+(rule (simplify (ne result_ty (clz x_ty X) (all_zero _)))
+      (sge result_ty X (all_zero x_ty)))
 
 ;;;;; Same simplifications applied directly when the count-leading /
 ;;;;; trailing-zeros value is consumed as a `brif` condition (the 2-op
@@ -460,23 +460,23 @@
 ;; `brif (ctz X) bt be` branches when `ctz(X) != 0`, i.e. LSB(X) == 0.
 (rule (simplify_skeleton (brif (ctz x_ty X) _ _))
       (replace_branch_cond
-        (eq $I8 (band x_ty X (iconst_u x_ty 1)) (iconst_u x_ty 0))))
+        (eq $I8 (band x_ty X (iconst_u x_ty 1)) (all_zero x_ty))))
 
 ;; `brif (clz X) bt be` branches when `clz(X) != 0`, i.e. MSB(X) == 0.
 (rule (simplify_skeleton (brif (clz x_ty X) _ _))
-      (replace_branch_cond (sge $I8 X (iconst_u x_ty 0))))
+      (replace_branch_cond (sge $I8 X (all_zero x_ty))))
 
 ;; Same when an `ireduce` (truncation) sits between the count and the
 ;; brif. The count is in [0, bitwidth] so the truncation is lossless.
 (rule (simplify_skeleton (brif (ireduce _ (ctz x_ty x)) _ _))
       (replace_branch_cond
-        (eq $I8 (band x_ty x (iconst_u x_ty 1)) (iconst_u x_ty 0))))
+        (eq $I8 (band x_ty x (iconst_u x_ty 1)) (all_zero x_ty))))
 
 (rule (simplify_skeleton (brif (ireduce _ (clz x_ty x)) _ _))
-      (replace_branch_cond (sge $I8 x (iconst_u x_ty 0))))
+      (replace_branch_cond (sge $I8 x (all_zero x_ty))))
 
 ;; ~x == x --> 0
-(rule (simplify (eq ty (bnot cty x) x)) (subsume (iconst_u ty 0)))
+(rule (simplify (eq ty (bnot cty x) x)) (subsume (all_zero ty)))
 
 ;; ~x != x --> 1
 (rule (simplify (ne ty (bnot cty x) x)) (subsume (cmp_true ty)))
@@ -492,10 +492,10 @@
 (rule (simplify (ult rty x (ushr ty x y))) (subsume (all_zero rty)))
 
 ;; smin(x, y) > smax(x, y) --> false
-(rule (simplify (sgt ty (smin cty x y) (smax cty x y))) (iconst_u ty 0))
+(rule (simplify (sgt ty (smin cty x y) (smax cty x y))) (all_zero ty))
 
 ;; umin(x, y) > umax(x, y) --> false
-(rule (simplify (ugt ty (umin cty x y) (umax cty x y))) (iconst_u ty 0))
+(rule (simplify (ugt ty (umin cty x y) (umax cty x y))) (all_zero ty))
 
 ;; smin(x, y) <= smax(x, y) --> true
 (rule (simplify (sle ty (smin cty x y) (smax cty x y))) (cmp_true ty))
@@ -533,3 +533,15 @@
 
 ;; -x != -y ==> x != y
 (rule (simplify (ne ty (ineg cty x) (ineg cty y))) (ne ty x y))
+
+;; (x >>s y) >s -1 --> x >=s 0
+(rule (simplify (sgt ty (sshr cty x y) (iconst_s cty -1)))
+      (subsume (sge ty x (all_zero cty))))
+
+;; (x >>s y) >=s 0 --> x >=s 0
+(rule (simplify (sge ty (sshr cty x y) (all_zero cty)))
+      (subsume (sge ty x (all_zero cty))))
+
+;; rotl(x, k) == rotl(y, k) --> x == y.
+(rule (simplify (eq ty (rotl cty x k) (rotl cty y k)))
+      (subsume (eq ty x y)))

--- a/cranelift/codegen/src/opts/selects.isle
+++ b/cranelift/codegen/src/opts/selects.isle
@@ -7,19 +7,19 @@
 ;; Push zeroes to the right -- this makes the select `truthy`, as used elsewhere
 ;; if icmp { 0 } else { nonzero } => if !icmp { nonzero } else { 0 }
 (rule (simplify (select sty (icmp cty cc x y)
-                        zero @ (iconst_u _ 0)
+                        zero @ (all_zero _)
                         nonzero @ (iconst_u _ (u64_when_non_zero))))
     (select sty (icmp cty (intcc_complement cc) x y) nonzero zero))
 
 ;; if icmp(x, y) { 1 } else { 0 } => uextend(icmp(x, y))
 (rule (simplify (select ty cmp @ (icmp _ cc x y)
                         (iconst_u _ 1)
-                        (iconst_u _ 0)))
+                        (all_zero _)))
     (uextend_maybe ty cmp))
 ;; if icmp(x, y) { -1 } else { 0 } => uextend(icmp(x, y))
 (rule (simplify (select ty cmp@(icmp _ cc x y)
                         (iconst_s _ -1)
-                        (iconst_s _ 0)))
+                        (all_zero _)))
     (bmask ty cmp))
 
 ;; Transform select-of-icmp into {u,s}{min,max} instructions where possible.
@@ -94,10 +94,10 @@
 ;; Lifts arithmetic negation outside of select.
 (rule (simplify (select ty c (ineg ty x) (ineg ty y))) (ineg ty (select ty c x y)))
 
-(rule (simplify (select ty (sgt _ x (iconst_u ty 0)) x (ineg ty x))) (subsume (iabs ty x)))
-(rule (simplify (select ty (sge _ x (iconst_u ty 0)) x (ineg ty x))) (subsume (iabs ty x)))
-(rule (simplify (select ty (sle _ x (iconst_u ty 0)) (ineg ty x) x)) (subsume (iabs ty x)))
-(rule (simplify (select ty (slt _ x (iconst_u ty 0)) (ineg ty x) x)) (subsume (iabs ty x)))
+(rule (simplify (select ty (sgt _ x (all_zero ty)) x (ineg ty x))) (subsume (iabs ty x)))
+(rule (simplify (select ty (sge _ x (all_zero ty)) x (ineg ty x))) (subsume (iabs ty x)))
+(rule (simplify (select ty (sle _ x (all_zero ty)) (ineg ty x) x)) (subsume (iabs ty x)))
+(rule (simplify (select ty (slt _ x (all_zero ty)) (ineg ty x) x)) (subsume (iabs ty x)))
 
 ;; fold add-select to select-add
 (rule (simplify
@@ -110,14 +110,14 @@
 (rule (simplify (select ty d (select ty d x _) a)) (select ty d x a))
 
 ;; min x y < x => false and its commutative versions
-(rule (simplify (sgt (fits_in_64 ty) (smin _ x y) x)) (iconst_u ty 0))
-(rule (simplify (sgt (fits_in_64 ty) (smin _ x y) y)) (iconst_u ty 0))
-(rule (simplify (slt (fits_in_64 ty) x (smin _ x z))) (iconst_u ty 0))
-(rule (simplify (slt (fits_in_64 ty) x (smin _ y x))) (iconst_u ty 0))
-(rule (simplify (ugt (fits_in_64 ty) (umin _ x y) x)) (iconst_u ty 0))
-(rule (simplify (ugt (fits_in_64 ty) (umin _ x y) y)) (iconst_u ty 0))
-(rule (simplify (ult (fits_in_64 ty) x (umin _ x z))) (iconst_u ty 0))
-(rule (simplify (ult (fits_in_64 ty) x (umin _ y x))) (iconst_u ty 0))
+(rule (simplify (sgt (fits_in_64 ty) (smin _ x y) x)) (all_zero ty))
+(rule (simplify (sgt (fits_in_64 ty) (smin _ x y) y)) (all_zero ty))
+(rule (simplify (slt (fits_in_64 ty) x (smin _ x z))) (all_zero ty))
+(rule (simplify (slt (fits_in_64 ty) x (smin _ y x))) (all_zero ty))
+(rule (simplify (ugt (fits_in_64 ty) (umin _ x y) x)) (all_zero ty))
+(rule (simplify (ugt (fits_in_64 ty) (umin _ x y) y)) (all_zero ty))
+(rule (simplify (ult (fits_in_64 ty) x (umin _ x z))) (all_zero ty))
+(rule (simplify (ult (fits_in_64 ty) x (umin _ y x))) (all_zero ty))
 
 ;; (x == y) ? x : y => y
 ;; select(eq/ne) patterns that always collapse to y.

--- a/cranelift/codegen/src/opts/shifts.isle
+++ b/cranelift/codegen/src/opts/shifts.isle
@@ -3,23 +3,23 @@
 ;; x>>0 == x<<0 == x rotr 0 == x rotl 0 == x.
 (rule (simplify (ishl ty
                       x
-                      (iconst_u ty 0)))
+                      (all_zero ty)))
       (subsume x))
 (rule (simplify (ushr ty
                       x
-                      (iconst_u ty 0)))
+                      (all_zero ty)))
       (subsume x))
 (rule (simplify (sshr ty
                       x
-                      (iconst_u ty 0)))
+                      (all_zero ty)))
       (subsume x))
 (rule (simplify (rotr ty
                       x
-                      (iconst_u ty 0)))
+                      (all_zero ty)))
       (subsume x))
 (rule (simplify (rotl ty
                       x
-                      (iconst_u ty 0)))
+                      (all_zero ty)))
       (subsume x))
 
 ;; `(x >> k) << k` is the same as masking off the bottom `k` bits (regardless if
@@ -188,7 +188,7 @@
                               (u64_and k1 (ty_shift_mask ty))
                               (u64_and k2 (ty_shift_mask ty))))
       (if-let true (u64_lt_eq (ty_bits_u64 ty) shift_amt))
-      (subsume (iconst_u ty 0)))
+      (subsume (all_zero ty)))
 
 (rule (simplify (ushr ty
                       (ushr ty x (iconst_u _ k1))
@@ -197,7 +197,7 @@
                               (u64_and k1 (ty_shift_mask ty))
                               (u64_and k2 (ty_shift_mask ty))))
       (if-let true (u64_lt_eq (ty_bits_u64 ty) shift_amt))
-      (subsume (iconst_u ty 0)))
+      (subsume (all_zero ty)))
 
 ;; (rotl (rotr x y) y) == x
 ;; (rotr (rotl x y) y) == x
@@ -319,11 +319,11 @@
 (rule (simplify (ushr ty (band ty x (ishl ty y z)) z)) (band ty y (ushr ty x z)))
 
 ;; Zero remains zero for any shift or rotate amount.
-(rule (simplify (ishl ty (iconst_u ty 0) x)) (subsume (iconst_u ty 0)))
-(rule (simplify (ushr ty (iconst_u ty 0) x)) (subsume (iconst_u ty 0)))
-(rule (simplify (sshr ty (iconst_u ty 0) x)) (subsume (iconst_u ty 0)))
-(rule (simplify (rotl ty (iconst_u ty 0) x)) (subsume (iconst_u ty 0)))
-(rule (simplify (rotr ty (iconst_u ty 0) x)) (subsume (iconst_u ty 0)))
+(rule (simplify (ishl ty (all_zero ty) x)) (subsume (all_zero ty)))
+(rule (simplify (ushr ty (all_zero ty) x)) (subsume (all_zero ty)))
+(rule (simplify (sshr ty (all_zero ty) x)) (subsume (all_zero ty)))
+(rule (simplify (rotl ty (all_zero ty) x)) (subsume (all_zero ty)))
+(rule (simplify (rotr ty (all_zero ty) x)) (subsume (all_zero ty)))
 
 ;; All ones remain all ones for arithmetic right shifts or rotates.
 (rule (simplify (sshr ty (iconst_s ty -1) x)) (subsume (iconst_s ty -1)))

--- a/cranelift/filetests/filetests/egraph/arithmetic-precise.clif
+++ b/cranelift/filetests/filetests/egraph/arithmetic-precise.clif
@@ -562,3 +562,75 @@ block0(v0: i32, v1: i32):
 ;     return v3
 ; }
 
+function %udiv_shift_i32(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = iconst.i32 1
+    v3 = ishl v2, v1
+    v4 = udiv v0, v3
+    return v4
+}
+
+; function %udiv_shift_i32(i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32):
+;     v5 = ushr v0, v1
+;     v4 -> v5
+;     return v5
+; }
+
+function %add_zero_vector(i32x4) -> i32x4 {
+block0(v0: i32x4):
+    v1 = vconst.i32x4 0x00000000000000000000000000000000
+    v2 = iadd v0, v1
+    return v2
+}
+
+; function %add_zero_vector(i32x4) -> i32x4 fast {
+;     const0 = 0x00000000000000000000000000000000
+;
+; block0(v0: i32x4):
+;     return v0
+; }
+
+function %sub_zero_vector(i32x4) -> i32x4 {
+block0(v0: i32x4):
+    v1 = vconst.i32x4 0x00000000000000000000000000000000
+    v2 = isub v0, v1
+    return v2
+}
+
+; function %sub_zero_vector(i32x4) -> i32x4 fast {
+;     const0 = 0x00000000000000000000000000000000
+;
+; block0(v0: i32x4):
+;     return v0
+; }
+
+function %zero_sub_vector(i32x4) -> i32x4 {
+block0(v0: i32x4):
+    v1 = vconst.i32x4 0x00000000000000000000000000000000
+    v2 = isub v1, v0
+    return v2
+}
+
+; function %zero_sub_vector(i32x4) -> i32x4 fast {
+;     const0 = 0x00000000000000000000000000000000
+;
+; block0(v0: i32x4):
+;     v3 = ineg v0
+;     return v3
+; }
+
+function %mul_zero_vector(i32x4) -> i32x4 {
+block0(v0: i32x4):
+    v1 = vconst.i32x4 0x00000000000000000000000000000000
+    v2 = imul v0, v1
+    return v2
+}
+
+; function %mul_zero_vector(i32x4) -> i32x4 fast {
+;     const0 = 0x00000000000000000000000000000000
+;
+; block0(v0: i32x4):
+;     v1 = vconst.i32x4 const0
+;     return v1  ; v1 = const0
+; }

--- a/cranelift/filetests/filetests/egraph/fold-bitops.clif
+++ b/cranelift/filetests/filetests/egraph/fold-bitops.clif
@@ -695,6 +695,163 @@ block0(v0: i32, v1: i32, v2: i32):
 ;     return v7
 ; }
 
+function %xor_common_i32(i32, i32, i32) -> i32 {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = bxor v0, v1
+    v4 = bxor v0, v2
+    v5 = bxor v3, v4
+    return v5
+}
+
+; function %xor_common_i32(i32, i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32, v2: i32):
+;     v6 = bxor v1, v2
+;     return v6
+; }
+
+function %neg_low_bit_i32(i32) -> i32 {
+block0(v0: i32):
+    v1 = ineg v0
+    v2 = iconst.i32 1
+    v3 = band v1, v2
+    return v3
+}
+
+; function %neg_low_bit_i32(i32) -> i32 fast {
+; block0(v0: i32):
+;     v2 = iconst.i32 1
+;     v4 = band v0, v2  ; v2 = 1
+;     return v4
+; }
+
+function %mask_absorb_and_i32(i32, i32, i32) -> i32 {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = band v0, v1
+    v4 = bor v0, v2
+    v5 = band v3, v4
+    return v5
+}
+
+; function %mask_absorb_and_i32(i32, i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32, v2: i32):
+;     v3 = band v0, v1
+;     return v3
+; }
+
+function %mask_absorb_or_i32(i32, i32, i32) -> i32 {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = band v0, v1
+    v4 = bor v0, v2
+    v5 = bor v3, v4
+    return v5
+}
+
+; function %mask_absorb_or_i32(i32, i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32, v2: i32):
+;     v4 = bor v0, v2
+;     return v4
+; }
+
+function %merge_and_xor_i32(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = band v0, v1
+    v3 = bxor v0, v1
+    v4 = bor v2, v3
+    return v4
+}
+
+; function %merge_and_xor_i32(i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32):
+;     v5 = bor v0, v1
+;     return v5
+; }
+
+function %not_sub_not_i32(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = bnot v0
+    v3 = isub v2, v1
+    v4 = bnot v3
+    return v4
+}
+
+; function %not_sub_not_i32(i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32):
+;     v5 = iadd v0, v1
+;     return v5
+; }
+
+function %mask_absorb_and_reversed(i32, i32, i32) -> i32 {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = band v1, v0
+    v4 = bor v2, v0
+    v5 = band v4, v3
+    return v5
+}
+
+; function %mask_absorb_and_reversed(i32, i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32, v2: i32):
+;     v6 = band v0, v1
+;     return v6
+; }
+
+function %mask_absorb_or_reversed(i32, i32, i32) -> i32 {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = band v1, v0
+    v4 = bor v2, v0
+    v5 = bor v4, v3
+    return v5
+}
+
+; function %mask_absorb_or_reversed(i32, i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32, v2: i32):
+;     v6 = bor v0, v2
+;     return v6
+; }
+
+function %merge_and_xor_reversed(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = band v1, v0
+    v3 = bxor v1, v0
+    v4 = bor v3, v2
+    return v4
+}
+
+; function %merge_and_xor_reversed(i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32):
+;     v5 = bor v1, v0
+;     return v5
+; }
+
+function %xor_distinct(i32, i32, i32, i32) -> i32 {
+block0(v0: i32, v1: i32, v2: i32, v3: i32):
+    v4 = bxor v0, v1
+    v5 = bxor v2, v3
+    v6 = bxor v4, v5
+    return v6
+}
+
+; function %xor_distinct(i32, i32, i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32, v2: i32, v3: i32):
+;     v4 = bxor v0, v1
+;     v5 = bxor v2, v3
+;     v6 = bxor v4, v5
+;     return v6
+; }
+
+function %xor_common_vector(i32x4, i32x4, i32x4) -> i32x4 {
+block0(v0: i32x4, v1: i32x4, v2: i32x4):
+    v3 = bxor v0, v1
+    v4 = bxor v0, v2
+    v5 = bxor v3, v4
+    return v5
+}
+
+; function %xor_common_vector(i32x4, i32x4, i32x4) -> i32x4 fast {
+; block0(v0: i32x4, v1: i32x4, v2: i32x4):
+;     v6 = bxor v1, v2
+;     return v6
+; }
+
 ;; (x & y) & (z & x) --> (x & y) & z
 function %band_band_common_third(i32, i32, i32) -> i32 {
 block0(v0: i32, v1: i32, v2: i32):

--- a/cranelift/filetests/filetests/egraph/i128-opts.clif
+++ b/cranelift/filetests/filetests/egraph/i128-opts.clif
@@ -84,8 +84,8 @@ block0(v0: i8x16):
     v1 = icmp ne v0, v0
     return v1
     ; check: const0 = 0x00000000000000000000000000000000
-    ; check: v4 = vconst.i8x16 const0
-    ; check: return v4  ; v4 = const0
+    ; check: v2 = vconst.i8x16 const0
+    ; check: return v2  ; v2 = const0
 }
 
 function %bor_extended_constants_i128() -> i128 {

--- a/cranelift/filetests/filetests/egraph/icmp.clif
+++ b/cranelift/filetests/filetests/egraph/icmp.clif
@@ -773,3 +773,111 @@ block0(v0: i32, v1: i32):
 ;     v5 = icmp ne v0, v1
 ;     return v5
 ; }
+
+function %shift_nonnegative_i32(i32, i32) -> i8 {
+block0(v0: i32, v1: i32):
+    v2 = sshr v0, v1
+    v3 = iconst.i32 -1
+    v4 = icmp sgt v2, v3
+    return v4
+}
+
+; function %shift_nonnegative_i32(i32, i32) -> i8 fast {
+; block0(v0: i32, v1: i32):
+;     v5 = iconst.i32 0
+;     v6 = icmp sge v0, v5  ; v5 = 0
+;     return v6
+; }
+
+function %eq_rotl_i32(i32, i32, i32) -> i8 {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = rotl v0, v2
+    v4 = rotl v1, v2
+    v5 = icmp eq v3, v4
+    return v5
+}
+
+; function %eq_rotl_i32(i32, i32, i32) -> i8 fast {
+; block0(v0: i32, v1: i32, v2: i32):
+;     v6 = icmp eq v0, v1
+;     return v6
+; }
+
+function %shift_nonnegative_zero(i32, i32) -> i8 {
+block0(v0: i32, v1: i32):
+    v2 = sshr v0, v1
+    v3 = iconst.i32 0
+    v4 = icmp sge v2, v3
+    return v4
+}
+
+; function %shift_nonnegative_zero(i32, i32) -> i8 fast {
+; block0(v0: i32, v1: i32):
+;     v3 = iconst.i32 0
+;     v5 = icmp sge v0, v3  ; v3 = 0
+;     return v5
+; }
+
+function %eq_rotl_distinct_counts(i32, i32, i32, i32) -> i8 {
+block0(v0: i32, v1: i32, v2: i32, v3: i32):
+    v4 = rotl v0, v2
+    v5 = rotl v1, v3
+    v6 = icmp eq v4, v5
+    return v6
+}
+
+; function %eq_rotl_distinct_counts(i32, i32, i32, i32) -> i8 fast {
+; block0(v0: i32, v1: i32, v2: i32, v3: i32):
+;     v4 = rotl v0, v2
+;     v5 = rotl v1, v3
+;     v6 = icmp eq v4, v5
+;     return v6
+; }
+
+function %shift_nonnegative_zero_vector(i32x4, i32) -> i32x4 {
+block0(v0: i32x4, v1: i32):
+    v2 = sshr v0, v1
+    v3 = vconst.i32x4 0x00000000000000000000000000000000
+    v4 = icmp sge v2, v3
+    return v4
+}
+
+; function %shift_nonnegative_zero_vector(i32x4, i32) -> i32x4 fast {
+;     const0 = 0x00000000000000000000000000000000
+;
+; block0(v0: i32x4, v1: i32):
+;     v3 = vconst.i32x4 const0
+;     v5 = icmp sge v0, v3  ; v3 = const0
+;     return v5
+; }
+
+function %ult_zero_vector(i32x4) -> i32x4 {
+block0(v0: i32x4):
+    v1 = vconst.i32x4 0x00000000000000000000000000000000
+    v2 = icmp ult v0, v1
+    return v2
+}
+
+; function %ult_zero_vector(i32x4) -> i32x4 fast {
+;     const0 = 0x00000000000000000000000000000000
+;
+; block0(v0: i32x4):
+;     v1 = vconst.i32x4 const0
+;     return v1  ; v1 = const0
+; }
+
+function %uge_zero_vector(i32x4) -> i32x4 {
+block0(v0: i32x4):
+    v1 = vconst.i32x4 0x00000000000000000000000000000000
+    v2 = icmp uge v0, v1
+    return v2
+}
+
+; function %uge_zero_vector(i32x4) -> i32x4 fast {
+;     const0 = 0x00000000000000000000000000000000
+;     const1 = 0xffffffffffffffffffffffffffffffff
+;
+; block0(v0: i32x4):
+;     v5 = vconst.i32x4 const1
+;     return v5  ; v5 = const1
+; }

--- a/cranelift/filetests/filetests/egraph/issue-12328.clif
+++ b/cranelift/filetests/filetests/egraph/issue-12328.clif
@@ -9,8 +9,8 @@ block0(v0: i32x4, v1: i32x4):
     v4 = band v2, v3
     return v4
     ; check: const0 = 0x00000000000000000000000000000000
-    ; check: v7 = vconst.i32x4 const0
-    ; check: return v7  ; v7 = const0
+    ; check: v5 = vconst.i32x4 const0
+    ; check: return v5  ; v5 = const0
 }
 
 function %slt_sgt_i32x4(i32x4, i32x4) -> i32x4 {
@@ -20,8 +20,8 @@ block0(v0: i32x4, v1: i32x4):
     v4 = band v2, v3
     return v4
     ; check: const0 = 0x00000000000000000000000000000000
-    ; check: v7 = vconst.i32x4 const0
-    ; check: return v7  ; v7 = const0
+    ; check: v5 = vconst.i32x4 const0
+    ; check: return v5  ; v5 = const0
 }
 
 function %ugt_ult_i32x4(i32x4, i32x4) -> i32x4 {
@@ -31,8 +31,8 @@ block0(v0: i32x4, v1: i32x4):
     v4 = band v2, v3
     return v4
     ; check: const0 = 0x00000000000000000000000000000000
-    ; check: v7 = vconst.i32x4 const0
-    ; check: return v7  ; v7 = const0
+    ; check: v5 = vconst.i32x4 const0
+    ; check: return v5  ; v5 = const0
 }
 
 function %ult_ugt_i32x4(i32x4, i32x4) -> i32x4 {
@@ -42,8 +42,8 @@ block0(v0: i32x4, v1: i32x4):
     v4 = band v2, v3
     return v4
     ; check: const0 = 0x00000000000000000000000000000000
-    ; check: v7 = vconst.i32x4 const0
-    ; check: return v7  ; v7 = const0
+    ; check: v5 = vconst.i32x4 const0
+    ; check: return v5  ; v5 = const0
 }
 
 function %sgt_slt_i64x2(i64x2, i64x2) -> i64x2 {
@@ -53,8 +53,8 @@ block0(v0: i64x2, v1: i64x2):
     v4 = band v2, v3
     return v4
     ; check: const0 = 0x00000000000000000000000000000000
-    ; check: v7 = vconst.i64x2 const0
-    ; check: return v7  ; v7 = const0
+    ; check: v5 = vconst.i64x2 const0
+    ; check: return v5  ; v5 = const0
 }
 
 function %slt_sgt_i16x8(i16x8, i16x8) -> i16x8 {
@@ -64,8 +64,8 @@ block0(v0: i16x8, v1: i16x8):
     v4 = band v2, v3
     return v4
     ; check: const0 = 0x00000000000000000000000000000000
-    ; check: v7 = vconst.i16x8 const0
-    ; check: return v7  ; v7 = const0
+    ; check: v5 = vconst.i16x8 const0
+    ; check: return v5  ; v5 = const0
 }
 
 function %ugt_ult_i8x16(i8x16, i8x16) -> i8x16 {
@@ -75,6 +75,6 @@ block0(v0: i8x16, v1: i8x16):
     v4 = band v2, v3
     return v4
     ; check: const0 = 0x00000000000000000000000000000000
-    ; check: v7 = vconst.i8x16 const0
-    ; check: return v7  ; v7 = const0
+    ; check: v5 = vconst.i8x16 const0
+    ; check: return v5  ; v5 = const0
 }

--- a/cranelift/filetests/filetests/egraph/shifts2.clif
+++ b/cranelift/filetests/filetests/egraph/shifts2.clif
@@ -32,3 +32,121 @@ block0(v0: i64, v1: i64, v3: i64):
 ;     return v7
 ; }
 
+function %not_sshr_not_i32(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = bnot v0
+    v3 = sshr v2, v1
+    v4 = bnot v3
+    return v4
+}
+
+; function %not_sshr_not_i32(i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32):
+;     v5 = sshr v0, v1
+;     return v5
+; }
+
+function %not_ushr_not_i32(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = bnot v0
+    v3 = ushr v2, v1
+    v4 = bnot v3
+    return v4
+}
+
+; function %not_ushr_not_i32(i32, i32) -> i32 fast {
+; block0(v0: i32, v1: i32):
+;     v2 = bnot v0
+;     v3 = ushr v2, v1
+;     v4 = bnot v3
+;     return v4
+; }
+
+function %not_sshr_not_vector(i32x4, i32) -> i32x4 {
+block0(v0: i32x4, v1: i32):
+    v2 = bnot v0
+    v3 = sshr v2, v1
+    v4 = bnot v3
+    return v4
+}
+
+; function %not_sshr_not_vector(i32x4, i32) -> i32x4 fast {
+; block0(v0: i32x4, v1: i32):
+;     v5 = sshr v0, v1
+;     return v5
+; }
+
+function %ishl_zero_vector(i32) -> i32x4 {
+block0(v0: i32):
+    v1 = vconst.i32x4 0x00000000000000000000000000000000
+    v2 = ishl v1, v0
+    return v2
+}
+
+; function %ishl_zero_vector(i32) -> i32x4 fast {
+;     const0 = 0x00000000000000000000000000000000
+;
+; block0(v0: i32):
+;     v1 = vconst.i32x4 const0
+;     return v1  ; v1 = const0
+; }
+
+function %ushr_zero_vector(i32) -> i32x4 {
+block0(v0: i32):
+    v1 = vconst.i32x4 0x00000000000000000000000000000000
+    v2 = ushr v1, v0
+    return v2
+}
+
+; function %ushr_zero_vector(i32) -> i32x4 fast {
+;     const0 = 0x00000000000000000000000000000000
+;
+; block0(v0: i32):
+;     v1 = vconst.i32x4 const0
+;     return v1  ; v1 = const0
+; }
+
+function %sshr_zero_vector(i32) -> i32x4 {
+block0(v0: i32):
+    v1 = vconst.i32x4 0x00000000000000000000000000000000
+    v2 = sshr v1, v0
+    return v2
+}
+
+; function %sshr_zero_vector(i32) -> i32x4 fast {
+;     const0 = 0x00000000000000000000000000000000
+;
+; block0(v0: i32):
+;     v1 = vconst.i32x4 const0
+;     return v1  ; v1 = const0
+; }
+
+function %rotl_zero_vector(i32) -> i32x4 {
+block0(v0: i32):
+    v1 = vconst.i32x4 0x00000000000000000000000000000000
+    v2 = rotl v1, v0
+    return v2
+}
+
+; function %rotl_zero_vector(i32) -> i32x4 fast {
+;     const0 = 0x00000000000000000000000000000000
+;
+; block0(v0: i32):
+;     v1 = vconst.i32x4 const0
+;     return v1  ; v1 = const0
+; }
+
+function %rotr_zero_vector(i32) -> i32x4 {
+block0(v0: i32):
+    v1 = vconst.i32x4 0x00000000000000000000000000000000
+    v2 = rotr v1, v0
+    return v2
+}
+
+; function %rotr_zero_vector(i32) -> i32x4 fast {
+;     const0 = 0x00000000000000000000000000000000
+;
+; block0(v0: i32):
+;     v1 = vconst.i32x4 const0
+;     return v1  ; v1 = const0
+; }

--- a/cranelift/filetests/filetests/runtests/fold-bitops.clif
+++ b/cranelift/filetests/filetests/runtests/fold-bitops.clif
@@ -290,3 +290,105 @@ block0(v0: i32, v1: i32):
 
 ; run: %test_bxor_bor_bnot_bxor(0, 0) == 0xffffffff
 ; run: %test_bxor_bor_bnot_bxor(1, 0) == 0xffffffff
+
+function %udiv_shift_i32(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = iconst.i32 1
+    v3 = ishl v2, v1
+    v4 = udiv v0, v3
+    return v4
+}
+; run: %udiv_shift_i32(0, 0) == 0
+; run: %udiv_shift_i32(123, 0) == 123
+; run: %udiv_shift_i32(-1, 1) == 2147483647
+; run: %udiv_shift_i32(-1, 31) == 1
+; run: %udiv_shift_i32(-1, 32) == -1
+; run: %udiv_shift_i32(-1, 33) == 2147483647
+; run: %udiv_shift_i32(-1, -1) == 1
+; run: %udiv_shift_i32(-2147483648, 31) == 1
+
+function %shift_nonnegative_i32(i32, i32) -> i8 {
+block0(v0: i32, v1: i32):
+    v2 = sshr v0, v1
+    v3 = iconst.i32 -1
+    v4 = icmp sgt v2, v3
+    return v4
+}
+; run: %shift_nonnegative_i32(0, 0) == 1
+; run: %shift_nonnegative_i32(1, 31) == 1
+; run: %shift_nonnegative_i32(-1, 0) == 0
+; run: %shift_nonnegative_i32(-1, 32) == 0
+; run: %shift_nonnegative_i32(-2147483648, 31) == 0
+; run: %shift_nonnegative_i32(2147483647, -1) == 1
+; run: %shift_nonnegative_i32(-2147483648, 33) == 0
+
+function %eq_rotl_i32(i32, i32, i32) -> i8 {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = rotl v0, v2
+    v4 = rotl v1, v2
+    v5 = icmp eq v3, v4
+    return v5
+}
+; run: %eq_rotl_i32(0, 0, 0) == 1
+; run: %eq_rotl_i32(1, 2, 31) == 0
+; run: %eq_rotl_i32(-1, -1, -1) == 1
+; run: %eq_rotl_i32(1, 1, 32) == 1
+; run: %eq_rotl_i32(-2147483648, 2147483647, 33) == 0
+
+function %not_sshr_not_i32(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = bnot v0
+    v3 = sshr v2, v1
+    v4 = bnot v3
+    return v4
+}
+; run: %not_sshr_not_i32(0, 0) == 0
+; run: %not_sshr_not_i32(0, 31) == 0
+; run: %not_sshr_not_i32(-1, 1) == -1
+; run: %not_sshr_not_i32(2147483647, 1) == 1073741823
+; run: %not_sshr_not_i32(-2147483648, 31) == -1
+; run: %not_sshr_not_i32(-2147483648, 32) == -2147483648
+; run: %not_sshr_not_i32(-2147483648, 33) == -1073741824
+; run: %not_sshr_not_i32(-1, -1) == -1
+
+function %not_ushr_not_i32(i32, i32) -> i32 {
+block0(v0: i32, v1: i32):
+    v2 = bnot v0
+    v3 = ushr v2, v1
+    v4 = bnot v3
+    return v4
+}
+; run: %not_ushr_not_i32(0, 1) == -2147483648
+; run: %not_ushr_not_i32(-1, 31) == -1
+
+function %udiv_shift_i64(i64, i64) -> i64 {
+block0(v0: i64, v1: i64):
+    v2 = iconst.i64 1
+    v3 = ishl v2, v1
+    v4 = udiv v0, v3
+    return v4
+}
+; run: %udiv_shift_i64(-1, 63) == 1
+; run: %udiv_shift_i64(-1, 64) == -1
+; run: %udiv_shift_i64(-1, 65) == 9223372036854775807
+; run: %udiv_shift_i64(-1, -1) == 1
+
+function %neg_low_bit_i8(i8) -> i8 {
+block0(v0: i8):
+    v1 = ineg v0
+    v2 = iconst.i8 1
+    v3 = band v1, v2
+    return v3
+}
+; run: %neg_low_bit_i8(-128) == 0
+; run: %neg_low_bit_i8(127) == 1
+
+function %not_sub_not_i64(i64, i64) -> i64 {
+block0(v0: i64, v1: i64):
+    v2 = bnot v0
+    v3 = isub v2, v1
+    v4 = bnot v3
+    return v4
+}
+; run: %not_sub_not_i64(9223372036854775807, 1) == -9223372036854775808
+; run: %not_sub_not_i64(-9223372036854775808, -1) == 9223372036854775807

--- a/cranelift/filetests/filetests/runtests/simd-vector.clif
+++ b/cranelift/filetests/filetests/runtests/simd-vector.clif
@@ -22,3 +22,56 @@ block0(v0: i64x2):
 
 ; run: %test_bxor_x_x_i64x2([0 0]) == [0 0]
 ; run: %test_bxor_x_x_i64x2([0x123456789abcdef0 0xffffffffffffffff]) == [0 0]
+
+function %xor_common_vector(i32x4, i32x4, i32x4) -> i32x4 {
+block0(v0: i32x4, v1: i32x4, v2: i32x4):
+    v3 = bxor v0, v1
+    v4 = bxor v0, v2
+    v5 = bxor v3, v4
+    return v5
+}
+; run: %xor_common_vector([1 2 -1 -2147483648], [0 85 -1 -2147483648], [1 170 -1 2147483647]) == [1 255 0 -1]
+
+function %not_sshr_not_vector(i32x4, i32) -> i32x4 {
+block0(v0: i32x4, v1: i32):
+    v2 = bnot v0
+    v3 = sshr v2, v1
+    v4 = bnot v3
+    return v4
+}
+; run: %not_sshr_not_vector([0 2147483647 -1 -2147483648], 31) == [0 0 -1 -1]
+; run: %not_sshr_not_vector([0 2147483647 -1 -2147483648], 32) == [0 2147483647 -1 -2147483648]
+
+function %shift_nonnegative_zero_vector(i32x4, i32) -> i32x4 {
+block0(v0: i32x4, v1: i32):
+    v2 = sshr v0, v1
+    v3 = vconst.i32x4 0x00000000000000000000000000000000
+    v4 = icmp sge v2, v3
+    return v4
+}
+; run: %shift_nonnegative_zero_vector([0 2147483647 -1 -2147483648], 31) == [-1 -1 0 0]
+; run: %shift_nonnegative_zero_vector([0 2147483647 -1 -2147483648], 32) == [-1 -1 0 0]
+
+function %zero_sub_vector(i32x4) -> i32x4 {
+block0(v0: i32x4):
+    v1 = vconst.i32x4 0x00000000000000000000000000000000
+    v2 = isub v1, v0
+    return v2
+}
+; run: %zero_sub_vector([0 1 -1 -2147483648]) == [0 -1 1 -2147483648]
+
+function %ult_zero_vector(i32x4) -> i32x4 {
+block0(v0: i32x4):
+    v1 = vconst.i32x4 0x00000000000000000000000000000000
+    v2 = icmp ult v0, v1
+    return v2
+}
+; run: %ult_zero_vector([0 1 -1 -2147483648]) == [0 0 0 0]
+
+function %uge_zero_vector(i32x4) -> i32x4 {
+block0(v0: i32x4):
+    v1 = vconst.i32x4 0x00000000000000000000000000000000
+    v2 = icmp uge v0, v1
+    return v2
+}
+; run: %uge_zero_vector([0 1 -1 -2147483648]) == [-1 -1 -1 -1]


### PR DESCRIPTION
Add new opt rules:

- `x /u (1 << y) ==> x >>u y`
- `(x ^ y) ^ (x ^ z) ==> y ^ z`
- `(-x) & 1 ==> x & 1`
- `(x >>s y) >s -1 ==> x >=s 0`
- `(x >>s y) >=s 0 ==> x >=s 0`
- `(x & y) & (x | z) ==> x & y`
- `(x & y) | (x | z) ==> x | z`
- `(x & y) | (x ^ y) ==> x | y`
- `~((~x) - y) ==> x + y`
- `rotl(x, k) == rotl(y, k) ==> x == y`
- `~((~x) >>s y) ==> x >>s y`

Apply `all_zero` helper to existing zero-constant rules in:

{arithmetic, bitops, cprop, extends, icmp, selects, shifts}.isle