### PR TITLE
Fix debug assert in `ref.test` of `any.convert_extern`-internalized `externref`s

### DIFF
--- a/crates/cranelift/src/func_environ/gc.rs
+++ b/crates/cranelift/src/func_environ/gc.rs
@@ -1274,6 +1274,32 @@ pub fn translate_ref_test(
         WasmHeapType::ConcreteArray(ty)
         | WasmHeapType::ConcreteStruct(ty)
         | WasmHeapType::ConcreteExn(ty) => {
+            // An `anyref` can be a host `externref` internalized by
+            // `any.convert_extern`, and such an object's header holds the
+            // reserved type index rather than a real one, so check the object's
+            // kind before reading it.
+            if val_ty.heap_type == WasmHeapType::Any {
+                let expected_kind = match test_ty.heap_type {
+                    WasmHeapType::ConcreteArray(_) => VMGcKind::ArrayRef,
+                    WasmHeapType::ConcreteStruct(_) => VMGcKind::StructRef,
+                    _ => unreachable!(
+                        "checked all of the `any` hierarchy (top, bottom, and i31ref further above)"
+                    ),
+                };
+                let kind_matches = check_header_kind(func_env, builder, val, expected_kind);
+                let kind_matches_block = builder.create_block();
+                let zero = builder.ins().iconst(ir::types::I32, 0);
+                builder.ins().brif(
+                    kind_matches,
+                    kind_matches_block,
+                    &[],
+                    continue_block,
+                    &[zero.into()],
+                );
+                builder.seal_block(kind_matches_block);
+                builder.switch_to_block(kind_matches_block);
+            }
+
             let expected_interned_ty = ty.unwrap_module_type_index();
             let expected_shared_ty =
                 func_env.module_interned_to_shared_ty(&mut builder.cursor(), expected_interned_ty);

--- a/tests/disas/gc/copying/br-on-cast-fail.wat
+++ b/tests/disas/gc/copying/br-on-cast-fail.wat
@@ -18,11 +18,11 @@
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 123 ""
 ;;     region1 = 160 ""
-;;     region2 = 130 ""
-;;     region3 = 6 ""
-;;     region4 = 196 ""
-;;     region5 = 206 ""
-;;     region6 = 108 ""
+;;     region2 = 196 ""
+;;     region3 = 206 ""
+;;     region4 = 108 ""
+;;     region5 = 130 ""
+;;     region6 = 6 ""
 ;;     region7 = 25 ""
 ;;     region8 = 68 ""
 ;;     gv0 = vmctx
@@ -39,35 +39,43 @@
 ;;                                 block3:
 ;; @002e                               v7 = iconst.i32 1
 ;; @002e                               v8 = band.i32 v2, v7  ; v7 = 1
-;;                                     v26 = iconst.i32 0
-;; @002e                               brif v8, block5(v26), block4  ; v26 = 0
+;;                                     v38 = iconst.i32 0
+;; @002e                               brif v8, block5(v38), block4  ; v38 = 0
 ;;
 ;;                                 block4:
-;; @002e                               v13 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002e                               v14 = load.i64 notrap aligned readonly can_move region4 v13+32
-;; @002e                               v12 = uextend.i64 v2
-;; @002e                               v15 = iadd v14, v12
-;; @002e                               v16 = iconst.i64 4
-;; @002e                               v17 = iadd v15, v16  ; v16 = 4
-;; @002e                               v18 = load.i32 user2 readonly region6 v17
-;; @002e                               v10 = load.i64 notrap aligned readonly can_move region2 v0+40
-;; @002e                               v11 = load.i32 notrap aligned readonly can_move region3 v10
-;; @002e                               v19 = icmp eq v18, v11
-;; @002e                               v20 = uextend.i32 v19
-;; @002e                               jump block5(v20)
-;;
-;;                                 block5(v21: i32):
-;; @002e                               brif v21, block6, block2
+;; @002e                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @002e                               v12 = load.i64 notrap aligned readonly can_move region2 v11+32
+;; @002e                               v10 = uextend.i64 v2
+;; @002e                               v13 = iadd v12, v10
+;; @002e                               v16 = load.i32 user2 readonly region4 v13
+;; @002e                               v17 = iconst.i32 -1342177280
+;; @002e                               v18 = band v16, v17  ; v17 = -1342177280
+;; @002e                               v19 = icmp eq v18, v17  ; v17 = -1342177280
+;;                                     v39 = iconst.i32 0
+;; @002e                               brif v19, block6, block5(v39)  ; v39 = 0
 ;;
 ;;                                 block6:
-;; @0034                               v23 = load.i64 notrap aligned readonly can_move region8 v0+56
-;; @0034                               v22 = load.i64 notrap aligned readonly can_move region7 v0+72
-;; @0034                               call_indirect sig0, v23(v22, v0)
+;; @002e                               v28 = iconst.i64 4
+;; @002e                               v29 = iadd.i64 v13, v28  ; v28 = 4
+;; @002e                               v30 = load.i32 user2 readonly region4 v29
+;; @002e                               v22 = load.i64 notrap aligned readonly can_move region5 v0+40
+;; @002e                               v23 = load.i32 notrap aligned readonly can_move region6 v22
+;; @002e                               v31 = icmp eq v30, v23
+;; @002e                               v32 = uextend.i32 v31
+;; @002e                               jump block5(v32)
+;;
+;;                                 block5(v33: i32):
+;; @002e                               brif v33, block7, block2
+;;
+;;                                 block7:
+;; @0034                               v35 = load.i64 notrap aligned readonly can_move region8 v0+56
+;; @0034                               v34 = load.i64 notrap aligned readonly can_move region7 v0+72
+;; @0034                               call_indirect sig0, v35(v34, v0)
 ;; @0036                               return
 ;;
 ;;                                 block2:
-;; @0038                               v25 = load.i64 notrap aligned readonly can_move region8 v0+88
-;; @0038                               v24 = load.i64 notrap aligned readonly can_move region7 v0+104
-;; @0038                               call_indirect sig0, v25(v24, v0)
+;; @0038                               v37 = load.i64 notrap aligned readonly can_move region8 v0+88
+;; @0038                               v36 = load.i64 notrap aligned readonly can_move region7 v0+104
+;; @0038                               call_indirect sig0, v37(v36, v0)
 ;; @003a                               return
 ;; }

--- a/tests/disas/gc/copying/br-on-cast.wat
+++ b/tests/disas/gc/copying/br-on-cast.wat
@@ -18,11 +18,11 @@
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 123 ""
 ;;     region1 = 160 ""
-;;     region2 = 130 ""
-;;     region3 = 6 ""
-;;     region4 = 196 ""
-;;     region5 = 206 ""
-;;     region6 = 108 ""
+;;     region2 = 196 ""
+;;     region3 = 206 ""
+;;     region4 = 108 ""
+;;     region5 = 130 ""
+;;     region6 = 6 ""
 ;;     region7 = 25 ""
 ;;     region8 = 68 ""
 ;;     gv0 = vmctx
@@ -39,35 +39,43 @@
 ;;                                 block3:
 ;; @002f                               v7 = iconst.i32 1
 ;; @002f                               v8 = band.i32 v2, v7  ; v7 = 1
-;;                                     v26 = iconst.i32 0
-;; @002f                               brif v8, block5(v26), block4  ; v26 = 0
+;;                                     v38 = iconst.i32 0
+;; @002f                               brif v8, block5(v38), block4  ; v38 = 0
 ;;
 ;;                                 block4:
-;; @002f                               v13 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002f                               v14 = load.i64 notrap aligned readonly can_move region4 v13+32
-;; @002f                               v12 = uextend.i64 v2
-;; @002f                               v15 = iadd v14, v12
-;; @002f                               v16 = iconst.i64 4
-;; @002f                               v17 = iadd v15, v16  ; v16 = 4
-;; @002f                               v18 = load.i32 user2 readonly region6 v17
-;; @002f                               v10 = load.i64 notrap aligned readonly can_move region2 v0+40
-;; @002f                               v11 = load.i32 notrap aligned readonly can_move region3 v10
-;; @002f                               v19 = icmp eq v18, v11
-;; @002f                               v20 = uextend.i32 v19
-;; @002f                               jump block5(v20)
-;;
-;;                                 block5(v21: i32):
-;; @002f                               brif v21, block2, block6
+;; @002f                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @002f                               v12 = load.i64 notrap aligned readonly can_move region2 v11+32
+;; @002f                               v10 = uextend.i64 v2
+;; @002f                               v13 = iadd v12, v10
+;; @002f                               v16 = load.i32 user2 readonly region4 v13
+;; @002f                               v17 = iconst.i32 -1342177280
+;; @002f                               v18 = band v16, v17  ; v17 = -1342177280
+;; @002f                               v19 = icmp eq v18, v17  ; v17 = -1342177280
+;;                                     v39 = iconst.i32 0
+;; @002f                               brif v19, block6, block5(v39)  ; v39 = 0
 ;;
 ;;                                 block6:
-;; @0035                               v23 = load.i64 notrap aligned readonly can_move region8 v0+56
-;; @0035                               v22 = load.i64 notrap aligned readonly can_move region7 v0+72
-;; @0035                               call_indirect sig0, v23(v22, v0)
+;; @002f                               v28 = iconst.i64 4
+;; @002f                               v29 = iadd.i64 v13, v28  ; v28 = 4
+;; @002f                               v30 = load.i32 user2 readonly region4 v29
+;; @002f                               v22 = load.i64 notrap aligned readonly can_move region5 v0+40
+;; @002f                               v23 = load.i32 notrap aligned readonly can_move region6 v22
+;; @002f                               v31 = icmp eq v30, v23
+;; @002f                               v32 = uextend.i32 v31
+;; @002f                               jump block5(v32)
+;;
+;;                                 block5(v33: i32):
+;; @002f                               brif v33, block2, block7
+;;
+;;                                 block7:
+;; @0035                               v35 = load.i64 notrap aligned readonly can_move region8 v0+56
+;; @0035                               v34 = load.i64 notrap aligned readonly can_move region7 v0+72
+;; @0035                               call_indirect sig0, v35(v34, v0)
 ;; @0037                               return
 ;;
 ;;                                 block2:
-;; @0039                               v25 = load.i64 notrap aligned readonly can_move region8 v0+88
-;; @0039                               v24 = load.i64 notrap aligned readonly can_move region7 v0+104
-;; @0039                               call_indirect sig0, v25(v24, v0)
+;; @0039                               v37 = load.i64 notrap aligned readonly can_move region8 v0+88
+;; @0039                               v36 = load.i64 notrap aligned readonly can_move region7 v0+104
+;; @0039                               call_indirect sig0, v37(v36, v0)
 ;; @003b                               return
 ;; }

