### PR TITLE
Fix native stack-walking on macOS arm64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,6 +992,7 @@ version = "0.136.0-dev"
 dependencies = [
  "cranelift-codegen",
  "libc",
+ "mach2 0.6.0",
  "target-lexicon 0.13.5",
 ]
 
@@ -4594,6 +4595,7 @@ version = "49.0.0-dev"
 dependencies = [
  "addr2line 0.26.0",
  "async-trait",
+ "backtrace",
  "bitflags 2.11.1",
  "bumpalo",
  "bytes",

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -18,6 +18,9 @@ target-lexicon = { workspace = true }
 [target.'cfg(target_arch = "riscv64")'.dependencies]
 libc = { workspace = true }
 
+[target.'cfg(all(target_arch = "aarch64", target_os = "macos"))'.dependencies]
+mach2 = { workspace = true }
+
 [features]
 default = ["std"]
 std = ["cranelift-codegen/std"]

--- a/cranelift/native/src/lib.rs
+++ b/cranelift/native/src/lib.rs
@@ -10,6 +10,9 @@ use target_lexicon::Triple;
 #[cfg(all(target_arch = "riscv64", target_os = "linux"))]
 mod riscv;
 
+#[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+mod macos;
+
 /// Return an `isa` builder configured for the current host
 /// machine, or `Err(())` if the host machine is not supported
 /// in the current configuration.
@@ -130,10 +133,15 @@ pub fn infer_native_flags(isa_builder: &mut dyn Configurable) -> Result<(), &'st
             isa_builder.enable("has_i8mm").unwrap();
         }
 
-        if cfg!(target_os = "macos") {
-            // Pointer authentication is always available on Apple Silicon.
-            isa_builder.enable("sign_return_address").unwrap();
+        #[cfg(target_os = "macos")]
+        {
+            // Describing return addresses as signed when macOS has disabled
+            // pointer authentication makes the system DWARF unwinder reject them.
+            if macos::pointer_authentication_enabled()? {
+                isa_builder.enable("sign_return_address").unwrap();
+            }
             // macOS enforces the use of the B key for return addresses.
+            // Keep this default even when signing is explicitly enabled later.
             isa_builder.enable("sign_return_address_with_bkey").unwrap();
         }
     }

--- a/cranelift/native/src/macos.rs
+++ b/cranelift/native/src/macos.rs
@@ -1,0 +1,39 @@
+//! Runtime pointer-authentication state on macOS.
+
+use mach2::kern_return::KERN_SUCCESS;
+use mach2::mach_init::mach_thread_self;
+use mach2::mach_port::mach_port_deallocate;
+use mach2::structs::arm_thread_state64_t;
+use mach2::thread_act::thread_get_state;
+use mach2::thread_status::ARM_THREAD_STATE64;
+use mach2::traps::mach_task_self;
+
+pub(super) fn pointer_authentication_enabled() -> Result<bool, &'static str> {
+    // macOS disables pointer authentication for ordinary arm64 executables and
+    // some arm64e plugin hosts. Read the current thread's state rather than
+    // inferring this from CPU features or the executable's Mach-O header.
+    let mut state = arm_thread_state64_t::default();
+    let mut count = arm_thread_state64_t::count();
+    // SAFETY: mach_thread_self supplies an owned send right to this thread.
+    // The buffer and count match ARM_THREAD_STATE64, and the right is released
+    // after the query, including when the query fails.
+    let result = unsafe {
+        let thread = mach_thread_self();
+        let result = thread_get_state(
+            thread,
+            ARM_THREAD_STATE64,
+            (&mut state as *mut arm_thread_state64_t).cast(),
+            &mut count,
+        );
+        mach_port_deallocate(mach_task_self(), thread);
+        result
+    };
+    if result != KERN_SUCCESS || count != arm_thread_state64_t::count() {
+        return Err("failed to query macOS pointer authentication state");
+    }
+
+    // mach/arm/_structs.h calls this field __opaque_flags when pointer
+    // authentication is enabled at compile time, and __pad otherwise.
+    const ARM_THREAD_STATE64_FLAGS_NO_PTRAUTH: u32 = 0x1;
+    Ok(state.__pad & ARM_THREAD_STATE64_FLAGS_NO_PTRAUTH == 0)
+}

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -93,6 +93,7 @@ mach2 = { workspace = true, optional = true }
 rustix = { workspace = true, optional = true, features = ["mm", "param"] }
 
 [dev-dependencies]
+backtrace = { workspace = true }
 env_logger = { workspace = true }
 proptest = { workspace = true }
 rand = { workspace = true, features = ['thread_rng'] }
@@ -117,6 +118,10 @@ harness = false
 [[test]]
 name = "pooling_alloc_near_oom"
 harness = false