--- a/tests/disas/gc/copying/ref-cast.wat
+++ b/tests/disas/gc/copying/ref-cast.wat
@@ -10,11 +10,11 @@
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 123 ""
 ;;     region1 = 160 ""
-;;     region2 = 130 ""
-;;     region3 = 6 ""
-;;     region4 = 196 ""
-;;     region5 = 206 ""
-;;     region6 = 108 ""
+;;     region2 = 196 ""
+;;     region3 = 206 ""
+;;     region4 = 108 ""
+;;     region5 = 130 ""
+;;     region6 = 6 ""
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -28,25 +28,33 @@
 ;;                                 block2:
 ;; @001e                               v7 = iconst.i32 1
 ;; @001e                               v8 = band.i32 v2, v7  ; v7 = 1
-;;                                     v22 = iconst.i32 0
-;; @001e                               brif v8, block4(v22), block3  ; v22 = 0
+;;                                     v34 = iconst.i32 0
+;; @001e                               brif v8, block4(v34), block3  ; v34 = 0
 ;;
 ;;                                 block3:
-;; @001e                               v13 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001e                               v14 = load.i64 notrap aligned readonly can_move region4 v13+32
-;; @001e                               v12 = uextend.i64 v2
-;; @001e                               v15 = iadd v14, v12
-;; @001e                               v16 = iconst.i64 4
-;; @001e                               v17 = iadd v15, v16  ; v16 = 4
-;; @001e                               v18 = load.i32 user2 readonly region6 v17
-;; @001e                               v10 = load.i64 notrap aligned readonly can_move region2 v0+40
-;; @001e                               v11 = load.i32 notrap aligned readonly can_move region3 v10
-;; @001e                               v19 = icmp eq v18, v11
-;; @001e                               v20 = uextend.i32 v19
-;; @001e                               jump block4(v20)
+;; @001e                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001e                               v12 = load.i64 notrap aligned readonly can_move region2 v11+32
+;; @001e                               v10 = uextend.i64 v2
+;; @001e                               v13 = iadd v12, v10
+;; @001e                               v16 = load.i32 user2 readonly region4 v13
+;; @001e                               v17 = iconst.i32 -1342177280
+;; @001e                               v18 = band v16, v17  ; v17 = -1342177280
+;; @001e                               v19 = icmp eq v18, v17  ; v17 = -1342177280
+;;                                     v35 = iconst.i32 0
+;; @001e                               brif v19, block5, block4(v35)  ; v35 = 0
 ;;
-;;                                 block4(v21: i32):
-;; @001e                               trapz v21, user19
+;;                                 block5:
+;; @001e                               v28 = iconst.i64 4
+;; @001e                               v29 = iadd.i64 v13, v28  ; v28 = 4
+;; @001e                               v30 = load.i32 user2 readonly region4 v29
+;; @001e                               v22 = load.i64 notrap aligned readonly can_move region5 v0+40
+;; @001e                               v23 = load.i32 notrap aligned readonly can_move region6 v22
+;; @001e                               v31 = icmp eq v30, v23
+;; @001e                               v32 = uextend.i32 v31
+;; @001e                               jump block4(v32)
+;;
+;;                                 block4(v33: i32):
+;; @001e                               trapz v33, user19
 ;; @0021                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/copying/ref-test-concrete-type.wat
+++ b/tests/disas/gc/copying/ref-test-concrete-type.wat
@@ -10,11 +10,11 @@
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 123 ""
 ;;     region1 = 160 ""
-;;     region2 = 130 ""
-;;     region3 = 6 ""
-;;     region4 = 196 ""
-;;     region5 = 206 ""
-;;     region6 = 108 ""
+;;     region2 = 196 ""
+;;     region3 = 206 ""
+;;     region4 = 108 ""
+;;     region5 = 130 ""
+;;     region6 = 6 ""
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -28,26 +28,34 @@
 ;;                                 block2:
 ;; @001d                               v7 = iconst.i32 1
 ;; @001d                               v8 = band.i32 v2, v7  ; v7 = 1
-;;                                     v22 = iconst.i32 0
-;; @001d                               brif v8, block4(v22), block3  ; v22 = 0
+;;                                     v34 = iconst.i32 0
+;; @001d                               brif v8, block4(v34), block3  ; v34 = 0
 ;;
 ;;                                 block3:
-;; @001d                               v13 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001d                               v14 = load.i64 notrap aligned readonly can_move region4 v13+32
-;; @001d                               v12 = uextend.i64 v2
-;; @001d                               v15 = iadd v14, v12
-;; @001d                               v16 = iconst.i64 4
-;; @001d                               v17 = iadd v15, v16  ; v16 = 4
-;; @001d                               v18 = load.i32 user2 readonly region6 v17
-;; @001d                               v10 = load.i64 notrap aligned readonly can_move region2 v0+40
-;; @001d                               v11 = load.i32 notrap aligned readonly can_move region3 v10
-;; @001d                               v19 = icmp eq v18, v11
-;; @001d                               v20 = uextend.i32 v19
-;; @001d                               jump block4(v20)
+;; @001d                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001d                               v12 = load.i64 notrap aligned readonly can_move region2 v11+32
+;; @001d                               v10 = uextend.i64 v2
+;; @001d                               v13 = iadd v12, v10
+;; @001d                               v16 = load.i32 user2 readonly region4 v13
+;; @001d                               v17 = iconst.i32 -1342177280
+;; @001d                               v18 = band v16, v17  ; v17 = -1342177280
+;; @001d                               v19 = icmp eq v18, v17  ; v17 = -1342177280
+;;                                     v35 = iconst.i32 0
+;; @001d                               brif v19, block5, block4(v35)  ; v35 = 0
 ;;
-;;                                 block4(v21: i32):
+;;                                 block5:
+;; @001d                               v28 = iconst.i64 4
+;; @001d                               v29 = iadd.i64 v13, v28  ; v28 = 4
+;; @001d                               v30 = load.i32 user2 readonly region4 v29
+;; @001d                               v22 = load.i64 notrap aligned readonly can_move region5 v0+40
+;; @001d                               v23 = load.i32 notrap aligned readonly can_move region6 v22
+;; @001d                               v31 = icmp eq v30, v23
+;; @001d                               v32 = uextend.i32 v31
+;; @001d                               jump block4(v32)
+;;
+;;                                 block4(v33: i32):
 ;; @0020                               jump block1
 ;;
 ;;                                 block1:
-;; @0020                               return v21
+;; @0020                               return v33
 ;; }

--- a/tests/disas/gc/drc/br-on-cast-fail.wat
+++ b/tests/disas/gc/drc/br-on-cast-fail.wat
@@ -19,11 +19,11 @@
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 123 ""
 ;;     region1 = 160 ""
-;;     region2 = 130 ""
-;;     region3 = 6 ""
-;;     region4 = 196 ""
-;;     region5 = 206 ""
-;;     region6 = 108 ""
+;;     region2 = 196 ""
+;;     region3 = 206 ""
+;;     region4 = 108 ""
+;;     region5 = 130 ""
+;;     region6 = 6 ""
 ;;     region7 = 25 ""
 ;;     region8 = 68 ""
 ;;     gv0 = vmctx
@@ -40,35 +40,43 @@
 ;;                                 block3:
 ;; @002e                               v7 = iconst.i32 1
 ;; @002e                               v8 = band.i32 v2, v7  ; v7 = 1
-;;                                     v26 = iconst.i32 0
-;; @002e                               brif v8, block5(v26), block4  ; v26 = 0
+;;                                     v38 = iconst.i32 0
+;; @002e                               brif v8, block5(v38), block4  ; v38 = 0
 ;;
 ;;                                 block4:
-;; @002e                               v13 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002e                               v14 = load.i64 notrap aligned readonly can_move region4 v13+32
-;; @002e                               v12 = uextend.i64 v2
-;; @002e                               v15 = iadd v14, v12
-;; @002e                               v16 = iconst.i64 4
-;; @002e                               v17 = iadd v15, v16  ; v16 = 4
-;; @002e                               v18 = load.i32 user2 readonly region6 v17
-;; @002e                               v10 = load.i64 notrap aligned readonly can_move region2 v0+40
-;; @002e                               v11 = load.i32 notrap aligned readonly can_move region3 v10
-;; @002e                               v19 = icmp eq v18, v11
-;; @002e                               v20 = uextend.i32 v19
-;; @002e                               jump block5(v20)
-;;
-;;                                 block5(v21: i32):
-;; @002e                               brif v21, block6, block2
+;; @002e                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @002e                               v12 = load.i64 notrap aligned readonly can_move region2 v11+32
+;; @002e                               v10 = uextend.i64 v2
+;; @002e                               v13 = iadd v12, v10
+;; @002e                               v16 = load.i32 user2 readonly region4 v13
+;; @002e                               v17 = iconst.i32 -1342177280
+;; @002e                               v18 = band v16, v17  ; v17 = -1342177280
+;; @002e                               v19 = icmp eq v18, v17  ; v17 = -1342177280
+;;                                     v39 = iconst.i32 0
+;; @002e                               brif v19, block6, block5(v39)  ; v39 = 0
 ;;
 ;;                                 block6:
-;; @0034                               v23 = load.i64 notrap aligned readonly can_move region8 v0+56
-;; @0034                               v22 = load.i64 notrap aligned readonly can_move region7 v0+72
-;; @0034                               call_indirect sig0, v23(v22, v0)
+;; @002e                               v28 = iconst.i64 4
+;; @002e                               v29 = iadd.i64 v13, v28  ; v28 = 4
+;; @002e                               v30 = load.i32 user2 readonly region4 v29
+;; @002e                               v22 = load.i64 notrap aligned readonly can_move region5 v0+40
+;; @002e                               v23 = load.i32 notrap aligned readonly can_move region6 v22
+;; @002e                               v31 = icmp eq v30, v23
+;; @002e                               v32 = uextend.i32 v31
+;; @002e                               jump block5(v32)
+;;
+;;                                 block5(v33: i32):
+;; @002e                               brif v33, block7, block2
+;;
+;;                                 block7:
+;; @0034                               v35 = load.i64 notrap aligned readonly can_move region8 v0+56
+;; @0034                               v34 = load.i64 notrap aligned readonly can_move region7 v0+72
+;; @0034                               call_indirect sig0, v35(v34, v0)
 ;; @0036                               return
 ;;
 ;;                                 block2:
-;; @0038                               v25 = load.i64 notrap aligned readonly can_move region8 v0+88
-;; @0038                               v24 = load.i64 notrap aligned readonly can_move region7 v0+104
-;; @0038                               call_indirect sig0, v25(v24, v0)
+;; @0038                               v37 = load.i64 notrap aligned readonly can_move region8 v0+88
+;; @0038                               v36 = load.i64 notrap aligned readonly can_move region7 v0+104
+;; @0038                               call_indirect sig0, v37(v36, v0)
 ;; @003a                               return
 ;; }