+
+[[test]]
+name = "native_backtrace"
+required-features = ["cranelift", "runtime", "std", "wat"]
 
 # =============================================================================
 #

--- a/crates/wasmtime/tests/native_backtrace.rs
+++ b/crates/wasmtime/tests/native_backtrace.rs
@@ -1,0 +1,112 @@
+#![cfg(all(any(unix, windows), has_host_compiler_backend, not(miri)))]
+
+use wasmtime::{Caller, Config, Engine, Func, Inlining, Instance, Module, Result, Store};
+
+fn check_stack(wat: &str, expected: &[&str], value: i32) -> Result<()> {
+    let mut config = Config::new();
+    config
+        .native_unwind_info(true)
+        .compiler_inlining(Inlining::No);
+    let engine = Engine::new(&config)?;
+    let module = Module::new(&engine, wat)?;
+    let start = module.text().as_ptr() as usize;
+    let functions = module
+        .functions()
+        .map(|f| (f.name, start + f.offset, f.len))
+        .collect::<Vec<_>>();
+    let mut store = Store::new(&engine, Vec::<usize>::with_capacity(128));
+    let capture = Func::wrap(&mut store, |mut caller: Caller<'_, Vec<usize>>| {
+        backtrace::trace(|frame| {
+            let frames = caller.data_mut();
+            // Stop before growing the buffer to avoid allocating in the callback.
+            if frames.len() == frames.capacity() {
+                return false;
+            }
+            frames.push(frame.ip() as usize);
+            true
+        });
+        10_i32
+    });
+    let instance = Instance::new(&mut store, &module, &[capture.into()])?;
+    let actual = instance
+        .get_typed_func::<(), i32>(&mut store, "run")?
+        .call(&mut store, ())?;
+    assert_eq!(actual, value);
+    let names = store
+        .data()
+        .iter()
+        .filter_map(|pc| {
+            // A recovered return address may point one byte past a function.
+            functions
+                .iter()
+                .find(|(_, lo, len)| *pc > *lo && *pc <= *lo + *len)
+                .and_then(|(name, _, _)| name.as_deref())
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(names, expected);
+    Ok(())
+}
+
+#[test]
+fn native_unwind_through_host_call() -> Result<()> {
+    check_stack(
+        r#"(module
+            (import "" "capture" (func $capture (result i32)))
+            (func $inner (result i32) call $capture i32.const 1 i32.add)
+            (func $middle (result i32) call $inner i32.const 2 i32.add)
+            (func $run (export "run") (result i32) call $middle i32.const 4 i32.add))"#,
+        &["inner", "middle", "run"],
+        17,
+    )
+}
+
+#[test]
+fn native_unwind_after_tail_call_changes_stack_arguments() -> Result<()> {
+    // More arguments than fit in registers forces the tail caller to resize
+    // the stack. Its frame must disappear, while its caller remains walkable.
+    let params = "i32 ".repeat(24);
+    let args = "i32.const 1 ".repeat(24);
+    check_stack(
+        &format!(
+            r#"(module
+                (import "" "capture" (func $capture (result i32)))
+                (func $inner (param {params}) (result i32)
+                    call $capture local.get 23 i32.add)
+                (func $tail (result i32) {args} return_call $inner)
+                (func $run (export "run") (result i32)
+                    call $tail i32.const 4 i32.add))"#,
+        ),
+        &["inner", "run"],
+        15,
+    )
+}
+
+#[test]
+fn native_unwind_after_tail_call_to_host() -> Result<()> {
+    check_stack(
+        r#"(module
+            (import "" "capture" (func $capture (result i32)))
+            (func $tail (result i32) return_call $capture)
+            (func $run (export "run") (result i32) call $tail i32.const 4 i32.add))"#,
+        &["run"],
+        14,
+    )
+}
+
+#[test]
+fn native_unwind_after_tail_call_removes_stack_arguments() -> Result<()> {
+    let params = "i32 ".repeat(24);
+    let args = "i32.const 1 ".repeat(24);
+    check_stack(
+        &format!(
+            r#"(module
+                (import "" "capture" (func $capture (result i32)))
+                (func $inner (result i32) call $capture i32.const 1 i32.add)
+                (func $tail (param {params}) (result i32) return_call $inner)
+                (func $run (export "run") (result i32)
+                    {args} call $tail i32.const 4 i32.add))"#,
+        ),
+        &["inner", "run"],
+        15,
+    )
+}


### PR DESCRIPTION
macOS disables pointer authentication for ordinary arm64 executables. This PR checks the main executable’s Mach-O header and enables return-address signing by default only for arm64e processes.

Previously, Cranelift generated unwind metadata that incorrectly described unsigned return addresses as signed. This caused native backtraces captured inside host imports to stop before recovering the Wasm callers. 

The issue was discovered while developing native stack-walking tests in https://github.com/bytecodealliance/wasmtime/pull/14304.