--- a/tests/disas/gc/drc/br-on-cast.wat
+++ b/tests/disas/gc/drc/br-on-cast.wat
@@ -19,11 +19,11 @@
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 123 ""
 ;;     region1 = 160 ""
-;;     region2 = 130 ""
-;;     region3 = 6 ""
-;;     region4 = 196 ""
-;;     region5 = 206 ""
-;;     region6 = 108 ""
+;;     region2 = 196 ""
+;;     region3 = 206 ""
+;;     region4 = 108 ""
+;;     region5 = 130 ""
+;;     region6 = 6 ""
 ;;     region7 = 25 ""
 ;;     region8 = 68 ""
 ;;     gv0 = vmctx
@@ -40,35 +40,43 @@
 ;;                                 block3:
 ;; @002f                               v7 = iconst.i32 1
 ;; @002f                               v8 = band.i32 v2, v7  ; v7 = 1
-;;                                     v26 = iconst.i32 0
-;; @002f                               brif v8, block5(v26), block4  ; v26 = 0
+;;                                     v38 = iconst.i32 0
+;; @002f                               brif v8, block5(v38), block4  ; v38 = 0
 ;;
 ;;                                 block4:
-;; @002f                               v13 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002f                               v14 = load.i64 notrap aligned readonly can_move region4 v13+32
-;; @002f                               v12 = uextend.i64 v2
-;; @002f                               v15 = iadd v14, v12
-;; @002f                               v16 = iconst.i64 4
-;; @002f                               v17 = iadd v15, v16  ; v16 = 4
-;; @002f                               v18 = load.i32 user2 readonly region6 v17
-;; @002f                               v10 = load.i64 notrap aligned readonly can_move region2 v0+40
-;; @002f                               v11 = load.i32 notrap aligned readonly can_move region3 v10
-;; @002f                               v19 = icmp eq v18, v11
-;; @002f                               v20 = uextend.i32 v19
-;; @002f                               jump block5(v20)
-;;
-;;                                 block5(v21: i32):
-;; @002f                               brif v21, block2, block6
+;; @002f                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @002f                               v12 = load.i64 notrap aligned readonly can_move region2 v11+32
+;; @002f                               v10 = uextend.i64 v2
+;; @002f                               v13 = iadd v12, v10
+;; @002f                               v16 = load.i32 user2 readonly region4 v13
+;; @002f                               v17 = iconst.i32 -1342177280
+;; @002f                               v18 = band v16, v17  ; v17 = -1342177280
+;; @002f                               v19 = icmp eq v18, v17  ; v17 = -1342177280
+;;                                     v39 = iconst.i32 0
+;; @002f                               brif v19, block6, block5(v39)  ; v39 = 0
 ;;
 ;;                                 block6:
-;; @0035                               v23 = load.i64 notrap aligned readonly can_move region8 v0+56
-;; @0035                               v22 = load.i64 notrap aligned readonly can_move region7 v0+72
-;; @0035                               call_indirect sig0, v23(v22, v0)
+;; @002f                               v28 = iconst.i64 4
+;; @002f                               v29 = iadd.i64 v13, v28  ; v28 = 4
+;; @002f                               v30 = load.i32 user2 readonly region4 v29
+;; @002f                               v22 = load.i64 notrap aligned readonly can_move region5 v0+40
+;; @002f                               v23 = load.i32 notrap aligned readonly can_move region6 v22
+;; @002f                               v31 = icmp eq v30, v23
+;; @002f                               v32 = uextend.i32 v31
+;; @002f                               jump block5(v32)
+;;
+;;                                 block5(v33: i32):
+;; @002f                               brif v33, block2, block7
+;;
+;;                                 block7:
+;; @0035                               v35 = load.i64 notrap aligned readonly can_move region8 v0+56
+;; @0035                               v34 = load.i64 notrap aligned readonly can_move region7 v0+72
+;; @0035                               call_indirect sig0, v35(v34, v0)
 ;; @0037                               return
 ;;
 ;;                                 block2:
-;; @0039                               v25 = load.i64 notrap aligned readonly can_move region8 v0+88
-;; @0039                               v24 = load.i64 notrap aligned readonly can_move region7 v0+104
-;; @0039                               call_indirect sig0, v25(v24, v0)
+;; @0039                               v37 = load.i64 notrap aligned readonly can_move region8 v0+88
+;; @0039                               v36 = load.i64 notrap aligned readonly can_move region7 v0+104
+;; @0039                               call_indirect sig0, v37(v36, v0)
 ;; @003b                               return
 ;; }

--- a/tests/disas/gc/drc/ref-cast.wat
+++ b/tests/disas/gc/drc/ref-cast.wat
@@ -11,11 +11,11 @@
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 123 ""
 ;;     region1 = 160 ""
-;;     region2 = 130 ""
-;;     region3 = 6 ""
-;;     region4 = 196 ""
-;;     region5 = 206 ""
-;;     region6 = 108 ""
+;;     region2 = 196 ""
+;;     region3 = 206 ""
+;;     region4 = 108 ""
+;;     region5 = 130 ""
+;;     region6 = 6 ""
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -29,25 +29,33 @@
 ;;                                 block2:
 ;; @001e                               v7 = iconst.i32 1
 ;; @001e                               v8 = band.i32 v2, v7  ; v7 = 1
-;;                                     v22 = iconst.i32 0
-;; @001e                               brif v8, block4(v22), block3  ; v22 = 0
+;;                                     v34 = iconst.i32 0
+;; @001e                               brif v8, block4(v34), block3  ; v34 = 0
 ;;
 ;;                                 block3:
-;; @001e                               v13 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001e                               v14 = load.i64 notrap aligned readonly can_move region4 v13+32
-;; @001e                               v12 = uextend.i64 v2
-;; @001e                               v15 = iadd v14, v12
-;; @001e                               v16 = iconst.i64 4
-;; @001e                               v17 = iadd v15, v16  ; v16 = 4
-;; @001e                               v18 = load.i32 user2 readonly region6 v17
-;; @001e                               v10 = load.i64 notrap aligned readonly can_move region2 v0+40
-;; @001e                               v11 = load.i32 notrap aligned readonly can_move region3 v10
-;; @001e                               v19 = icmp eq v18, v11
-;; @001e                               v20 = uextend.i32 v19
-;; @001e                               jump block4(v20)
+;; @001e                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001e                               v12 = load.i64 notrap aligned readonly can_move region2 v11+32
+;; @001e                               v10 = uextend.i64 v2
+;; @001e                               v13 = iadd v12, v10
+;; @001e                               v16 = load.i32 user2 readonly region4 v13
+;; @001e                               v17 = iconst.i32 -1342177280
+;; @001e                               v18 = band v16, v17  ; v17 = -1342177280
+;; @001e                               v19 = icmp eq v18, v17  ; v17 = -1342177280
+;;                                     v35 = iconst.i32 0
+;; @001e                               brif v19, block5, block4(v35)  ; v35 = 0
 ;;
-;;                                 block4(v21: i32):
-;; @001e                               trapz v21, user19
+;;                                 block5:
+;; @001e                               v28 = iconst.i64 4
+;; @001e                               v29 = iadd.i64 v13, v28  ; v28 = 4
+;; @001e                               v30 = load.i32 user2 readonly region4 v29
+;; @001e                               v22 = load.i64 notrap aligned readonly can_move region5 v0+40
+;; @001e                               v23 = load.i32 notrap aligned readonly can_move region6 v22
+;; @001e                               v31 = icmp eq v30, v23
+;; @001e                               v32 = uextend.i32 v31
+;; @001e                               jump block4(v32)
+;;
+;;                                 block4(v33: i32):
+;; @001e                               trapz v33, user19
 ;; @0021                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/drc/ref-test-concrete-type.wat
+++ b/tests/disas/gc/drc/ref-test-concrete-type.wat
@@ -11,11 +11,11 @@
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 123 ""
 ;;     region1 = 160 ""
-;;     region2 = 130 ""
-;;     region3 = 6 ""
-;;     region4 = 196 ""
-;;     region5 = 206 ""
-;;     region6 = 108 ""
+;;     region2 = 196 ""
+;;     region3 = 206 ""
+;;     region4 = 108 ""
+;;     region5 = 130 ""
+;;     region6 = 6 ""
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -29,26 +29,34 @@
 ;;                                 block2:
 ;; @001d                               v7 = iconst.i32 1
 ;; @001d                               v8 = band.i32 v2, v7  ; v7 = 1
-;;                                     v22 = iconst.i32 0
-;; @001d                               brif v8, block4(v22), block3  ; v22 = 0
+;;                                     v34 = iconst.i32 0
+;; @001d                               brif v8, block4(v34), block3  ; v34 = 0
 ;;
 ;;                                 block3:
-;; @001d                               v13 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001d                               v14 = load.i64 notrap aligned readonly can_move region4 v13+32
-;; @001d                               v12 = uextend.i64 v2
-;; @001d                               v15 = iadd v14, v12
-;; @001d                               v16 = iconst.i64 4
-;; @001d                               v17 = iadd v15, v16  ; v16 = 4
-;; @001d                               v18 = load.i32 user2 readonly region6 v17
-;; @001d                               v10 = load.i64 notrap aligned readonly can_move region2 v0+40
-;; @001d                               v11 = load.i32 notrap aligned readonly can_move region3 v10
-;; @001d                               v19 = icmp eq v18, v11
-;; @001d                               v20 = uextend.i32 v19
-;; @001d                               jump block4(v20)
+;; @001d                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001d                               v12 = load.i64 notrap aligned readonly can_move region2 v11+32
+;; @001d                               v10 = uextend.i64 v2
+;; @001d                               v13 = iadd v12, v10
+;; @001d                               v16 = load.i32 user2 readonly region4 v13
+;; @001d                               v17 = iconst.i32 -1342177280
+;; @001d                               v18 = band v16, v17  ; v17 = -1342177280
+;; @001d                               v19 = icmp eq v18, v17  ; v17 = -1342177280
+;;                                     v35 = iconst.i32 0
+;; @001d                               brif v19, block5, block4(v35)  ; v35 = 0
 ;;
-;;                                 block4(v21: i32):
+;;                                 block5:
+;; @001d                               v28 = iconst.i64 4
+;; @001d                               v29 = iadd.i64 v13, v28  ; v28 = 4
+;; @001d                               v30 = load.i32 user2 readonly region4 v29
+;; @001d                               v22 = load.i64 notrap aligned readonly can_move region5 v0+40
+;; @001d                               v23 = load.i32 notrap aligned readonly can_move region6 v22
+;; @001d                               v31 = icmp eq v30, v23
+;; @001d                               v32 = uextend.i32 v31
+;; @001d                               jump block4(v32)
+;;
+;;                                 block4(v33: i32):
 ;; @0020                               jump block1
 ;;
 ;;                                 block1:
-;; @0020                               return v21
+;; @0020                               return v33
 ;; }

--- a/tests/disas/gc/null/br-on-cast-fail.wat
+++ b/tests/disas/gc/null/br-on-cast-fail.wat
@@ -19,11 +19,11 @@
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 123 ""
 ;;     region1 = 160 ""
-;;     region2 = 130 ""
-;;     region3 = 6 ""
-;;     region4 = 196 ""
-;;     region5 = 206 ""
-;;     region6 = 108 ""
+;;     region2 = 196 ""
+;;     region3 = 206 ""
+;;     region4 = 108 ""
+;;     region5 = 130 ""
+;;     region6 = 6 ""
 ;;     region7 = 25 ""
 ;;     region8 = 68 ""
 ;;     gv0 = vmctx
@@ -40,35 +40,43 @@
 ;;                                 block3:
 ;; @002e                               v7 = iconst.i32 1
 ;; @002e                               v8 = band.i32 v2, v7  ; v7 = 1
-;;                                     v26 = iconst.i32 0
-;; @002e                               brif v8, block5(v26), block4  ; v26 = 0
+;;                                     v38 = iconst.i32 0
+;; @002e                               brif v8, block5(v38), block4  ; v38 = 0
 ;;
 ;;                                 block4:
-;; @002e                               v13 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002e                               v14 = load.i64 notrap aligned readonly can_move region4 v13+32
-;; @002e                               v12 = uextend.i64 v2
-;; @002e                               v15 = iadd v14, v12
-;; @002e                               v16 = iconst.i64 4
-;; @002e                               v17 = iadd v15, v16  ; v16 = 4
-;; @002e                               v18 = load.i32 user2 readonly region6 v17
-;; @002e                               v10 = load.i64 notrap aligned readonly can_move region2 v0+40
-;; @002e                               v11 = load.i32 notrap aligned readonly can_move region3 v10
-;; @002e                               v19 = icmp eq v18, v11
-;; @002e                               v20 = uextend.i32 v19
-;; @002e                               jump block5(v20)
-;;
-;;                                 block5(v21: i32):
-;; @002e                               brif v21, block6, block2
+;; @002e                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @002e                               v12 = load.i64 notrap aligned readonly can_move region2 v11+32
+;; @002e                               v10 = uextend.i64 v2
+;; @002e                               v13 = iadd v12, v10
+;; @002e                               v16 = load.i32 user2 readonly region4 v13
+;; @002e                               v17 = iconst.i32 -1342177280
+;; @002e                               v18 = band v16, v17  ; v17 = -1342177280
+;; @002e                               v19 = icmp eq v18, v17  ; v17 = -1342177280
+;;                                     v39 = iconst.i32 0
+;; @002e                               brif v19, block6, block5(v39)  ; v39 = 0
 ;;
 ;;                                 block6:
-;; @0034                               v23 = load.i64 notrap aligned readonly can_move region8 v0+56
-;; @0034                               v22 = load.i64 notrap aligned readonly can_move region7 v0+72
-;; @0034                               call_indirect sig0, v23(v22, v0)
+;; @002e                               v28 = iconst.i64 4
+;; @002e                               v29 = iadd.i64 v13, v28  ; v28 = 4
+;; @002e                               v30 = load.i32 user2 readonly region4 v29
+;; @002e                               v22 = load.i64 notrap aligned readonly can_move region5 v0+40
+;; @002e                               v23 = load.i32 notrap aligned readonly can_move region6 v22
+;; @002e                               v31 = icmp eq v30, v23
+;; @002e                               v32 = uextend.i32 v31
+;; @002e                               jump block5(v32)
+;;
+;;                                 block5(v33: i32):
+;; @002e                               brif v33, block7, block2
+;;
+;;                                 block7:
+;; @0034                               v35 = load.i64 notrap aligned readonly can_move region8 v0+56
+;; @0034                               v34 = load.i64 notrap aligned readonly can_move region7 v0+72
+;; @0034                               call_indirect sig0, v35(v34, v0)
 ;; @0036                               return
 ;;
 ;;                                 block2:
-;; @0038                               v25 = load.i64 notrap aligned readonly can_move region8 v0+88
-;; @0038                               v24 = load.i64 notrap aligned readonly can_move region7 v0+104
-;; @0038                               call_indirect sig0, v25(v24, v0)
+;; @0038                               v37 = load.i64 notrap aligned readonly can_move region8 v0+88
+;; @0038                               v36 = load.i64 notrap aligned readonly can_move region7 v0+104
+;; @0038                               call_indirect sig0, v37(v36, v0)
 ;; @003a                               return
 ;; }

--- a/tests/disas/gc/null/br-on-cast.wat
+++ b/tests/disas/gc/null/br-on-cast.wat
@@ -19,11 +19,11 @@
 ;; function u0:0(i64 vmctx, i64, i32) tail {
 ;;     region0 = 123 ""
 ;;     region1 = 160 ""
-;;     region2 = 130 ""
-;;     region3 = 6 ""
-;;     region4 = 196 ""
-;;     region5 = 206 ""
-;;     region6 = 108 ""
+;;     region2 = 196 ""
+;;     region3 = 206 ""
+;;     region4 = 108 ""
+;;     region5 = 130 ""
+;;     region6 = 6 ""
 ;;     region7 = 25 ""
 ;;     region8 = 68 ""
 ;;     gv0 = vmctx
@@ -40,35 +40,43 @@
 ;;                                 block3:
 ;; @002f                               v7 = iconst.i32 1
 ;; @002f                               v8 = band.i32 v2, v7  ; v7 = 1
-;;                                     v26 = iconst.i32 0
-;; @002f                               brif v8, block5(v26), block4  ; v26 = 0
+;;                                     v38 = iconst.i32 0
+;; @002f                               brif v8, block5(v38), block4  ; v38 = 0
 ;;
 ;;                                 block4:
-;; @002f                               v13 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002f                               v14 = load.i64 notrap aligned readonly can_move region4 v13+32
-;; @002f                               v12 = uextend.i64 v2
-;; @002f                               v15 = iadd v14, v12
-;; @002f                               v16 = iconst.i64 4
-;; @002f                               v17 = iadd v15, v16  ; v16 = 4
-;; @002f                               v18 = load.i32 user2 readonly region6 v17
-;; @002f                               v10 = load.i64 notrap aligned readonly can_move region2 v0+40
-;; @002f                               v11 = load.i32 notrap aligned readonly can_move region3 v10
-;; @002f                               v19 = icmp eq v18, v11
-;; @002f                               v20 = uextend.i32 v19
-;; @002f                               jump block5(v20)
-;;
-;;                                 block5(v21: i32):
-;; @002f                               brif v21, block2, block6
+;; @002f                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @002f                               v12 = load.i64 notrap aligned readonly can_move region2 v11+32
+;; @002f                               v10 = uextend.i64 v2
+;; @002f                               v13 = iadd v12, v10
+;; @002f                               v16 = load.i32 user2 readonly region4 v13
+;; @002f                               v17 = iconst.i32 -1342177280
+;; @002f                               v18 = band v16, v17  ; v17 = -1342177280
+;; @002f                               v19 = icmp eq v18, v17  ; v17 = -1342177280
+;;                                     v39 = iconst.i32 0
+;; @002f                               brif v19, block6, block5(v39)  ; v39 = 0
 ;;
 ;;                                 block6:
-;; @0035                               v23 = load.i64 notrap aligned readonly can_move region8 v0+56
-;; @0035                               v22 = load.i64 notrap aligned readonly can_move region7 v0+72
-;; @0035                               call_indirect sig0, v23(v22, v0)
+;; @002f                               v28 = iconst.i64 4
+;; @002f                               v29 = iadd.i64 v13, v28  ; v28 = 4
+;; @002f                               v30 = load.i32 user2 readonly region4 v29
+;; @002f                               v22 = load.i64 notrap aligned readonly can_move region5 v0+40
+;; @002f                               v23 = load.i32 notrap aligned readonly can_move region6 v22
+;; @002f                               v31 = icmp eq v30, v23
+;; @002f                               v32 = uextend.i32 v31
+;; @002f                               jump block5(v32)
+;;
+;;                                 block5(v33: i32):
+;; @002f                               brif v33, block2, block7
+;;
+;;                                 block7:
+;; @0035                               v35 = load.i64 notrap aligned readonly can_move region8 v0+56
+;; @0035                               v34 = load.i64 notrap aligned readonly can_move region7 v0+72
+;; @0035                               call_indirect sig0, v35(v34, v0)
 ;; @0037                               return
 ;;
 ;;                                 block2:
-;; @0039                               v25 = load.i64 notrap aligned readonly can_move region8 v0+88
-;; @0039                               v24 = load.i64 notrap aligned readonly can_move region7 v0+104
-;; @0039                               call_indirect sig0, v25(v24, v0)
+;; @0039                               v37 = load.i64 notrap aligned readonly can_move region8 v0+88
+;; @0039                               v36 = load.i64 notrap aligned readonly can_move region7 v0+104
+;; @0039                               call_indirect sig0, v37(v36, v0)
 ;; @003b                               return
 ;; }

--- a/tests/disas/gc/null/ref-cast.wat
+++ b/tests/disas/gc/null/ref-cast.wat
@@ -11,11 +11,11 @@
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 123 ""
 ;;     region1 = 160 ""
-;;     region2 = 130 ""
-;;     region3 = 6 ""
-;;     region4 = 196 ""
-;;     region5 = 206 ""
-;;     region6 = 108 ""
+;;     region2 = 196 ""
+;;     region3 = 206 ""
+;;     region4 = 108 ""
+;;     region5 = 130 ""
+;;     region6 = 6 ""
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -29,25 +29,33 @@
 ;;                                 block2:
 ;; @001e                               v7 = iconst.i32 1
 ;; @001e                               v8 = band.i32 v2, v7  ; v7 = 1
-;;                                     v22 = iconst.i32 0
-;; @001e                               brif v8, block4(v22), block3  ; v22 = 0
+;;                                     v34 = iconst.i32 0
+;; @001e                               brif v8, block4(v34), block3  ; v34 = 0
 ;;
 ;;                                 block3:
-;; @001e                               v13 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001e                               v14 = load.i64 notrap aligned readonly can_move region4 v13+32
-;; @001e                               v12 = uextend.i64 v2
-;; @001e                               v15 = iadd v14, v12
-;; @001e                               v16 = iconst.i64 4
-;; @001e                               v17 = iadd v15, v16  ; v16 = 4
-;; @001e                               v18 = load.i32 user2 readonly region6 v17
-;; @001e                               v10 = load.i64 notrap aligned readonly can_move region2 v0+40
-;; @001e                               v11 = load.i32 notrap aligned readonly can_move region3 v10
-;; @001e                               v19 = icmp eq v18, v11
-;; @001e                               v20 = uextend.i32 v19
-;; @001e                               jump block4(v20)
+;; @001e                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001e                               v12 = load.i64 notrap aligned readonly can_move region2 v11+32
+;; @001e                               v10 = uextend.i64 v2
+;; @001e                               v13 = iadd v12, v10
+;; @001e                               v16 = load.i32 user2 readonly region4 v13
+;; @001e                               v17 = iconst.i32 -1342177280
+;; @001e                               v18 = band v16, v17  ; v17 = -1342177280
+;; @001e                               v19 = icmp eq v18, v17  ; v17 = -1342177280
+;;                                     v35 = iconst.i32 0
+;; @001e                               brif v19, block5, block4(v35)  ; v35 = 0
 ;;
-;;                                 block4(v21: i32):
-;; @001e                               trapz v21, user19
+;;                                 block5:
+;; @001e                               v28 = iconst.i64 4
+;; @001e                               v29 = iadd.i64 v13, v28  ; v28 = 4
+;; @001e                               v30 = load.i32 user2 readonly region4 v29
+;; @001e                               v22 = load.i64 notrap aligned readonly can_move region5 v0+40
+;; @001e                               v23 = load.i32 notrap aligned readonly can_move region6 v22
+;; @001e                               v31 = icmp eq v30, v23
+;; @001e                               v32 = uextend.i32 v31
+;; @001e                               jump block4(v32)
+;;
+;;                                 block4(v33: i32):
+;; @001e                               trapz v33, user19
 ;; @0021                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/gc/null/ref-test-concrete-type.wat
+++ b/tests/disas/gc/null/ref-test-concrete-type.wat
@@ -11,11 +11,11 @@
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 123 ""
 ;;     region1 = 160 ""
-;;     region2 = 130 ""
-;;     region3 = 6 ""
-;;     region4 = 196 ""
-;;     region5 = 206 ""
-;;     region6 = 108 ""
+;;     region2 = 196 ""
+;;     region3 = 206 ""
+;;     region4 = 108 ""
+;;     region5 = 130 ""
+;;     region6 = 6 ""
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -29,26 +29,34 @@
 ;;                                 block2:
 ;; @001d                               v7 = iconst.i32 1
 ;; @001d                               v8 = band.i32 v2, v7  ; v7 = 1
-;;                                     v22 = iconst.i32 0
-;; @001d                               brif v8, block4(v22), block3  ; v22 = 0
+;;                                     v34 = iconst.i32 0
+;; @001d                               brif v8, block4(v34), block3  ; v34 = 0
 ;;
 ;;                                 block3:
-;; @001d                               v13 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @001d                               v14 = load.i64 notrap aligned readonly can_move region4 v13+32
-;; @001d                               v12 = uextend.i64 v2
-;; @001d                               v15 = iadd v14, v12
-;; @001d                               v16 = iconst.i64 4
-;; @001d                               v17 = iadd v15, v16  ; v16 = 4
-;; @001d                               v18 = load.i32 user2 readonly region6 v17
-;; @001d                               v10 = load.i64 notrap aligned readonly can_move region2 v0+40
-;; @001d                               v11 = load.i32 notrap aligned readonly can_move region3 v10
-;; @001d                               v19 = icmp eq v18, v11
-;; @001d                               v20 = uextend.i32 v19
-;; @001d                               jump block4(v20)
+;; @001d                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @001d                               v12 = load.i64 notrap aligned readonly can_move region2 v11+32
+;; @001d                               v10 = uextend.i64 v2
+;; @001d                               v13 = iadd v12, v10
+;; @001d                               v16 = load.i32 user2 readonly region4 v13
+;; @001d                               v17 = iconst.i32 -1342177280
+;; @001d                               v18 = band v16, v17  ; v17 = -1342177280
+;; @001d                               v19 = icmp eq v18, v17  ; v17 = -1342177280
+;;                                     v35 = iconst.i32 0
+;; @001d                               brif v19, block5, block4(v35)  ; v35 = 0
 ;;
-;;                                 block4(v21: i32):
+;;                                 block5:
+;; @001d                               v28 = iconst.i64 4
+;; @001d                               v29 = iadd.i64 v13, v28  ; v28 = 4
+;; @001d                               v30 = load.i32 user2 readonly region4 v29
+;; @001d                               v22 = load.i64 notrap aligned readonly can_move region5 v0+40
+;; @001d                               v23 = load.i32 notrap aligned readonly can_move region6 v22
+;; @001d                               v31 = icmp eq v30, v23
+;; @001d                               v32 = uextend.i32 v31
+;; @001d                               jump block4(v32)
+;;
+;;                                 block4(v33: i32):
 ;; @0020                               jump block1
 ;;
 ;;                                 block1:
-;; @0020                               return v21
+;; @0020                               return v33
 ;; }

--- a/tests/disas/gc/ref-test-cast-final-type.wat
+++ b/tests/disas/gc/ref-test-cast-final-type.wat
@@ -17,11 +17,11 @@
 ;; function u0:0(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 123 ""
 ;;     region1 = 160 ""
-;;     region2 = 130 ""
-;;     region3 = 6 ""
-;;     region4 = 196 ""
-;;     region5 = 206 ""
-;;     region6 = 108 ""
+;;     region2 = 196 ""
+;;     region3 = 206 ""
+;;     region4 = 108 ""
+;;     region5 = 130 ""
+;;     region6 = 6 ""
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -35,38 +35,46 @@
 ;;                                 block2:
 ;; @0024                               v7 = iconst.i32 1
 ;; @0024                               v8 = band.i32 v2, v7  ; v7 = 1
-;;                                     v22 = iconst.i32 0
-;; @0024                               brif v8, block4(v22), block3  ; v22 = 0
+;;                                     v34 = iconst.i32 0
+;; @0024                               brif v8, block4(v34), block3  ; v34 = 0
 ;;
 ;;                                 block3:
-;; @0024                               v13 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @0024                               v14 = load.i64 notrap aligned readonly can_move region4 v13+32
-;; @0024                               v12 = uextend.i64 v2
-;; @0024                               v15 = iadd v14, v12
-;; @0024                               v16 = iconst.i64 4
-;; @0024                               v17 = iadd v15, v16  ; v16 = 4
-;; @0024                               v18 = load.i32 user2 readonly region6 v17
-;; @0024                               v10 = load.i64 notrap aligned readonly can_move region2 v0+40
-;; @0024                               v11 = load.i32 notrap aligned readonly can_move region3 v10
-;; @0024                               v19 = icmp eq v18, v11
-;; @0024                               v20 = uextend.i32 v19
-;; @0024                               jump block4(v20)
+;; @0024                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @0024                               v12 = load.i64 notrap aligned readonly can_move region2 v11+32
+;; @0024                               v10 = uextend.i64 v2
+;; @0024                               v13 = iadd v12, v10
+;; @0024                               v16 = load.i32 user2 readonly region4 v13
+;; @0024                               v17 = iconst.i32 -1342177280
+;; @0024                               v18 = band v16, v17  ; v17 = -1342177280
+;; @0024                               v19 = icmp eq v18, v17  ; v17 = -1342177280
+;;                                     v35 = iconst.i32 0
+;; @0024                               brif v19, block5, block4(v35)  ; v35 = 0
 ;;
-;;                                 block4(v21: i32):
+;;                                 block5:
+;; @0024                               v28 = iconst.i64 4
+;; @0024                               v29 = iadd.i64 v13, v28  ; v28 = 4
+;; @0024                               v30 = load.i32 user2 readonly region4 v29
+;; @0024                               v22 = load.i64 notrap aligned readonly can_move region5 v0+40
+;; @0024                               v23 = load.i32 notrap aligned readonly can_move region6 v22
+;; @0024                               v31 = icmp eq v30, v23
+;; @0024                               v32 = uextend.i32 v31
+;; @0024                               jump block4(v32)
+;;
+;;                                 block4(v33: i32):
 ;; @0027                               jump block1
 ;;
 ;;                                 block1:
-;; @0027                               return v21
+;; @0027                               return v33
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> i32 tail {
 ;;     region0 = 123 ""
 ;;     region1 = 160 ""
-;;     region2 = 130 ""
-;;     region3 = 6 ""
-;;     region4 = 196 ""
-;;     region5 = 206 ""
-;;     region6 = 108 ""
+;;     region2 = 196 ""
+;;     region3 = 206 ""
+;;     region4 = 108 ""
+;;     region5 = 130 ""
+;;     region6 = 6 ""
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly can_move region0 gv0+8
 ;;     gv2 = load.i64 notrap aligned region1 gv1+24
@@ -80,25 +88,33 @@
 ;;                                 block2:
 ;; @002c                               v7 = iconst.i32 1
 ;; @002c                               v8 = band.i32 v2, v7  ; v7 = 1
-;;                                     v22 = iconst.i32 0
-;; @002c                               brif v8, block4(v22), block3  ; v22 = 0
+;;                                     v34 = iconst.i32 0
+;; @002c                               brif v8, block4(v34), block3  ; v34 = 0
 ;;
 ;;                                 block3:
-;; @002c                               v13 = load.i64 notrap aligned readonly can_move region0 v0+8
-;; @002c                               v14 = load.i64 notrap aligned readonly can_move region4 v13+32
-;; @002c                               v12 = uextend.i64 v2
-;; @002c                               v15 = iadd v14, v12
-;; @002c                               v16 = iconst.i64 4
-;; @002c                               v17 = iadd v15, v16  ; v16 = 4
-;; @002c                               v18 = load.i32 user2 readonly region6 v17
-;; @002c                               v10 = load.i64 notrap aligned readonly can_move region2 v0+40
-;; @002c                               v11 = load.i32 notrap aligned readonly can_move region3 v10
-;; @002c                               v19 = icmp eq v18, v11
-;; @002c                               v20 = uextend.i32 v19
-;; @002c                               jump block4(v20)
+;; @002c                               v11 = load.i64 notrap aligned readonly can_move region0 v0+8
+;; @002c                               v12 = load.i64 notrap aligned readonly can_move region2 v11+32
+;; @002c                               v10 = uextend.i64 v2
+;; @002c                               v13 = iadd v12, v10
+;; @002c                               v16 = load.i32 user2 readonly region4 v13
+;; @002c                               v17 = iconst.i32 -1342177280
+;; @002c                               v18 = band v16, v17  ; v17 = -1342177280
+;; @002c                               v19 = icmp eq v18, v17  ; v17 = -1342177280
+;;                                     v35 = iconst.i32 0
+;; @002c                               brif v19, block5, block4(v35)  ; v35 = 0
 ;;
-;;                                 block4(v21: i32):
-;; @002c                               trapz v21, user19
+;;                                 block5:
+;; @002c                               v28 = iconst.i64 4
+;; @002c                               v29 = iadd.i64 v13, v28  ; v28 = 4
+;; @002c                               v30 = load.i32 user2 readonly region4 v29
+;; @002c                               v22 = load.i64 notrap aligned readonly can_move region5 v0+40
+;; @002c                               v23 = load.i32 notrap aligned readonly can_move region6 v22
+;; @002c                               v31 = icmp eq v30, v23
+;; @002c                               v32 = uextend.i32 v31
+;; @002c                               jump block4(v32)
+;;
+;;                                 block4(v33: i32):
+;; @002c                               trapz v33, user19
 ;; @002f                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/misc_testsuite/gc/issue-14301.wast
+++ b/tests/misc_testsuite/gc/issue-14301.wast
@@ -1,0 +1,57 @@
+;;! gc = true
+
+(module
+  (type $s (sub (struct)))
+  (func (export "test-struct") (param externref) (result i32)
+    (ref.test (ref null $s) (any.convert_extern (local.get 0))))
+  (func (export "cast-struct") (param externref) (result i32)
+    (drop (ref.cast (ref null $s) (any.convert_extern (local.get 0))))
+    (i32.const 0))
+  (func (export "br-on-cast-struct") (param externref) (result i32)
+    (block $l (result (ref $s))
+      (br_on_cast $l anyref (ref $s) (any.convert_extern (local.get 0)))
+      (drop)
+      (return (i32.const 0)))
+    (drop)
+    (i32.const 1)))
+
+(assert_return (invoke "test-struct" (ref.extern 1)) (i32.const 0))
+(assert_trap (invoke "cast-struct" (ref.extern 1)) "cast failure")
+(assert_return (invoke "br-on-cast-struct" (ref.extern 1)) (i32.const 0))
+
+(module
+  (type $a (sub (array i8)))
+  (func (export "test-array") (param externref) (result i32)
+    (ref.test (ref null $a) (any.convert_extern (local.get 0)))))
+
+(assert_return (invoke "test-array" (ref.extern 1)) (i32.const 0))
+
+(module
+  (type $s (struct))
+  (func (export "test-final") (param externref) (result i32)
+    (ref.test (ref null $s) (any.convert_extern (local.get 0)))))
+
+(assert_return (invoke "test-final" (ref.extern 1)) (i32.const 0))
+
+(module
+  (func (export "test-abstract") (param externref) (result i32)
+    (ref.test (ref null struct) (any.convert_extern (local.get 0)))))
+
+(assert_return (invoke "test-abstract" (ref.extern 1)) (i32.const 0))
+
+(module
+  (type $s (sub (struct (field i32))))
+  (type $a (sub (array i8)))
+  (func (export "test-real-struct") (result i32)
+    (ref.test (ref null $s) (struct.new $s (i32.const 1))))
+  (func (export "test-real-array") (result i32)
+    (ref.test (ref null $a) (array.new_default $a (i32.const 1))))
+  (func (export "cast-round-trip") (result i32)
+    (struct.get $s 0
+      (ref.cast (ref $s)
+        (any.convert_extern
+          (extern.convert_any (struct.new $s (i32.const 42))))))))
+
+(assert_return (invoke "test-real-struct") (i32.const 1))
+(assert_return (invoke "test-real-array") (i32.const 1))
+(assert_return (invoke "cast-round-trip") (i32.const 42))


### PR DESCRIPTION
We would interpret the `externref` as having a type of `VMSharedTypeIndex::reserve_value()`, which triggered debug assertions, but since that is an invalid type index and therefore does not appear in e.g. any supertype arrays, it couldn't result in incorrect downcasts when debug assertions were disabled.

The fix is to check the `VMGcKind` when we're `ref.test`ing an `anyref`, as it might be an internalized `externref`.

Fixes #14301

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please review the Bytecode Alliance's AI tool usage policy at
https://github.com/bytecodealliance/governance/blob/main/AI_TOOL_POLICY.md

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
